### PR TITLE
chore: `ApiBuilder` support default without token

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -92,7 +92,13 @@ pub struct ApiBuilder {
 
 impl Default for ApiBuilder {
     fn default() -> Self {
-        Self::new()
+        Self {
+            endpoint: "https://huggingface.co".to_string(),
+            url_template: "{endpoint}/{repo_id}/resolve/{revision}/{filename}".to_string(),
+            cache: Cache::default(),
+            progress: true,
+            token: None,
+        }
     }
 }
 
@@ -117,14 +123,10 @@ impl ApiBuilder {
     pub fn from_cache(cache: Cache) -> Self {
         let token = cache.token();
 
-        let progress = true;
-
         Self {
-            endpoint: "https://huggingface.co".to_string(),
-            url_template: "{endpoint}/{repo_id}/resolve/{revision}/{filename}".to_string(),
             cache,
             token,
-            progress,
+            ..Self::default()
         }
     }
 

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -84,10 +84,10 @@ pub enum ApiError {
 #[derive(Debug)]
 pub struct ApiBuilder {
     endpoint: String,
-    cache: Cache,
     url_template: String,
-    token: Option<String>,
+    cache: Cache,
     progress: bool,
+    token: Option<String>,
 }
 
 impl Default for ApiBuilder {
@@ -170,12 +170,11 @@ impl ApiBuilder {
         let no_redirect_client = HeaderAgent::new(no_redirect_agent, headers);
 
         Ok(Api {
+            client,
+            no_redirect_client,
             endpoint: self.endpoint,
             url_template: self.url_template,
             cache: self.cache,
-            client,
-
-            no_redirect_client,
             progress: self.progress,
         })
     }
@@ -193,11 +192,11 @@ struct Metadata {
 /// or download files with [`Api::download`]
 #[derive(Clone, Debug)]
 pub struct Api {
+    client: HeaderAgent,
+    no_redirect_client: HeaderAgent,
     endpoint: String,
     url_template: String,
     cache: Cache,
-    client: HeaderAgent,
-    no_redirect_client: HeaderAgent,
     progress: bool,
 }
 

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -86,7 +86,18 @@ pub struct ApiBuilder {
 
 impl Default for ApiBuilder {
     fn default() -> Self {
-        Self::new()
+        ApiBuilder {
+            endpoint: "https://huggingface.co".to_string(),
+            url_template: "{endpoint}/{repo_id}/resolve/{revision}/{filename}".to_string(),
+            cache: Cache::default(),
+            progress: true,
+            token: None,
+            // Async specific:
+            max_files: num_cpus::get(),
+            chunk_size: 10_000_000,
+            parallel_failures: 0,
+            max_retries: 0,
+        }
     }
 }
 
@@ -111,18 +122,10 @@ impl ApiBuilder {
     pub fn from_cache(cache: Cache) -> Self {
         let token = cache.token();
 
-        let progress = true;
-
         Self {
-            endpoint: "https://huggingface.co".to_string(),
-            url_template: "{endpoint}/{repo_id}/resolve/{revision}/{filename}".to_string(),
             cache,
             token,
-            max_files: num_cpus::get(),
-            chunk_size: 10_000_000,
-            parallel_failures: 0,
-            max_retries: 0,
-            progress,
+            ..Self::default()
         }
     }
 

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -73,14 +73,15 @@ pub enum ApiError {
 #[derive(Debug)]
 pub struct ApiBuilder {
     endpoint: String,
-    cache: Cache,
     url_template: String,
+    cache: Cache,
+    progress: bool,
     token: Option<String>,
+    // Async specific:
     max_files: usize,
     chunk_size: usize,
     parallel_failures: usize,
     max_retries: usize,
-    progress: bool,
 }
 
 impl Default for ApiBuilder {
@@ -185,16 +186,16 @@ impl ApiBuilder {
             .default_headers(headers)
             .build()?;
         Ok(Api {
+            client,
+            relative_redirect_client,
             endpoint: self.endpoint,
             url_template: self.url_template,
             cache: self.cache,
-            client,
-            relative_redirect_client,
+            progress: self.progress,
             max_files: self.max_files,
             chunk_size: self.chunk_size,
             parallel_failures: self.parallel_failures,
             max_retries: self.max_retries,
-            progress: self.progress,
         })
     }
 }
@@ -211,16 +212,17 @@ struct Metadata {
 /// or download files with [`Api::download`]
 #[derive(Clone, Debug)]
 pub struct Api {
+    client: Client,
+    relative_redirect_client: Client,
     endpoint: String,
     url_template: String,
     cache: Cache,
-    client: Client,
-    relative_redirect_client: Client,
+    progress: bool,
+    // Async specific:
     max_files: usize,
     chunk_size: usize,
     parallel_failures: usize,
     max_retries: usize,
-    progress: bool,
 }
 
 fn make_relative(src: &Path, dst: &Path) -> PathBuf {


### PR DESCRIPTION
When creating an API instance the current methods enforce checking for a local `token` file, even when you intend to provide your own via `with_token()`, thus finding a token is redundant, as is the info log of one missing being emitted.

- `from_cache()` calls `cache.token()` to set the `token` field in the builder.
- You cannot call `with_token()` prior, both `default()` and `new()` methods use the same initialization. Only workaround is to duplicate `from_cache()` and omit the token check.
- The token is later used by the private `build_headers()` method during the final `build()` call.

**This PR changes:**
- The `Default` impl for both sync/async structs to provide the same struct value except for the `token` field, leaving it as `None` by default. `from_cache()` will use the "Struct Update" syntax to spread the remaining default field values (_this communicates more clearly what the method is actually modifying_).
- The order of fields for the `Api` and `ApiBuilder` structs were grouped contextually for better visibility vs interleaved. Handled via a separate commit.

I've tried to minimize affecting anything else, but technically if someone was relying on `ApiBuilder::default()` before instead of `::new()`, the only difference should be that `token` is not potentially set for them. Anyone who is using `::new()` should be unaffected by this change.

---

Related: https://github.com/huggingface/hf-hub/issues/54#issuecomment-2118679106