### PR TITLE
Adding `ApiBuilder::from_cache` method.

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -113,7 +113,7 @@ impl ApiBuilder {
 
     /// From a given cache
     /// ```
-    /// use hf_hub::api::sync::ApiBuilder;
+    /// use hf_hub::{api::sync::ApiBuilder, Cache};
     /// let path = std::path::PathBuf::from("/tmp");
     /// let cache = Cache::new(path);
     /// let api = ApiBuilder::from_cache(cache).build().unwrap();

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -108,6 +108,17 @@ impl ApiBuilder {
     /// ```
     pub fn new() -> Self {
         let cache = Cache::default();
+        Self::from_cache(cache)
+    }
+
+    /// From a given cache
+    /// ```
+    /// use hf_hub::api::sync::ApiBuilder;
+    /// let path = std::path::PathBuf::from("/tmp");
+    /// let cache = Cache::new(path);
+    /// let api = ApiBuilder::from_cache(cache).build().unwrap();
+    /// ```
+    pub fn from_cache(cache: Cache) -> Self {
         let token = cache.token();
 
         let progress = true;

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -101,7 +101,7 @@ impl ApiBuilder {
 
     /// From a given cache
     /// ```
-    /// use hf_hub::api::tokio::ApiBuilder;
+    /// use hf_hub::{api::tokio::ApiBuilder, Cache};
     /// let path = std::path::PathBuf::from("/tmp");
     /// let cache = Cache::new(path);
     /// let api = ApiBuilder::from_cache(cache).build().unwrap();

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -96,6 +96,17 @@ impl ApiBuilder {
     /// ```
     pub fn new() -> Self {
         let cache = Cache::default();
+        Self::from_cache(cache)
+    }
+
+    /// From a given cache
+    /// ```
+    /// use hf_hub::api::tokio::ApiBuilder;
+    /// let path = std::path::PathBuf::from("/tmp");
+    /// let cache = Cache::new(path);
+    /// let api = ApiBuilder::from_cache(cache).build().unwrap();
+    /// ```
+    pub fn from_cache(cache: Cache) -> Self {
         let token = cache.token();
 
         let progress = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@ impl Cache {
         &self.path
     }
 
-    pub(crate) fn token_path(&self) -> PathBuf {
+    /// Returns the location of the token file
+    pub fn token_path(&self) -> PathBuf {
         let mut path = self.path.clone();
         // Remove `"hub"`
         path.pop();


### PR DESCRIPTION
Turns out `dirs::home_dir()` can fail on Android apps (there is no $home_dir
set for them).

This is probably super niche, and I didn't find any good way to detect the location cache folder,
therefore I simply include these new functions to allow creating and API from a functional cache.

This is interesting anyway for anyone wanting to use a custom cache location.