### PR TITLE
feat/reuse blobs

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -485,10 +485,8 @@ impl ApiRepo {
         Ok(pointer_path)
     }
 
-    /// Downloads a remote file (if not already present) into the cache directory
-    /// to be used locally.
-    /// This functions require internet access to verify if new versions of the file
-    /// exist, even if a file is already on disk at location.
+    /// Downloads a remote file into the cache directory to be used locally.
+    /// If the file is already present it will be overwritten.
     /// ```no_run
     /// # use hf_hub::api::sync::Api;
     /// let api = Api::new().unwrap();

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -443,31 +443,33 @@ impl ApiRepo {
         let cache = self.api.cache.repo(self.repo.clone());
 
         let blob_path = cache.blob_path(&metadata.etag);
-        std::fs::create_dir_all(blob_path.parent().unwrap())?;
+        if !blob_path.exists() {
+            std::fs::create_dir_all(blob_path.parent().unwrap())?;
 
-        let progressbar = if self.api.progress {
-            let progress = ProgressBar::new(metadata.size as u64);
-            progress.set_style(
-                ProgressStyle::with_template(
-                    "{msg} [{elapsed_precise}] [{wide_bar}] {bytes}/{total_bytes} {bytes_per_sec} ({eta})",
-                )
-                .unwrap(), // .progress_chars("━ "),
-            );
-            let maxlength = 30;
-            let message = if filename.len() > maxlength {
-                format!("..{}", &filename[filename.len() - maxlength..])
+            let progressbar = if self.api.progress {
+                let progress = ProgressBar::new(metadata.size as u64);
+                progress.set_style(
+                    ProgressStyle::with_template(
+                        "{msg} [{elapsed_precise}] [{wide_bar}] {bytes}/{total_bytes} {bytes_per_sec} ({eta})",
+                    )
+                    .unwrap(), // .progress_chars("━ "),
+                );
+                let maxlength = 30;
+                let message = if filename.len() > maxlength {
+                    format!("..{}", &filename[filename.len() - maxlength..])
+                } else {
+                    filename.to_string()
+                };
+                progress.set_message(message);
+                Some(progress)
             } else {
-                filename.to_string()
+                None
             };
-            progress.set_message(message);
-            Some(progress)
-        } else {
-            None
-        };
 
-        let tmp_filename = self.api.download_tempfile(&url, progressbar)?;
+            let tmp_filename = self.api.download_tempfile(&url, progressbar)?;
 
-        std::fs::rename(tmp_filename, &blob_path)?;
+            std::fs::rename(tmp_filename, &blob_path)?;
+        }
 
         let mut pointer_path = cache.pointer_path(&metadata.commit_hash);
         pointer_path.push(filename);


### PR DESCRIPTION
### Current behavior
When the file/symlink is not found in snapshots the blob is downloaded regardless of whether or not it is already present.
### New behavior
When the file/symlink is not found in snapshots the etag is used to check for the corresponding blob. It is used if already present.
### Potential Issues
- The python library provides users with the option to force the download of the file. If this request is accepted we should likely do the same. I am however unaware of how such options should be introduced in this repository
- Probably not really an issue, existed before this change was introduced: If symlinking generally works on Windows but fails once, we move the file and end up with invalid symlinks (if I am not mistaken?, not 100% sure because it is Windows, but from what I understand of CreateSymbolicLinkW and std::os::windows::fs::symlink_file). 