### PR TITLE
Add means of disabling native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,14 +33,15 @@ num_cpus = { version = "1.15.0", optional = true }
 tokio = { version = "1.29.1", optional = true, features = ["fs", "macros"] }
 futures = { version = "0.3.28", optional = true }
 thiserror = { version = "1.0.43", optional = true }
-ureq = { version = "2.8.0", optional = true, features = ["native-tls", "json", "socks-proxy"] }
+ureq = { version = "2.8.0", optional = true, features = ["json", "socks-proxy"] }
 native-tls = { version = "0.2.11", optional = true }
 log = "0.4.19"
 
 [features]
-default = ["online"]
-online = ["dep:ureq", "dep:native-tls", "dep:rand", "dep:serde", "dep:serde_json", "dep:indicatif", "dep:thiserror", "dep:http"]
+default = ["online", "native-tls"]
+online = ["dep:ureq", "dep:rand", "dep:serde", "dep:serde_json", "dep:indicatif", "dep:thiserror", "dep:http"]
 tokio = ["dep:reqwest", "dep:tokio", "tokio/rt-multi-thread", "dep:futures", "dep:rand", "dep:serde", "dep:serde_json", "dep:indicatif", "dep:num_cpus", "dep:thiserror"]
+native-tls = ["dep:native-tls", "ureq/native-tls"]
 
 [dev-dependencies]
 hex-literal = "0.4.1"


### PR DESCRIPTION
Hello 👋 

Thank you for making the Hugging Face hub, it's super convenient.

This PR adds a means of disabling the `native-tls` dependency, because we're using `rust_tls` and really don't want the native one.

It works by adding a new default feature `native-tls` that adds the existing `native-tls` optional dependencies (both for ureq and as a direct dependency). So by default this PR doesn't change anything.

However, it is now possible to remove the `native-tls` dependencies by adding the `hf-hub` without its default features, and with the `online` feature enabled.

I checked that the resulting cargo tree doesn't have `native-tls` at all in this configuration, while `native-tls` remains when the default features are enabled.

Thank you for reading 🙂 