### PR TITLE
Resumable downloads.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,8 @@
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
               rustup
+              pkg-config
+              openssl
             ];
           };
 

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -29,7 +29,7 @@ type HeaderMap = HashMap<&'static str, String>;
 type HeaderName = &'static str;
 
 /// Specific name for the sync part of the resumable file
-const EXTENTION: &'static str = ".part";
+const EXTENTION: &str = ".part";
 
 struct Wrapper<'a, P: Progress, R: Read> {
     progress: &'a mut P,
@@ -429,7 +429,7 @@ impl Api {
         tmp_path: PathBuf,
         filename: &str,
     ) -> Result<PathBuf, ApiError> {
-        progress.init(size as usize, filename);
+        progress.init(size, filename);
         let filepath = tmp_path;
 
         // Create the file and set everything properly

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -707,6 +707,7 @@ mod tests {
     use rand::{distributions::Alphanumeric, Rng};
     use serde_json::{json, Value};
     use sha2::{Digest, Sha256};
+    use std::io::{Seek, SeekFrom, Write};
 
     struct TempDir {
         path: PathBuf,
@@ -800,6 +801,41 @@ mod tests {
         assert_eq!(
             val[..],
             hex!("b908f2b7227d4d31a2105dfa31095e28d304f9bc938bfaaa57ee2cacf1f62d32")
+        );
+
+        // Here we prove the previous part was correctly resuming by purposefully corrupting the
+        // file.
+        let blob = std::fs::canonicalize(&downloaded_path).unwrap();
+        let mut file = std::fs::OpenOptions::new().write(true).open(&blob).unwrap();
+        let size = file.metadata().unwrap().len();
+        // Not random for consistent sha corruption
+        let truncate: f32 = 0.5;
+        let new_size = (size as f32 * truncate) as u64;
+        // Truncating
+        file.set_len(new_size).unwrap();
+        // Corrupting by changing a single byte.
+        file.seek(SeekFrom::Start(new_size - 1)).unwrap();
+        file.write_all(&[0]).unwrap();
+
+        let mut blob_part = blob.clone();
+        blob_part.set_extension(".part");
+        std::fs::rename(blob, &blob_part).unwrap();
+        std::fs::remove_file(&downloaded_path).unwrap();
+        let content = std::fs::read(&*blob_part).unwrap();
+        assert_eq!(content.len() as u64, new_size);
+        let val = Sha256::digest(content);
+        // We modified the sha.
+        assert!(
+            val[..] != hex!("b908f2b7227d4d31a2105dfa31095e28d304f9bc938bfaaa57ee2cacf1f62d32")
+        );
+        let new_downloaded_path = api.model(model_id.clone()).download("config.json").unwrap();
+        let val = Sha256::digest(std::fs::read(&*new_downloaded_path).unwrap());
+        println!("Sha {val:#x}");
+        assert_eq!(downloaded_path, new_downloaded_path);
+        assert_eq!(
+            val[..],
+            // Corrupted sha
+            hex!("32b83c94ee55a8d43d68b03a859975f6789d647342ddeb2326fcd5e0127035b5")
         );
     }
 

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -516,7 +516,7 @@ impl ApiRepo {
             .await
         {
             Ok(mut f) => {
-                let len = f.metadata().await.unwrap().len();
+                let len = f.metadata().await?.len();
                 if len == (length + N_BYTES) as u64 {
                     f.seek(SeekFrom::Start(length as u64)).await.unwrap();
                     let mut buf = [0u8; N_BYTES];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
     not(feature = "ureq"),
     doc = "Documentation is meant to be compiled with default features (at least ureq)"
 )]
-#[cfg(any(feature = "tokio", feature = "ureq"))]
-use rand::{distributions::Alphanumeric, Rng};
 use std::io::Write;
 use std::path::PathBuf;
 
@@ -108,21 +106,6 @@ impl Cache {
     /// ```
     pub fn space(&self, model_id: String) -> CacheRepo {
         self.repo(Repo::new(model_id, RepoType::Space))
-    }
-
-    #[cfg(any(feature = "tokio", feature = "ureq"))]
-    pub(crate) fn temp_path(&self) -> PathBuf {
-        let mut path = self.path().clone();
-        path.push("tmp");
-        std::fs::create_dir_all(&path).ok();
-
-        let s: String = rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(7)
-            .map(char::from)
-            .collect();
-        path.push(s);
-        path.to_path_buf()
     }
 }
 


### PR DESCRIPTION
Notes on the strategy here.


Sync:
- Relatively straigforward, we're not multiplexing, we write in order, therefore we can simply pick up whereever we left off.

Tokio:
Since we're multiplexing, writes are not happening in order. We could:
- Store every written interval and skip those, but that involves creating somewhat complex datastructures.
- Instead, since writes are *mostly* ordered, we simply commit whatever was fully written as a single `u64` at the very end of the partial file. When resuming, we read that single int, and resume from there. Anything fishy and we drop the resumability.

This feels simpler that the more complex version, seems to work quite well in practice (only tested on stable networks right now).
The probability for storing invalid files seems low (since commit happens at a single location both in code and in file). 