### PR TITLE
Add proxy from env.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ num_cpus = { version = "1.15.0", optional = true}
 tokio = { version = "1.29.1", optional = true, features = ["fs", "macros"] }
 futures = { version = "0.3.28", optional = true}
 thiserror = { version = "1.0.43", optional = true }
-ureq = { version = "2.7.1", optional = true, features = ["native-tls", "json"] }
+ureq = { version = "2.8.0", optional = true, features = ["native-tls", "json", "socks-proxy"] }
 native-tls = { version = "0.2.11", optional = true }
 log = "0.4.19"
 

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -163,8 +163,16 @@ impl ApiBuilder {
     /// Consumes the builder and buids the final [`Api`]
     pub fn build(self) -> Result<Api, ApiError> {
         let headers = self.build_headers()?;
-        let client = HeaderAgent::new(ureq::builder().build(), headers.clone());
-        let no_redirect_client = HeaderAgent::new(ureq::builder().redirects(0).build(), headers);
+
+        let agent = ureq::builder().try_proxy_from_env(true).build();
+        let client = HeaderAgent::new(agent, headers.clone());
+
+        let no_redirect_agent = ureq::builder()
+            .try_proxy_from_env(true)
+            .redirects(0)
+            .build();
+        let no_redirect_client = HeaderAgent::new(no_redirect_agent, headers);
+
         Ok(Api {
             endpoint: self.endpoint,
             url_template: self.url_template,


### PR DESCRIPTION
In mainland China, people usually need to access the international internet through a proxy.
Otherwise, they may encounter connection errors.
For example: error trying to connect: tcp connect error: Connection timed out (os error 110)

So it's necessary to support obtaining proxy configurations from environment variables to facilitate the use by users in mainland China.