### PR TITLE
Expose `metadata` and `pointer_path` methods

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -471,7 +471,8 @@ impl Api {
         &self.client
     }
 
-    fn metadata(&self, url: &str) -> Result<Metadata, ApiError> {
+    /// Get metadata for the file at the given URL.
+    pub fn metadata(&self, url: &str) -> Result<Metadata, ApiError> {
         let mut response = self
             .no_redirect_client
             .get(url)

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -360,11 +360,29 @@ impl ApiBuilder {
     }
 }
 
+/// File metadata.
 #[derive(Debug)]
-struct Metadata {
+pub struct Metadata {
     commit_hash: String,
     etag: String,
     size: usize,
+}
+
+impl Metadata {
+    /// Get the commit hash of the file.
+    pub fn commit_hash(&self) -> &str {
+        &self.commit_hash
+    }
+
+    /// Get the etag of the file.
+    pub fn etag(&self) -> &str {
+        &self.etag
+    }
+
+    /// Get the file size.
+    pub fn size(&self) -> usize {
+        self.size
+    }
 }
 
 /// The actual Api used to interact with the hub.

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -1226,6 +1226,7 @@ mod tests {
             json!({
                 "_id": "621ffdc136468d709f17ddb4",
                 "author": "mcpotato",
+                "config": {},
                 "createdAt": "2022-03-02T23:29:05.000Z",
                 "disabled": false,
                 "downloads": 0,

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -1354,6 +1354,7 @@ mod tests {
             json!({
                 "_id": "621ffdc136468d709f17ddb4",
                 "author": "mcpotato",
+                "config": {},
                 "createdAt": "2022-03-02T23:29:05.000Z",
                 "disabled": false,
                 "downloads": 0,
@@ -1451,7 +1452,7 @@ mod tests {
             .build()
             .expect("failed to build API");
 
-        let repo = api.model("google-bert/bert-base-uncased".to_string());
+        let repo = api.model("danieldk/private-test".to_string());
         let error = repo
             .info()
             .await

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -401,10 +401,10 @@ impl ApiBuilder {
 }
 
 #[derive(Debug)]
-struct Metadata {
-    commit_hash: String,
-    etag: String,
-    size: usize,
+pub struct Metadata {
+    pub commit_hash: String,
+    pub etag: String,
+    pub size: usize,
 }
 
 /// The actual Api used to interact with the hub.
@@ -496,7 +496,7 @@ impl Api {
         &self.client
     }
 
-    async fn metadata(&self, url: &str) -> Result<Metadata, ApiError> {
+    pub async fn metadata(&self, url: &str) -> Result<Metadata, ApiError> {
         let response = self
             .relative_redirect_client
             .get(url)

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -400,11 +400,29 @@ impl ApiBuilder {
     }
 }
 
+/// File metadata.
 #[derive(Debug)]
 pub struct Metadata {
-    pub commit_hash: String,
-    pub etag: String,
-    pub size: usize,
+    commit_hash: String,
+    etag: String,
+    size: usize,
+}
+
+impl Metadata {
+    /// Get the commit hash of the file.
+    pub fn commit_hash(&self) -> &str {
+        &self.commit_hash
+    }
+
+    /// Get the etag of the file.
+    pub fn etag(&self) -> &str {
+        &self.etag
+    }
+
+    /// Get the file size.
+    pub fn size(&self) -> usize {
+        self.size
+    }
 }
 
 /// The actual Api used to interact with the hub.
@@ -496,6 +514,7 @@ impl Api {
         &self.client
     }
 
+    /// Get metadata for the file at the given URL.
     pub async fn metadata(&self, url: &str) -> Result<Metadata, ApiError> {
         let response = self
             .relative_redirect_client
@@ -523,7 +542,7 @@ impl Api {
             .to_str()?
             .to_string();
 
-        // The response was redirected o S3 most likely which will
+        // The response was redirected to S3 most likely which will
         // know about the size of the file
         let response = if response.status().is_redirection() {
             self.client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ impl CacheRepo {
         blob_path
     }
 
-    pub(crate) fn pointer_path(&self, commit_hash: &str) -> PathBuf {
+    pub fn pointer_path(&self, commit_hash: &str) -> PathBuf {
         let mut pointer_path = self.path();
         pointer_path.push("snapshots");
         pointer_path.push(commit_hash);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@ impl CacheRepo {
         Ok(())
     }
 
+    /// Get the path of the blob with the given etag.
     #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn blob_path(&self, etag: &str) -> PathBuf {
         let mut blob_path = self.path();
@@ -186,6 +187,10 @@ impl CacheRepo {
         blob_path
     }
 
+
+    /// Get the path of the snapshot with the given commit hash.
+    ///
+    /// This path contains symlink pointers to the files for this commit.
     pub fn pointer_path(&self, commit_hash: &str) -> PathBuf {
         let mut pointer_path = self.path();
         pointer_path.push("snapshots");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ impl CacheRepo {
     }
 
     #[cfg(any(feature = "tokio", feature = "ureq"))]
-    pub(crate) fn blob_path(&self, etag: &str) -> PathBuf {
+    pub fn blob_path(&self, etag: &str) -> PathBuf {
         let mut blob_path = self.path();
         blob_path.push("blobs");
         blob_path.push(etag);


### PR DESCRIPTION
I have used/needed these useful methods in [safetensors-browser](https://github.com/danieldk/safetensors-browser). Making them visible in the official crate makes it possible to upload safetensors-browser to crates.io again.