### PR TITLE
`derive(Debug)` in most places.

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -102,7 +102,6 @@ impl ApiBuilder {
     /// use hf_hub::api::sync::ApiBuilder;
     /// let api = ApiBuilder::new().build().unwrap();
     /// ```
-    #[must_use]
     pub fn new() -> Self {
         let cache = Cache::default();
         Self::from_cache(cache)
@@ -115,7 +114,6 @@ impl ApiBuilder {
     /// let cache = Cache::new(path);
     /// let api = ApiBuilder::from_cache(cache).build().unwrap();
     /// ```
-    #[must_use]
     pub fn from_cache(cache: Cache) -> Self {
         let token = cache.token();
 
@@ -131,21 +129,18 @@ impl ApiBuilder {
     }
 
     /// Wether to show a progressbar
-    #[must_use]
     pub fn with_progress(mut self, progress: bool) -> Self {
         self.progress = progress;
         self
     }
 
     /// Changes the location of the cache directory. Defaults is `~/.cache/huggingface/`.
-    #[must_use]
     pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
         self.cache = Cache::new(cache_dir);
         self
     }
 
     /// Sets the token to be used in the API
-    #[must_use]
     pub fn with_token(mut self, token: Option<String>) -> Self {
         self.token = token;
         self
@@ -210,7 +205,11 @@ fn make_relative(src: &Path, dst: &Path) -> PathBuf {
     let path = src;
     let base = dst;
 
-    assert_eq!(path.is_absolute(), base.is_absolute(), "This function is made to look at absolute paths only");
+    assert_eq!(
+        path.is_absolute(),
+        base.is_absolute(),
+        "This function is made to look at absolute paths only"
+    );
     let mut ita = path.components();
     let mut itb = base.components();
 
@@ -264,7 +263,6 @@ impl Api {
 
     /// Get the underlying api client
     /// Allows for lower level access
-    #[must_use]
     pub fn client(&self) -> &HeaderAgent {
         &self.client
     }
@@ -395,7 +393,6 @@ impl Api {
 
     /// Creates a new handle [`ApiRepo`] which contains operations
     /// on a particular [`Repo`]
-    #[must_use]
     pub fn repo(&self, repo: Repo) -> ApiRepo {
         ApiRepo::new(self.clone(), repo)
     }
@@ -407,7 +404,6 @@ impl Api {
     /// let api = Api::new().unwrap();
     /// let api = api.repo(Repo::new(model_id, RepoType::Model));
     /// ```
-    #[must_use]
     pub fn model(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Model))
     }
@@ -419,7 +415,6 @@ impl Api {
     /// let api = Api::new().unwrap();
     /// let api = api.repo(Repo::new(model_id, RepoType::Dataset));
     /// ```
-    #[must_use]
     pub fn dataset(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Dataset))
     }
@@ -431,7 +426,6 @@ impl Api {
     /// let api = Api::new().unwrap();
     /// let api = api.repo(Repo::new(model_id, RepoType::Space));
     /// ```
-    #[must_use]
     pub fn space(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Space))
     }
@@ -458,7 +452,6 @@ impl ApiRepo {
     /// let url = api.model("gpt2".to_string()).url("model.safetensors");
     /// assert_eq!(url, "https://huggingface.co/gpt2/resolve/main/model.safetensors");
     /// ```
-    #[must_use]
     pub fn url(&self, filename: &str) -> String {
         let endpoint = &self.api.endpoint;
         let revision = &self.repo.url_revision();

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -569,7 +569,6 @@ mod tests {
     use crate::api::Siblings;
     use crate::RepoType;
     use hex_literal::hex;
-    use log::warn;
     use rand::{distributions::Alphanumeric, Rng};
     use serde_json::{json, Value};
     use sha2::{Digest, Sha256};

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -95,7 +95,6 @@ impl ApiBuilder {
     /// use hf_hub::api::tokio::ApiBuilder;
     /// let api = ApiBuilder::new().build().unwrap();
     /// ```
-    #[must_use]
     pub fn new() -> Self {
         let cache = Cache::default();
         Self::from_cache(cache)
@@ -108,7 +107,6 @@ impl ApiBuilder {
     /// let cache = Cache::new(path);
     /// let api = ApiBuilder::from_cache(cache).build().unwrap();
     /// ```
-    #[must_use]
     pub fn from_cache(cache: Cache) -> Self {
         let token = cache.token();
 
@@ -128,21 +126,18 @@ impl ApiBuilder {
     }
 
     /// Wether to show a progressbar
-    #[must_use]
     pub fn with_progress(mut self, progress: bool) -> Self {
         self.progress = progress;
         self
     }
 
     /// Changes the location of the cache directory. Defaults is `~/.cache/huggingface/`.
-    #[must_use]
     pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
         self.cache = Cache::new(cache_dir);
         self
     }
 
     /// Sets the token to be used in the API
-    #[must_use]
     pub fn with_token(mut self, token: Option<String>) -> Self {
         self.token = token;
         self
@@ -232,7 +227,10 @@ fn make_relative(src: &Path, dst: &Path) -> PathBuf {
     let path = src;
     let base = dst;
 
-    assert!(path.is_absolute() == base.is_absolute(), "This function is made to look at absolute paths only");
+    assert!(
+        path.is_absolute() == base.is_absolute(),
+        "This function is made to look at absolute paths only"
+    );
     let mut ita = path.components();
     let mut itb = base.components();
 
@@ -294,7 +292,6 @@ impl Api {
 
     /// Get the underlying api client
     /// Allows for lower level access
-    #[must_use]
     pub fn client(&self) -> &Client {
         &self.client
     }
@@ -357,7 +354,6 @@ impl Api {
 
     /// Creates a new handle [`ApiRepo`] which contains operations
     /// on a particular [`Repo`]
-    #[must_use]
     pub fn repo(&self, repo: Repo) -> ApiRepo {
         ApiRepo::new(self.clone(), repo)
     }
@@ -369,7 +365,6 @@ impl Api {
     /// let api = Api::new().unwrap();
     /// let api = api.repo(Repo::new(model_id, RepoType::Model));
     /// ```
-    #[must_use]
     pub fn model(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Model))
     }
@@ -381,7 +376,6 @@ impl Api {
     /// let api = Api::new().unwrap();
     /// let api = api.repo(Repo::new(model_id, RepoType::Dataset));
     /// ```
-    #[must_use]
     pub fn dataset(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Dataset))
     }
@@ -393,7 +387,6 @@ impl Api {
     /// let api = Api::new().unwrap();
     /// let api = api.repo(Repo::new(model_id, RepoType::Space));
     /// ```
-    #[must_use]
     pub fn space(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Space))
     }
@@ -420,7 +413,6 @@ impl ApiRepo {
     /// let url = api.model("gpt2".to_string()).url("model.safetensors");
     /// assert_eq!(url, "https://huggingface.co/gpt2/resolve/main/model.safetensors");
     /// ```
-    #[must_use]
     pub fn url(&self, filename: &str) -> String {
         let endpoint = &self.api.endpoint;
         let revision = &self.repo.url_revision();

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -70,6 +70,7 @@ pub enum ApiError {
 }
 
 /// Helper to create [`Api`] with all the options.
+#[derive(Debug)]
 pub struct ApiBuilder {
     endpoint: String,
     cache: Cache,
@@ -94,6 +95,7 @@ impl ApiBuilder {
     /// use hf_hub::api::tokio::ApiBuilder;
     /// let api = ApiBuilder::new().build().unwrap();
     /// ```
+    #[must_use]
     pub fn new() -> Self {
         let cache = Cache::default();
         Self::from_cache(cache)
@@ -106,6 +108,7 @@ impl ApiBuilder {
     /// let cache = Cache::new(path);
     /// let api = ApiBuilder::from_cache(cache).build().unwrap();
     /// ```
+    #[must_use]
     pub fn from_cache(cache: Cache) -> Self {
         let token = cache.token();
 
@@ -125,18 +128,21 @@ impl ApiBuilder {
     }
 
     /// Wether to show a progressbar
+    #[must_use]
     pub fn with_progress(mut self, progress: bool) -> Self {
         self.progress = progress;
         self
     }
 
     /// Changes the location of the cache directory. Defaults is `~/.cache/huggingface/`.
+    #[must_use]
     pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
         self.cache = Cache::new(cache_dir);
         self
     }
 
     /// Sets the token to be used in the API
+    #[must_use]
     pub fn with_token(mut self, token: Option<String>) -> Self {
         self.token = token;
         self
@@ -155,7 +161,7 @@ impl ApiBuilder {
         Ok(headers)
     }
 
-    /// Consumes the builder and buids the final [`Api`]
+    /// Consumes the builder and builds the final [`Api`]
     pub fn build(self) -> Result<Api, ApiError> {
         let headers = self.build_headers()?;
         let client = Client::builder().default_headers(headers.clone()).build()?;
@@ -205,10 +211,10 @@ struct Metadata {
     size: usize,
 }
 
-/// The actual Api used to interacto with the hub.
+/// The actual Api used to interact with the hub.
 /// You can inspect repos with [`Api::info`]
 /// or download files with [`Api::download`]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Api {
     endpoint: String,
     url_template: String,
@@ -226,9 +232,7 @@ fn make_relative(src: &Path, dst: &Path) -> PathBuf {
     let path = src;
     let base = dst;
 
-    if path.is_absolute() != base.is_absolute() {
-        panic!("This function is made to look at absolute paths only");
-    }
+    assert!(path.is_absolute() == base.is_absolute(), "This function is made to look at absolute paths only");
     let mut ita = path.components();
     let mut itb = base.components();
 
@@ -290,6 +294,7 @@ impl Api {
 
     /// Get the underlying api client
     /// Allows for lower level access
+    #[must_use]
     pub fn client(&self) -> &Client {
         &self.client
     }
@@ -352,6 +357,7 @@ impl Api {
 
     /// Creates a new handle [`ApiRepo`] which contains operations
     /// on a particular [`Repo`]
+    #[must_use]
     pub fn repo(&self, repo: Repo) -> ApiRepo {
         ApiRepo::new(self.clone(), repo)
     }
@@ -363,6 +369,7 @@ impl Api {
     /// let api = Api::new().unwrap();
     /// let api = api.repo(Repo::new(model_id, RepoType::Model));
     /// ```
+    #[must_use]
     pub fn model(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Model))
     }
@@ -374,6 +381,7 @@ impl Api {
     /// let api = Api::new().unwrap();
     /// let api = api.repo(Repo::new(model_id, RepoType::Dataset));
     /// ```
+    #[must_use]
     pub fn dataset(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Dataset))
     }
@@ -385,12 +393,14 @@ impl Api {
     /// let api = Api::new().unwrap();
     /// let api = api.repo(Repo::new(model_id, RepoType::Space));
     /// ```
+    #[must_use]
     pub fn space(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Space))
     }
 }
 
 /// Shorthand for accessing things within a particular repo
+#[derive(Debug)]
 pub struct ApiRepo {
     api: Api,
     repo: Repo,
@@ -410,6 +420,7 @@ impl ApiRepo {
     /// let url = api.model("gpt2".to_string()).url("model.safetensors");
     /// assert_eq!(url, "https://huggingface.co/gpt2/resolve/main/model.safetensors");
     /// ```
+    #[must_use]
     pub fn url(&self, filename: &str) -> String {
         let endpoint = &self.api.endpoint;
         let revision = &self.repo.url_revision();
@@ -484,7 +495,7 @@ impl ApiRepo {
         let results: Result<(), ApiError> = results.into_iter().flatten().collect();
         results?;
         if let Some(p) = progressbar {
-            p.finish()
+            p.finish();
         }
         Ok(filename)
     }
@@ -645,7 +656,7 @@ mod tests {
 
     impl Drop for TempDir {
         fn drop(&mut self) {
-            std::fs::remove_dir_all(&self.path).unwrap()
+            std::fs::remove_dir_all(&self.path).unwrap();
         }
     }
 
@@ -722,7 +733,7 @@ mod tests {
         assert_eq!(
             val[..],
             hex!("59ce09415ad8aa45a9e34f88cec2548aeb9de9a73fcda9f6b33a86a065f32b90")
-        )
+        );
     }
 
     #[tokio::test]
@@ -744,7 +755,7 @@ mod tests {
         assert_eq!(
             val[..],
             hex!("9EB652AC4E40CC093272BBBE0F55D521CF67570060227109B5CDC20945A4489E")
-        )
+        );
     }
 
     #[tokio::test]
@@ -849,7 +860,7 @@ mod tests {
                 ],
                 sha: "3acdf8c72a4dd61d76f34d7b54ee2a5b088ea3b1".to_string(),
             }
-        )
+        );
     }
 
     #[tokio::test]

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -227,8 +227,9 @@ fn make_relative(src: &Path, dst: &Path) -> PathBuf {
     let path = src;
     let base = dst;
 
-    assert!(
-        path.is_absolute() == base.is_absolute(),
+    assert_eq!(
+        path.is_absolute(),
+        base.is_absolute(),
         "This function is made to look at absolute paths only"
     );
     let mut ita = path.components();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,23 +22,26 @@ pub enum RepoType {
 }
 
 /// A local struct used to fetch information from the cache folder.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Cache {
     path: PathBuf,
 }
 
 impl Cache {
     /// Creates a new cache object location
+    #[must_use]
     pub fn new(path: PathBuf) -> Self {
         Self { path }
     }
 
     /// Creates a new cache object location
+    #[must_use]
     pub fn path(&self) -> &PathBuf {
         &self.path
     }
 
     /// Returns the location of the token file
+    #[must_use]
     pub fn token_path(&self) -> PathBuf {
         let mut path = self.path.clone();
         // Remove `"hub"`
@@ -49,6 +52,7 @@ impl Cache {
 
     /// Returns the token value if it exists in the cache
     /// Use `huggingface-cli login` to set it up.
+    #[must_use]
     pub fn token(&self) -> Option<String> {
         let token_filename = self.token_path();
         if !token_filename.exists() {
@@ -57,10 +61,10 @@ impl Cache {
         match std::fs::read_to_string(token_filename) {
             Ok(token_content) => {
                 let token_content = token_content.trim();
-                if !token_content.is_empty() {
-                    Some(token_content.to_string())
-                } else {
+                if token_content.is_empty() {
                     None
+                } else {
+                    Some(token_content.to_string())
                 }
             }
             Err(_) => None,
@@ -69,6 +73,7 @@ impl Cache {
 
     /// Creates a new handle [`CacheRepo`] which contains operations
     /// on a particular [`Repo`]
+    #[must_use]
     pub fn repo(&self, repo: Repo) -> CacheRepo {
         CacheRepo::new(self.clone(), repo)
     }
@@ -80,6 +85,7 @@ impl Cache {
     /// let cache = Cache::new("/tmp/".into());
     /// let cache = cache.repo(Repo::new(model_id, RepoType::Model));
     /// ```
+    #[must_use]
     pub fn model(&self, model_id: String) -> CacheRepo {
         self.repo(Repo::new(model_id, RepoType::Model))
     }
@@ -91,6 +97,7 @@ impl Cache {
     /// let cache = Cache::new("/tmp/".into());
     /// let cache = cache.repo(Repo::new(model_id, RepoType::Dataset));
     /// ```
+    #[must_use]
     pub fn dataset(&self, model_id: String) -> CacheRepo {
         self.repo(Repo::new(model_id, RepoType::Dataset))
     }
@@ -102,6 +109,7 @@ impl Cache {
     /// let cache = Cache::new("/tmp/".into());
     /// let cache = cache.repo(Repo::new(model_id, RepoType::Space));
     /// ```
+    #[must_use]
     pub fn space(&self, model_id: String) -> CacheRepo {
         self.repo(Repo::new(model_id, RepoType::Space))
     }
@@ -123,6 +131,7 @@ impl Cache {
 }
 
 /// Shorthand for accessing things within a particular repo
+#[derive(Debug)]
 pub struct CacheRepo {
     cache: Cache,
     repo: Repo,
@@ -134,6 +143,7 @@ impl CacheRepo {
     }
     /// This will get the location of the file within the cache for the remote
     /// `filename`. Will return `None` if file is not already present in cache.
+    #[must_use]
     pub fn get(&self, filename: &str) -> Option<PathBuf> {
         let commit_path = self.ref_path();
         let commit_hash = std::fs::read_to_string(commit_path).ok()?;
@@ -165,11 +175,11 @@ impl CacheRepo {
         let ref_path = self.ref_path();
         // Needs to be done like this because revision might contain `/` creating subfolders here.
         std::fs::create_dir_all(ref_path.parent().unwrap())?;
-        let mut file1 = std::fs::OpenOptions::new()
+        let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
             .open(&ref_path)?;
-        file1.write_all(commit_hash.trim().as_bytes())?;
+        file.write_all(commit_hash.trim().as_bytes())?;
         Ok(())
     }
 
@@ -206,7 +216,7 @@ impl Default for Cache {
 }
 
 /// The representation of a repo on the hub.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Repo {
     repo_id: String,
     repo_type: RepoType,
@@ -215,11 +225,13 @@ pub struct Repo {
 
 impl Repo {
     /// Repo with the default branch ("main").
+    #[must_use]
     pub fn new(repo_id: String, repo_type: RepoType) -> Self {
         Self::with_revision(repo_id, repo_type, "main".to_string())
     }
 
     /// fully qualified Repo
+    #[must_use]
     pub fn with_revision(repo_id: String, repo_type: RepoType, revision: String) -> Self {
         Self {
             repo_id,
@@ -229,21 +241,25 @@ impl Repo {
     }
 
     /// Shortcut for [`Repo::new`] with [`RepoType::Model`]
+    #[must_use]
     pub fn model(repo_id: String) -> Self {
         Self::new(repo_id, RepoType::Model)
     }
 
     /// Shortcut for [`Repo::new`] with [`RepoType::Dataset`]
+    #[must_use]
     pub fn dataset(repo_id: String) -> Self {
         Self::new(repo_id, RepoType::Dataset)
     }
 
     /// Shortcut for [`Repo::new`] with [`RepoType::Space`]
+    #[must_use]
     pub fn space(repo_id: String) -> Self {
         Self::new(repo_id, RepoType::Space)
     }
 
     /// The normalized folder nameof the repo within the cache directory
+    #[must_use]
     pub fn folder_name(&self) -> String {
         let prefix = match self.repo_type {
             RepoType::Model => "models",
@@ -254,12 +270,14 @@ impl Repo {
     }
 
     /// The revision
+    #[must_use]
     pub fn revision(&self) -> &str {
         &self.revision
     }
 
     /// The actual URL part of the repo
     #[cfg(feature = "online")]
+    #[must_use]
     pub fn url(&self) -> String {
         match self.repo_type {
             RepoType::Model => self.repo_id.to_string(),
@@ -274,12 +292,14 @@ impl Repo {
 
     /// Revision needs to be url escaped before being used in a URL
     #[cfg(feature = "online")]
+    #[must_use]
     pub fn url_revision(&self) -> String {
         self.revision.replace('/', "%2F")
     }
 
     /// Used to compute the repo's url part when accessing the metadata of the repo
     #[cfg(feature = "online")]
+    #[must_use]
     pub fn api_url(&self) -> String {
         let prefix = match self.repo_type {
             RepoType::Model => "models",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,19 +29,16 @@ pub struct Cache {
 
 impl Cache {
     /// Creates a new cache object location
-    #[must_use]
     pub fn new(path: PathBuf) -> Self {
         Self { path }
     }
 
     /// Creates a new cache object location
-    #[must_use]
     pub fn path(&self) -> &PathBuf {
         &self.path
     }
 
     /// Returns the location of the token file
-    #[must_use]
     pub fn token_path(&self) -> PathBuf {
         let mut path = self.path.clone();
         // Remove `"hub"`
@@ -52,7 +49,6 @@ impl Cache {
 
     /// Returns the token value if it exists in the cache
     /// Use `huggingface-cli login` to set it up.
-    #[must_use]
     pub fn token(&self) -> Option<String> {
         let token_filename = self.token_path();
         if !token_filename.exists() {
@@ -73,7 +69,6 @@ impl Cache {
 
     /// Creates a new handle [`CacheRepo`] which contains operations
     /// on a particular [`Repo`]
-    #[must_use]
     pub fn repo(&self, repo: Repo) -> CacheRepo {
         CacheRepo::new(self.clone(), repo)
     }
@@ -85,7 +80,6 @@ impl Cache {
     /// let cache = Cache::new("/tmp/".into());
     /// let cache = cache.repo(Repo::new(model_id, RepoType::Model));
     /// ```
-    #[must_use]
     pub fn model(&self, model_id: String) -> CacheRepo {
         self.repo(Repo::new(model_id, RepoType::Model))
     }
@@ -97,7 +91,6 @@ impl Cache {
     /// let cache = Cache::new("/tmp/".into());
     /// let cache = cache.repo(Repo::new(model_id, RepoType::Dataset));
     /// ```
-    #[must_use]
     pub fn dataset(&self, model_id: String) -> CacheRepo {
         self.repo(Repo::new(model_id, RepoType::Dataset))
     }
@@ -109,7 +102,6 @@ impl Cache {
     /// let cache = Cache::new("/tmp/".into());
     /// let cache = cache.repo(Repo::new(model_id, RepoType::Space));
     /// ```
-    #[must_use]
     pub fn space(&self, model_id: String) -> CacheRepo {
         self.repo(Repo::new(model_id, RepoType::Space))
     }
@@ -143,7 +135,6 @@ impl CacheRepo {
     }
     /// This will get the location of the file within the cache for the remote
     /// `filename`. Will return `None` if file is not already present in cache.
-    #[must_use]
     pub fn get(&self, filename: &str) -> Option<PathBuf> {
         let commit_path = self.ref_path();
         let commit_hash = std::fs::read_to_string(commit_path).ok()?;
@@ -225,13 +216,11 @@ pub struct Repo {
 
 impl Repo {
     /// Repo with the default branch ("main").
-    #[must_use]
     pub fn new(repo_id: String, repo_type: RepoType) -> Self {
         Self::with_revision(repo_id, repo_type, "main".to_string())
     }
 
     /// fully qualified Repo
-    #[must_use]
     pub fn with_revision(repo_id: String, repo_type: RepoType, revision: String) -> Self {
         Self {
             repo_id,
@@ -241,25 +230,21 @@ impl Repo {
     }
 
     /// Shortcut for [`Repo::new`] with [`RepoType::Model`]
-    #[must_use]
     pub fn model(repo_id: String) -> Self {
         Self::new(repo_id, RepoType::Model)
     }
 
     /// Shortcut for [`Repo::new`] with [`RepoType::Dataset`]
-    #[must_use]
     pub fn dataset(repo_id: String) -> Self {
         Self::new(repo_id, RepoType::Dataset)
     }
 
     /// Shortcut for [`Repo::new`] with [`RepoType::Space`]
-    #[must_use]
     pub fn space(repo_id: String) -> Self {
         Self::new(repo_id, RepoType::Space)
     }
 
     /// The normalized folder nameof the repo within the cache directory
-    #[must_use]
     pub fn folder_name(&self) -> String {
         let prefix = match self.repo_type {
             RepoType::Model => "models",
@@ -270,14 +255,12 @@ impl Repo {
     }
 
     /// The revision
-    #[must_use]
     pub fn revision(&self) -> &str {
         &self.revision
     }
 
     /// The actual URL part of the repo
     #[cfg(feature = "online")]
-    #[must_use]
     pub fn url(&self) -> String {
         match self.repo_type {
             RepoType::Model => self.repo_id.to_string(),
@@ -292,14 +275,12 @@ impl Repo {
 
     /// Revision needs to be url escaped before being used in a URL
     #[cfg(feature = "online")]
-    #[must_use]
     pub fn url_revision(&self) -> String {
         self.revision.replace('/', "%2F")
     }
 
     /// Used to compute the repo's url part when accessing the metadata of the repo
     #[cfg(feature = "online")]
-    #[must_use]
     pub fn api_url(&self) -> String {
         let prefix = match self.repo_type {
             RepoType::Model => "models",


### PR DESCRIPTION
This started as wanting to debug print a `Repo`. It turned into 
- Derive `Debug` on nearly everything
- remove unused `Result` on `build_headers` 
- rename `file1` to `file` in `create_ref`
- two spelling fixes (`buids` -> `builds`, `interacto` -> `interact`)
- change `if` + `panic!` into an `assert_eq!` in `make_relative` (this seems like a bug? I think the assertion is supposed to check both paths are absolute - it currently accepts if both are not absolute paths. I left behavior unchanged)
- added semicolons where the expression was unused.

At one point I had `must_use` strewn around after a `clippy fix` but I decided to remove them to keep consistent with current practices. 