### PR TITLE
Disable rustls's aws-lc-rs feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.12.2", optional = true, default-features = false, features = [
   "json",
 ] }
-rustls = { version = "0.23.4", optional = true }
+rustls = { version = "0.23.4", optional = true, default-features = false, features = [
+  "ring",
+] }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = { version = "2", optional = true }
@@ -43,7 +45,7 @@ default = ["default-tls", "tokio", "ureq"]
 # These features are only relevant when used with the `tokio` feature, but this might change in the future.
 default-tls = []
 native-tls = ["dep:reqwest", "reqwest/default", "dep:native-tls", "ureq/native-tls"]
-rustls-tls = ["dep:rustls", "reqwest/rustls-tls"]
+rustls-tls = ["dep:reqwest", "dep:rustls", "reqwest/rustls-tls"]
 tokio = [
   "dep:futures",
   "dep:indicatif",


### PR DESCRIPTION
When both the `ring` and `aws-lc-rs` features in `rustls` are enabled, the rustls `CryptoProvider` installer from crate features no longer works, as the provider to be used is ambiguous [1].

This is the default configuration and feature set that other dependencies like `reqwest` are using.

[1]: https://docs.rs/rustls/latest/src/rustls/crypto/mod.rs.html#261-282