### PR TITLE
feat: Adds a new environment variable HF_HUB_USER_AGENT_ORIGIN to set origin of calls in user-agent

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,6 +13,8 @@ pub mod sync;
 
 const HF_ENDPOINT: &str = "HF_ENDPOINT";
 
+const ENV_UA_ORIGIN: &str = "HF_HUB_USER_AGENT_ORIGIN";
+
 /// This trait is used by users of the lib
 /// to implement custom behavior during file downloads
 pub trait Progress {

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -303,7 +303,12 @@ impl ApiBuilder {
 
     fn build_headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
-        let user_agent = format!("unkown/None; {NAME}/{VERSION}; rust/unknown");
+        let user_agent = format!("unknown/None; {NAME}/{VERSION}; rust/unknown");
+        // add origin user-agent if HF_HUB_USER_AGENT_ORIGIN is set in environment
+        let user_agent = match std::env::var("HF_HUB_USER_AGENT_ORIGIN").ok() {
+            Some(origin) => format!("{user_agent}; {origin}"),
+            None => user_agent,
+        };
         headers.insert(USER_AGENT, user_agent);
         if let Some(token) = &self.token {
             headers.insert(AUTHORIZATION, format!("Bearer {token}"));

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -608,7 +608,7 @@ impl ApiRepo {
         format!("{endpoint}/{repo_id}/resolve/{revision}/{filename}")
     }
 
-    async fn download_tempfile<'a, P: Progress + Clone + Send + Sync + 'static>(
+    async fn download_tempfile<P: Progress + Clone + Send + Sync + 'static>(
         &self,
         url: &str,
         length: usize,

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -1,4 +1,4 @@
-use super::Progress as SyncProgress;
+use super::{Progress as SyncProgress, ENV_UA_ORIGIN};
 use super::{RepoInfo, HF_ENDPOINT};
 use crate::{Cache, Repo, RepoType};
 use futures::stream::FuturesUnordered;
@@ -330,8 +330,8 @@ impl ApiBuilder {
         let mut headers = HeaderMap::new();
         let user_agent = format!("unknown/None; {NAME}/{VERSION}; rust/unknown");
         // add origin user-agent if HF_HUB_USER_AGENT_ORIGIN is set in environment
-        let user_agent = match std::env::var("HF_HUB_USER_AGENT_ORIGIN").ok() {
-            Some(origin) => format!("{user_agent}; {origin}"),
+        let user_agent = match std::env::var(ENV_UA_ORIGIN).ok() {
+            Some(origin) => format!("{user_agent}; origin/{origin}"),
             None => user_agent,
         };
         headers.insert(USER_AGENT, HeaderValue::from_str(&user_agent)?);
@@ -1322,7 +1322,7 @@ mod tests {
                 "gated": false,
                 "id": "mcpotato/42-eicar-street",
                 "lastModified": "2022-11-30T19:54:16.000Z",
-                "likes": 1,
+                "likes": 2,
                 "modelId": "mcpotato/42-eicar-street",
                 "private": false,
                 "sha": "8b3861f6931c4026b0cd22b38dbc09e7668983ac",
@@ -1370,6 +1370,7 @@ mod tests {
                 ],
                 "spaces": [],
                 "tags": ["pytorch", "region:us"],
+                "usedStorage": 22,
             })
         );
     }

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -328,7 +328,12 @@ impl ApiBuilder {
 
     fn build_headers(&self) -> Result<HeaderMap, ApiError> {
         let mut headers = HeaderMap::new();
-        let user_agent = format!("unkown/None; {NAME}/{VERSION}; rust/unknown");
+        let user_agent = format!("unknown/None; {NAME}/{VERSION}; rust/unknown");
+        // add origin user-agent if HF_HUB_USER_AGENT_ORIGIN is set in environment
+        let user_agent = match std::env::var("HF_HUB_USER_AGENT_ORIGIN").ok() {
+            Some(origin) => format!("{user_agent}; {origin}"),
+            None => user_agent,
+        };
         headers.insert(USER_AGENT, HeaderValue::from_str(&user_agent)?);
         if let Some(token) = &self.token {
             headers.insert(


### PR DESCRIPTION
Adds a new HF_HUB_USER_AGENT_ORIGIN environment variable that allows to set an origin to HTTP headers. It is convenient to track requests made by partners during collaborations.

Linked to https://github.com/huggingface/huggingface_hub/pull/2869 and https://github.com/huggingface/text-generation-inference/pull/3027