### PR TITLE
feat: support socks proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 /target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.19"
 num_cpus = { version = "1.15.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.12.2", optional = true, default-features = false, features = [
-  "json",
+  "json", "socks"
 ] }
 rustls = { version = "0.23.4", optional = true }
 serde = { version = "1.0.171", features = ["derive"], optional = true }


### PR DESCRIPTION
The synchronous interface already supports the socks5 protocol, but the asynchronous interface lacks support.

This pr adds support for the socks5 protocol to `tokio::Api`

Should fix #41