### PR TITLE
feat: allow endpoint to be configured

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -146,6 +146,12 @@ impl ApiBuilder {
         self
     }
 
+    /// Sets the hub endpoint
+    pub fn with_endpoint(mut self, endpoint: String) -> Self {
+        self.endpoint = endpoint;
+        self
+    }
+
     fn build_headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
         let user_agent = format!("unkown/None; {NAME}/{VERSION}; rust/unknown");

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -143,6 +143,12 @@ impl ApiBuilder {
         self
     }
 
+    /// Sets the hub endpoint
+    pub fn with_endpoint(mut self, endpoint: String) -> Self {
+        self.endpoint = endpoint;
+        self
+    }
+
     fn build_headers(&self) -> Result<HeaderMap, ApiError> {
         let mut headers = HeaderMap::new();
         let user_agent = format!("unkown/None; {NAME}/{VERSION}; rust/unknown");


### PR DESCRIPTION
This update enables the client to be configured with a different endpoint other than `https://huggingface.co`, allowing the use of a mirror with this library.