### PR TITLE
fix: fix native TLS option to use the native certificate roots.

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -338,12 +338,11 @@ impl ApiBuilder {
     pub fn build(self) -> Result<Api, ApiError> {
         let headers = self.build_headers();
 
-        let builder = builder()?.redirect_auth_headers(RedirectAuthHeaders::SameHost);
-        let agent: Agent = builder.build().into();
+        let bldr = builder()?.redirect_auth_headers(RedirectAuthHeaders::SameHost);
+        let agent: Agent = bldr.build().into();
         let client = HeaderAgent::new(agent, headers.clone());
 
-        let no_redirect_agent: Agent = Agent::config_builder()
-            // .try_proxy_from_env(true)
+        let no_redirect_agent: Agent = builder()?
             .max_redirects(0)
             .build()
             .into();
@@ -724,6 +723,7 @@ fn builder() -> Result<ConfigBuilder<AgentScope>, ApiError> {
     Ok(Agent::config_builder().tls_config(
         TlsConfig::builder()
             .provider(TlsProvider::NativeTls)
+            .root_certs(ureq::tls::RootCerts::PlatformVerifier)
             .build(),
     ))
 }


### PR DESCRIPTION
It looks like an update to `ureq` requires you to explicitly state that you want to use the native platform certificate verifier.

Personally, as someone operating behind an http proxy with a custom https certificate, that is usually why I'm needing native TLS in the first place, so I think it makes sense to enable by default.

This fixes me being unable to download anything when using libraries like candle because ureq isn't trusting my system's https certificate store.

**PS:** I thought there was another problem with this when it didn't work to run the example, but apparently the example actually tries to download a file that requires authentication. I did confirm this works by changing the repo + file to something that was public.