### PR TITLE
Adding a socks example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/examples/socks/target/

--- a/examples/socks/Cargo.toml
+++ b/examples/socks/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "socks"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hf-hub = { version = "0.4.0", path = "../.." }
+# Adding the `socks` features automatically adds it into
+# The reqwest built by hf-hub therefore enabling socks proxying.
+reqwest = { version = "0.12.9", features = ["socks"] }
+tokio = { version = "1.42.0", features = ["macros"] }

--- a/examples/socks/README.md
+++ b/examples/socks/README.md
@@ -1,0 +1,5 @@
+Example showcasing socks routing.
+Users simply need to add `reqwest` with proper `socks` feature enabled in order to enable it into `hf-hub`.
+
+
+This is due to [feature unification](https://doc.rust-lang.org/cargo/reference/resolver.html#features).

--- a/examples/socks/src/main.rs
+++ b/examples/socks/src/main.rs
@@ -1,0 +1,15 @@
+#[tokio::main]
+async fn main() {
+    let _proxy = std::env::var("HTTPS_PROXY").expect("This example expects a HTTPS_PROXY environment variable to be defined to test that the routing happens correctly. Starts a socks servers and use point HTTPS_PROXY to that server to see the routing in action.");
+
+    let api = hf_hub::api::tokio::ApiBuilder::new()
+        .with_progress(true)
+        .build()
+        .unwrap();
+
+    let _filename = api
+        .model("meta-llama/Llama-2-7b-hf".to_string())
+        .get("model-00001-of-00002.safetensors")
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
Showcasing how to enable `socks` without requiring modifications in this crate.