### PR TITLE
Add proxy-from-env feature to ureq crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/huggingface/hf-hub"
 readme = "README.md"
 keywords = ["huggingface", "hf", "hub", "machine-learning"]
 description = """
-This crates aims ease the interaction with [huggingface](https://huggingface.co/) 
+This crates aims ease the interaction with [huggingface](https://huggingface.co/)
 It aims to be compatible with [huggingface_hub](https://github.com/huggingface/huggingface_hub/) python package, but only implements a smaller subset of functions.
 """
 
@@ -35,6 +35,7 @@ tokio = { version = "1.29.1", optional = true, features = ["fs", "macros"] }
 ureq = { version = "2.8.0", optional = true, features = [
   "json",
   "socks-proxy",
+  "proxy-from-env"
 ] }
 
 [features]


### PR DESCRIPTION
The asynchronous version of hf-hub automatically enables proxy support based on environment variables by default, whereas the synchronous version does not. To ensure consistency between the two, it is necessary for the synchronous version to also adopt this behavior.