### PR TITLE
Fix minor syntax typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ This library uses tokio default TLS implementations which is `native-tls` (opens
 If you want control over the TLS backend you can remove the default features and only add the backend you are intending to use. 
 
 ```bash
-cargo add hf-hub -no-default-features --features ureq,rustls-tls
-cargo add hf-hub -no-default-features --features ureq,native-tls
-cargo add hf-hub -no-default-features --features tokio,rustls-tls
-cargo add hf-hub -no-default-features --features tokio,native-tls
+cargo add hf-hub --no-default-features --features ureq,rustls-tls
+cargo add hf-hub --no-default-features --features ureq,native-tls
+cargo add hf-hub --no-default-features --features tokio,rustls-tls
+cargo add hf-hub --no-default-features --features tokio,native-tls
 ```
 
 


### PR DESCRIPTION
The `no-default-features` flag is a double hyphen argument. See: https://doc.rust-lang.org/cargo/reference/features.html#command-line-feature-options

Running it without looks like:
![image](https://github.com/user-attachments/assets/351e0263-0ea4-4c16-8e75-b9269b568a12)

MacOS, rust v1.83.0