### PR TITLE
Support for resume functionality to avoid the need to re-download lar…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ ureq = { version = "2.8.0", optional = true, features = [
   "json",
   "socks-proxy",
 ] }
+pget="0.1.2"
 
 [features]
 default = ["default-tls", "tokio", "ureq"]
-download-with-offset = []
 # These features are only relevant when used with the `tokio` feature, but this might change in the future.
 default-tls = ["dep:reqwest", "reqwest/default"]
 rustls-tls = ["dep:reqwest", "dep:rustls", "reqwest/rustls-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ ureq = { version = "2.8.0", optional = true, features = [
 
 [features]
 default = ["default-tls", "tokio", "ureq"]
+download-with-offset = []
 # These features are only relevant when used with the `tokio` feature, but this might change in the future.
 default-tls = ["dep:reqwest", "reqwest/default"]
 rustls-tls = ["dep:reqwest", "dep:rustls", "reqwest/rustls-tls"]

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -1,10 +1,9 @@
 #[cfg(not(feature = "ureq"))]
-#[cfg(not(feature="tokio"))]
-fn main() {
-}
+#[cfg(not(feature = "tokio"))]
+fn main() {}
 
 #[cfg(feature = "ureq")]
-#[cfg(not(feature="tokio"))]
+#[cfg(not(feature = "tokio"))]
 fn main() {
     let api = hf_hub::api::sync::Api::new().unwrap();
 

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -22,6 +22,9 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Current name (used in user-agent)
 const NAME: &str = env!("CARGO_PKG_NAME");
 
+/// can use a mirror site to download
+const HF_ENDPOINT: Option<&str> = option_env!("HF_ENDPOINT");
+
 #[derive(Debug, Error)]
 /// All errors the API can throw
 pub enum ApiError {
@@ -113,7 +116,7 @@ impl ApiBuilder {
         let progress = true;
 
         Self {
-            endpoint: "https://huggingface.co".to_string(),
+            endpoint: HF_ENDPOINT.unwrap_or("https://huggingface.co").to_string(),
             url_template: "{endpoint}/{repo_id}/resolve/{revision}/{filename}".to_string(),
             cache,
             token,
@@ -412,7 +415,8 @@ impl ApiRepo {
     /// # use hf_hub::api::tokio::Api;
     /// let api = Api::new().unwrap();
     /// let url = api.model("gpt2".to_string()).url("model.safetensors");
-    /// assert_eq!(url, "https://huggingface.co/gpt2/resolve/main/model.safetensors");
+    /// const HF_ENDPOINT: Option<&str> = option_env!("HF_ENDPOINT");
+    /// assert_eq!(url, format!("{}{}",HF_ENDPOINT.unwrap_or("https://huggingface.co"),"/gpt2/resolve/main/model.safetensors"));
     /// ```
     pub fn url(&self, filename: &str) -> String {
         let endpoint = &self.api.endpoint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,15 +120,6 @@ impl Cache {
         path.push(s);
         path.to_path_buf()
     }
-
-    #[cfg(all(any(feature = "tokio", feature = "ureq"), feature="download-with-offset"))]
-    pub(crate) fn fixed_path(&self,filename:&dyn AsRef<std::path::Path>) -> PathBuf {
-        let mut path = self.path().clone();
-        path.push("tmp");
-        std::fs::create_dir_all(&path).ok();
-        path.push(filename);
-        path.to_path_buf()
-    }
 }
 
 /// Shorthand for accessing things within a particular repo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,15 @@ impl Cache {
         path.push(s);
         path.to_path_buf()
     }
+
+    #[cfg(all(any(feature = "tokio", feature = "ureq"), feature="download-with-offset"))]
+    pub(crate) fn fixed_path(&self,filename:&dyn AsRef<std::path::Path>) -> PathBuf {
+        let mut path = self.path().clone();
+        path.push("tmp");
+        std::fs::create_dir_all(&path).ok();
+        path.push(filename);
+        path.to_path_buf()
+    }
 }
 
 /// Shorthand for accessing things within a particular repo


### PR DESCRIPTION
Support for resume functionality to avoid the need to re-download large files from the beginning in case of network interruptions during the download process.
The compilation switch 'download-with-offset' controls whether to enable the resume functionality, with the default setting being disabled.