### PR TITLE
Adding native TLS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ log = "0.4.19"
 num_cpus = { version = "1.15.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.12.2", optional = true, default-features = false, features = [
-  "json",
+  "json", "native-tls", "rustls-tls"
 ] }
-rustls = { version = "0.23.4", optional = true }
+rustls = { version = "0.22.4", optional = true }
 serde = { version = "1.0.171", features = ["derive"], optional = true }
 serde_json = { version = "1.0.103", optional = true }
 thiserror = { version = "1.0.43", optional = true }
@@ -35,13 +35,15 @@ tokio = { version = "1.29.1", optional = true, features = ["fs", "macros"] }
 ureq = { version = "2.8.0", optional = true, features = [
   "json",
   "socks-proxy",
+  "native-tls",
 ] }
+native-tls = { version = "0.2.8" }
 
 [features]
 default = ["default-tls", "tokio", "ureq"]
 # These features are only relevant when used with the `tokio` feature, but this might change in the future.
-default-tls = ["dep:reqwest", "reqwest/default"]
-rustls-tls = ["dep:reqwest", "dep:rustls", "reqwest/rustls-tls"]
+default-tls = ["dep:reqwest", "reqwest/default", "dep:rustls"]
+rustls-tls = ["dep:reqwest", "reqwest/rustls-tls"]
 tokio = [
   "dep:futures",
   "dep:indicatif",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,16 @@ use std::path::PathBuf;
 #[cfg(any(feature = "tokio", feature = "ureq"))]
 pub mod api;
 
+/// Type of SSL to use for connections
+#[derive(Debug, Clone, Copy)]
+pub enum SSLType {
+    /// Use rustls crate for tls
+    RUSTLS,
+    /// Use native-tls crate for tls
+    NATIVE,
+}
+
+
 /// The type of repo to interact with
 #[derive(Debug, Clone, Copy)]
 pub enum RepoType {


### PR DESCRIPTION
Changed `tokio.rs` to allow configuration of TLS in `reqwest` clients. Changed `sync.rs` to allow configuration of TLS in `ureq` agents. Both are configured via the `ApiBuilder`.

The connection type is still defaulted to `rustls`. In the case of `tokio`, this isn't a strictly necessary change because `reqwest` can be configured via features but providing a programmatic interface could be handy.

I still want to make some changes to dependencies but wanted to open this for discussion.
fix #56 