### PR TITLE
feat: add `endpoint` method the `ApiBuilder`

### DIFF
--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -143,6 +143,12 @@ impl ApiBuilder {
         self
     }
 
+    /// Sets the Hub's HTTP URL
+    pub fn endpoint(mut self, endpoint: String) -> Self {
+        self.endpoint = endpoint;
+        self
+    }
+
     fn build_headers(&self) -> Result<HeaderMap, ApiError> {
         let mut headers = HeaderMap::new();
         let user_agent = format!("unkown/None; {NAME}/{VERSION}; rust/unknown");


### PR DESCRIPTION
In tandem with the recent addition of the `HF_ENDPOINT`, we add a method to set the HTTP endpoint for the Hub.