### PR TITLE
Fix failing API tests due to outdated model metadata expectations

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -1215,7 +1215,7 @@ mod tests {
                 "gated": false,
                 "id": "mcpotato/42-eicar-street",
                 "lastModified": "2022-11-30T19:54:16.000Z",
-                "likes": 3,
+                "likes": 4,
                 "modelId": "mcpotato/42-eicar-street",
                 "private": false,
                 "sha": "8b3861f6931c4026b0cd22b38dbc09e7668983ac",
@@ -1261,7 +1261,9 @@ mod tests {
                         "size": 31
                     }
                 ],
-                "spaces": [],
+                "spaces": [
+                    "szk2024/est"
+                ],
                 "tags": ["pytorch", "region:us"],
                 "usedStorage": 22
             })

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -1343,7 +1343,7 @@ mod tests {
                 "gated": false,
                 "id": "mcpotato/42-eicar-street",
                 "lastModified": "2022-11-30T19:54:16.000Z",
-                "likes": 3,
+                "likes": 4,
                 "modelId": "mcpotato/42-eicar-street",
                 "private": false,
                 "sha": "8b3861f6931c4026b0cd22b38dbc09e7668983ac",
@@ -1389,7 +1389,9 @@ mod tests {
                         "size": 31
                     }
                 ],
-                "spaces": [],
+                "spaces": [
+                    "szk2024/est"
+                ],
                 "tags": ["pytorch", "region:us"],
                 "usedStorage": 22
             })


### PR DESCRIPTION
# Fix failing API tests due to outdated model metadata expectations

## Problem
Two tests in the test suite were failing (2/26 tests):
- `detailed_info` test in `src/api/sync.rs` 
- `info_request` test in `src/api/tokio.rs`

Both tests were failing because they contained hardcoded assertions against live API responses from the `mcpotato/42-eicar-street` model on Hugging Face Hub. The model's metadata had naturally evolved over time, causing the tests to expect outdated values.

## Root Cause
The tests were performing exact JSON comparisons against live API responses, which is inherently brittle since:
1. Model metadata can change over time (likes, spaces, etc.)
2. The Hugging Face Hub is a live platform where user interactions modify model statistics
3. Models can be added to new spaces or receive more likes from the community

## Changes Made
Updated the hardcoded test expectations in both sync and async API implementations to match the current state of the model metadata:

### sync.rs changes:
- Updated `"likes": 3` → `"likes": 4` in the `detailed_info` test
- Added `"szk2024/est"` to the `spaces` array

### tokio.rs changes:
- Updated `"likes": 3` → `"likes": 4` in the `info_request` test  
- Added `"szk2024/est"` to the `spaces` array

## Impact
- ✅ All tests now pass (26/26)
- ✅ No functional code changes - only test expectation updates
- ✅ Both sync and async API implementations remain fully functional
- ✅ Test coverage maintained without compromising test validity

## Future Considerations
These tests validate the exact API response format but are vulnerable to live data changes. Consider:
- Using mock responses for exact JSON structure validation
- Testing against more stable models with predictable metadata
- Focusing assertions on response structure rather than exact values for live API tests

## Testing
```bash
cargo test
# All 26 tests pass
```

## Technical Details

### Files Changed
- `src/api/sync.rs` - Updated model metadata expectations in sync API test
- `src/api/tokio.rs` - Updated model metadata expectations in async API test

### Commit History
```
33cfedd test: add szk2024/est to spaces array in async API model metadata test
f618dfa test: update mcpotato model likes count from 3 to 4 in sync API test
```

### Branch Information
- **Source branch:** `test-fixes`
- **Target branch:** `main`
- **Type:** Bug fix (test maintenance)

## Validation

### Before Fix
```
test result: FAILED. 24 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```

### After Fix
```
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```