### PR TITLE
Remove markdown from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/huggingface/hf-hub"
 readme = "README.md"
 keywords = ["huggingface", "hf", "hub", "machine-learning"]
 description = """
-This crates aims ease the interaction with [huggingface](https://huggingface.co/) 
-It aims to be compatible with [huggingface_hub](https://github.com/huggingface/huggingface_hub/) python package, but only implements a smaller subset of functions.
+This crates aims ease the interaction with huggingface
+It aims to be compatible with the huggingface_hub python package, but only implements a smaller subset of functions.
 """
 
 


### PR DESCRIPTION
Per https://doc.rust-lang.org/cargo/reference/manifest.html#the-description-field ,

"This should be plain text (not Markdown)."