### PR TITLE
feat: add `tokio-rustls-tls` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: ilammy/setup-nasm@v1
+
       - name: Install Rust Stable
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ dirs = "5.0.1"
 http = { version = "1.0.0", optional = true }
 indicatif = { version = "0.17.5", optional = true }
 log = "0.4.19"
-native-tls = { version = "0.2.11", optional = true }
 num_cpus = { version = "1.15.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.12.2", optional = true, default-features = false, features = [
@@ -34,23 +33,15 @@ serde_json = { version = "1.0.103", optional = true }
 thiserror = { version = "1.0.43", optional = true }
 tokio = { version = "1.29.1", optional = true, features = ["fs", "macros"] }
 ureq = { version = "2.8.0", optional = true, features = [
-  "native-tls",
   "json",
   "socks-proxy",
 ] }
 
 [features]
-default = ["ureq", "tokio", "tokio-default-tls"]
-ureq = [
-  "dep:http",
-  "dep:indicatif",
-  "dep:native-tls",
-  "dep:rand",
-  "dep:serde",
-  "dep:serde_json",
-  "dep:thiserror",
-  "dep:ureq",
-]
+default = ["default-tls", "tokio", "ureq"]
+# These features are only relevant when used with the `tokio` feature, but this might change in the future.
+default-tls = ["dep:reqwest", "reqwest/default"]
+rustls-tls = ["dep:reqwest", "dep:rustls", "reqwest/rustls-tls"]
 tokio = [
   "dep:futures",
   "dep:indicatif",
@@ -66,8 +57,15 @@ tokio = [
   "dep:tokio",
   "tokio/rt-multi-thread",
 ]
-tokio-default-tls = ["dep:reqwest", "reqwest/default"]
-tokio-rustls-tls = ["dep:reqwest", "dep:rustls", "reqwest/rustls-tls"]
+ureq = [
+  "dep:http",
+  "dep:indicatif",
+  "dep:rand",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:thiserror",
+  "dep:ureq",
+]
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,7 @@ license = "Apache-2.0"
 documentation = "https://docs.rs/hf-hub"
 repository = "https://github.com/huggingface/hf-hub"
 readme = "README.md"
-keywords = [
-    "huggingface",
-    "hf",
-    "hub",
-    "machine-learning"
-]
+keywords = ["huggingface", "hf", "hub", "machine-learning"]
 description = """
 This crates aims ease the interaction with [huggingface](https://huggingface.co/) 
 It aims to be compatible with [huggingface_hub](https://github.com/huggingface/huggingface_hub/) python package, but only implements a smaller subset of functions.
@@ -22,26 +17,57 @@ It aims to be compatible with [huggingface_hub](https://github.com/huggingface/h
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+futures = { version = "0.3.28", optional = true }
 dirs = "5.0.1"
 http = { version = "1.0.0", optional = true }
+indicatif = { version = "0.17.5", optional = true }
+log = "0.4.19"
+native-tls = { version = "0.2.11", optional = true }
+num_cpus = { version = "1.15.0", optional = true }
 rand = { version = "0.8.5", optional = true }
-reqwest = { version = "0.11.18", optional = true, features = ["json"] }
+reqwest = { version = "0.12.2", optional = true, default-features = false, features = [
+  "json",
+] }
+rustls = { version = "0.23.4", optional = true }
 serde = { version = "1.0.171", features = ["derive"], optional = true }
 serde_json = { version = "1.0.103", optional = true }
-indicatif = { version = "0.17.5", optional = true }
-num_cpus = { version = "1.15.0", optional = true }
-tokio = { version = "1.29.1", optional = true, features = ["fs", "macros"] }
-futures = { version = "0.3.28", optional = true }
 thiserror = { version = "1.0.43", optional = true }
-ureq = { version = "2.8.0", optional = true, features = ["native-tls", "json", "socks-proxy"] }
-native-tls = { version = "0.2.11", optional = true }
-log = "0.4.19"
+tokio = { version = "1.29.1", optional = true, features = ["fs", "macros"] }
+ureq = { version = "2.8.0", optional = true, features = [
+  "native-tls",
+  "json",
+  "socks-proxy",
+] }
 
 [features]
-default = ["online"]
-online = ["ureq", "tokio"]
-ureq = ["dep:ureq", "dep:native-tls", "dep:rand", "dep:serde", "dep:serde_json", "dep:indicatif", "dep:thiserror", "dep:http"]
-tokio = ["dep:reqwest", "dep:tokio", "tokio/rt-multi-thread", "dep:futures", "dep:rand", "dep:serde", "dep:serde_json", "dep:indicatif", "dep:num_cpus", "dep:thiserror"]
+default = ["ureq", "tokio", "tokio-default-tls"]
+ureq = [
+  "dep:http",
+  "dep:indicatif",
+  "dep:native-tls",
+  "dep:rand",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:thiserror",
+  "dep:ureq",
+]
+tokio = [
+  "dep:futures",
+  "dep:indicatif",
+  "dep:num_cpus",
+  "dep:rand",
+  "dep:reqwest",
+  "reqwest/charset",
+  "reqwest/http2",
+  "reqwest/macos-system-configuration",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:thiserror",
+  "dep:tokio",
+  "tokio/rt-multi-thread",
+]
+tokio-default-tls = ["dep:reqwest", "reqwest/default"]
+tokio-rustls-tls = ["dep:reqwest", "dep:rustls", "reqwest/rustls-tls"]
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ let _filename = repo.get("config.json").unwrap();
 
 // filename  is now the local location within hf cache of the config.json file
 ```
+
+# SSL/TLS
+
+When using the [`ureq`](https://github.com/algesten/ureq) feature, you will always use its default TLS backend which is [rustls](https://github.com/rustls/rustls).
+
+When using [`tokio`](https://github.com/tokio-rs/tokio), by default `default-tls` will be enabled, which means OpenSSL. If you want/need to use rustls, disable the default features and use `rustls-tls` in conjunction with `tokio`.

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -567,7 +567,6 @@ impl ApiRepo {
 mod tests {
     use super::*;
     use crate::api::Siblings;
-    use crate::RepoType;
     use hex_literal::hex;
     use rand::{distributions::Alphanumeric, Rng};
     use serde_json::{json, Value};

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -623,9 +623,8 @@ impl ApiRepo {
 mod tests {
     use super::*;
     use crate::api::Siblings;
-    use crate::RepoType;
     use hex_literal::hex;
-    use rand::{distributions::Alphanumeric, Rng};
+    use rand::distributions::Alphanumeric;
     use serde_json::{json, Value};
     use sha2::{Digest, Sha256};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 #![deny(missing_docs)]
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
-#[cfg(any(feature="tokio", feature="ureq"))]
+#[cfg(any(feature = "tokio", feature = "ureq"))]
 use rand::{distributions::Alphanumeric, Rng};
 use std::io::Write;
 use std::path::PathBuf;
 
 /// The actual Api to interact with the hub.
-#[cfg(any(feature="tokio", feature="ureq"))]
+#[cfg(any(feature = "tokio", feature = "ureq"))]
 pub mod api;
 
 /// The type of repo to interact with
@@ -106,7 +106,7 @@ impl Cache {
         self.repo(Repo::new(model_id, RepoType::Space))
     }
 
-    #[cfg(any(feature="tokio", feature="ureq"))]
+    #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub(crate) fn temp_path(&self) -> PathBuf {
         let mut path = self.path().clone();
         path.push("tmp");
@@ -175,8 +175,7 @@ impl CacheRepo {
         Ok(())
     }
 
-
-    #[cfg(any(feature="tokio", feature="ureq"))]
+    #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub(crate) fn blob_path(&self, etag: &str) -> PathBuf {
         let mut blob_path = self.path();
         blob_path.push("blobs");
@@ -262,7 +261,7 @@ impl Repo {
     }
 
     /// The actual URL part of the repo
-    #[cfg(any(feature="tokio", feature="ureq"))]
+    #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn url(&self) -> String {
         match self.repo_type {
             RepoType::Model => self.repo_id.to_string(),
@@ -276,13 +275,13 @@ impl Repo {
     }
 
     /// Revision needs to be url escaped before being used in a URL
-    #[cfg(any(feature="tokio", feature="ureq"))]
+    #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn url_revision(&self) -> String {
         self.revision.replace('/', "%2F")
     }
 
     /// Used to compute the repo's url part when accessing the metadata of the repo
-    #[cfg(any(feature="tokio", feature="ureq"))]
+    #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn api_url(&self) -> String {
         let prefix = match self.repo_type {
             RepoType::Model => "models",


### PR DESCRIPTION
Adding the capability to use `rustls` when using the `tokio` feature instead of the default tls deps.

Also a bit of cleanup.