### PR TITLE
Add builder with_endpoint to allow setting alternate HF Hub endpoints

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -137,6 +137,12 @@ impl ApiBuilder {
         self
     }
 
+    /// Changes the endpoint of the API. Default is `https://huggingface.co`.
+    pub fn with_endpoint(mut self, endpoint: String) -> Self {
+        self.endpoint = endpoint;
+        self
+    }
+
     /// Changes the location of the cache directory. Defaults is `~/.cache/huggingface/`.
     pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
         self.cache = Cache::new(cache_dir);

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -130,6 +130,12 @@ impl ApiBuilder {
         self.progress = progress;
         self
     }
+    
+    /// Changes the endpoint of the API. Default is `https://huggingface.co`.
+    pub fn with_endpoint(mut self, endpoint: String) -> Self {
+        self.endpoint = endpoint;
+        self
+    }
 
     /// Changes the location of the cache directory. Defaults is `~/.cache/huggingface/`.
     pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {


### PR DESCRIPTION
Simple `with_endpoint` builder function to allow setting HF Hub endpoints. Useful for testing locally. 