### PR TITLE
Add cache repo

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -692,6 +692,7 @@ mod tests {
         let tmp = TempDir::new();
         let api = ApiBuilder::new()
             .with_progress(false)
+            .with_token(None)
             .with_cache_dir(tmp.path.clone())
             .build()
             .unwrap();

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -110,7 +110,7 @@ impl ApiBuilder {
         let cache = Cache::default();
         let token_filename = cache.token_path();
         if !token_filename.exists() {
-            log::info!("Token file not found {path:?}");
+            log::info!("Token file not found {token_filename:?}");
         }
         let token = match std::fs::read_to_string(token_filename) {
             Ok(token_content) => {
@@ -420,7 +420,7 @@ impl ApiRepo {
     /// let api = Api::new().unwrap();
     /// let local_filename = api.model("gpt2".to_string()).get("model.safetensors").unwrap();
     pub fn get(&self, filename: &str) -> Result<PathBuf, ApiError> {
-        if let Some(path) = self.api.cache.get(&self.repo, filename) {
+        if let Some(path) = self.api.cache.repo(self.repo.clone()).get(filename) {
             Ok(path)
         } else {
             self.download(filename)
@@ -440,7 +440,11 @@ impl ApiRepo {
         let url = self.url(filename);
         let metadata = self.api.metadata(&url)?;
 
-        let blob_path = self.api.cache.blob_path(&self.repo, &metadata.etag);
+        let blob_path = self
+            .api
+            .cache
+            .repo(self.repo.clone())
+            .blob_path(&metadata.etag);
         std::fs::create_dir_all(blob_path.parent().unwrap())?;
 
         let progressbar = if self.api.progress {
@@ -470,14 +474,16 @@ impl ApiRepo {
         let mut pointer_path = self
             .api
             .cache
-            .pointer_path(&self.repo, &metadata.commit_hash);
+            .repo(self.repo.clone())
+            .pointer_path(&metadata.commit_hash);
         pointer_path.push(filename);
         std::fs::create_dir_all(pointer_path.parent().unwrap()).ok();
 
         symlink_or_rename(&blob_path, &pointer_path)?;
         self.api
             .cache
-            .create_ref(&self.repo, &metadata.commit_hash)?;
+            .repo(self.repo.clone())
+            .create_ref(&metadata.commit_hash)?;
 
         Ok(pointer_path)
     }
@@ -562,7 +568,8 @@ mod tests {
         // Make sure the file is now seeable without connection
         let cache_path = api
             .cache
-            .get(&Repo::new(model_id, RepoType::Model), "config.json")
+            .repo(Repo::new(model_id, RepoType::Model))
+            .get("config.json")
             .unwrap();
         assert_eq!(cache_path, downloaded_path);
     }

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -773,6 +773,7 @@ mod tests {
     async fn info_request() {
         let tmp = TempDir::new();
         let api = ApiBuilder::new()
+            .with_token(None)
             .with_progress(false)
             .with_cache_dir(tmp.path.clone())
             .build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ impl Cache {
     /// ```
     /// # use hf_hub::{Cache, Repo, RepoType};
     /// # let model_id = "gpt2".to_string();
-    /// let cache = Cache::new().unwrap();
+    /// let cache = Cache::new("/tmp/".into());
     /// let cache = cache.repo(Repo::new(model_id, RepoType::Model));
     /// ```
     pub fn model(&self, model_id: String) -> CacheRepo {
@@ -66,7 +66,7 @@ impl Cache {
     /// ```
     /// # use hf_hub::{Cache, Repo, RepoType};
     /// # let model_id = "gpt2".to_string();
-    /// let cache = Cache::new().unwrap();
+    /// let cache = Cache::new("/tmp/".into());
     /// let cache = cache.repo(Repo::new(model_id, RepoType::Dataset));
     /// ```
     pub fn dataset(&self, model_id: String) -> CacheRepo {
@@ -77,7 +77,7 @@ impl Cache {
     /// ```
     /// # use hf_hub::{Cache, Repo, RepoType};
     /// # let model_id = "gpt2".to_string();
-    /// let cache = Cache::new().unwrap();
+    /// let cache = Cache::new("/tmp/".into());
     /// let cache = cache.repo(Repo::new(model_id, RepoType::Space));
     /// ```
     pub fn space(&self, model_id: String) -> CacheRepo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ impl Cache {
     }
 
     pub(crate) fn temp_path(&self) -> PathBuf {
-        let mut path = self.path();
+        let mut path = self.path().clone();
         path.push("tmp");
         std::fs::create_dir_all(&path).ok();
 
@@ -163,14 +163,6 @@ impl CacheRepo {
         pointer_path.push("snapshots");
         pointer_path.push(commit_hash);
         pointer_path
-    }
-
-    pub(crate) fn token_path(&self) -> PathBuf {
-        let mut path = self.path();
-        // Remove `"hub"`
-        path.pop();
-        path.push("token");
-        path
     }
 }
 


### PR DESCRIPTION
Similar to what is being done for `Api` vs `ApiRepo`.

I'm hesitant to even change the internals of `ApiRepo` to make them own a `CacheRepo`.
That would remove a bunch of clone, but potential discrepancy between `self.api.cache.repo(repo)` vs `self.cache_repo` 