### PR TITLE
feat: download progress callback

### DIFF
--- a/examples/download.rs
+++ b/examples/download.rs
@@ -1,10 +1,9 @@
 #[cfg(not(feature = "ureq"))]
-#[cfg(not(feature="tokio"))]
-fn main() {
-}
+#[cfg(not(feature = "tokio"))]
+fn main() {}
 
 #[cfg(feature = "ureq")]
-#[cfg(not(feature="tokio"))]
+#[cfg(not(feature = "tokio"))]
 fn main() {
     let api = hf_hub::api::sync::Api::new().unwrap();
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,6 @@
-use serde::Deserialize;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
 
 /// The asynchronous version of the API
 #[cfg(feature = "tokio")]
@@ -23,4 +25,20 @@ pub struct RepoInfo {
 
     /// The commit sha of the repo.
     pub sha: String,
+}
+
+/// The state of a download progress
+#[derive(Debug, Clone, Serialize)]
+pub struct ProgressEvent {
+    /// The resource to download
+    pub url: String,
+
+    /// The progress expressed as a value between 0 and 1
+    pub percentage: f32,
+
+    /// Time elapsed since the download as being started
+    pub elapsed_time: Duration,
+
+    /// Estimated time to complete the download
+    pub remaining_time: Duration,
 }

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -89,7 +89,7 @@ pub enum ApiError {
 struct ProgressCallbackFunction(Rc<RefCell<dyn FnMut(ProgressEvent)>>);
 
 impl Debug for ProgressCallbackFunction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_tuple("ProgressCallbackFunction")
             .field(&"callback")
             .finish()


### PR DESCRIPTION
### Motivation
Hf-hub is used by ML application/framework as entry point for model resources. When integrating hf-hub in libraries or desktop apps, it can be useful to show information about the on-going download process in different ways than a cli progress-bar (i.e. events forwarded to the tauri js side).

### Techinical details
The PR adds the method `ApiBuilder::with_progress_builder` (both sync and tokio modules) that allows to specify a callback everytime the download progress.

The callback are so specified:

-  _sync_: `pub fn with_progress_callback<F>(mut self, callback: F) -> Self
    where
        F: FnMut(ProgressEvent) + 'static`
- _tokio_: `pub fn with_progress_callback<F, Fut>(mut self, callback: F) -> Self
    where
        F: 'static + Send + Sync + Fn(ProgressEvent) -> Fut,
        Fut: Future<Output = ()> + Send + 'static,`

The event is defined as follow:
```
/// The download progress event
#[derive(Debug, Clone, Serialize)]
pub struct ProgressEvent {
    /// The resource to download
    pub url: String,

    /// The progress expressed as a value between 0 and 1
    pub percentage: f32,

    /// Time elapsed since the download as being started
    pub elapsed_time: Duration,

    /// Estimated time to complete the download
    pub remaining_time: Duration,
}
```

Serialize has been derived to simplify the usage in tauri applications.

### Alternatives

- Define `ApiRepo:download(&self, filename: &str, callback: C)`:
   For symmetry with `ApiBuilder::with_progress` I've prefered to implement the method on the ApiBuilder itself.

- Async callback implementation is far away from being ergonomics: a novel approch is under development [`#![feature(async_closure)]`](https://blog.rust-lang.org/inside-rust/2024/08/09/async-closures-call-for-testing.html) but I was not sure to bring it into this PR