### PR TITLE
Fix CJK filename crash bug in message formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ ureq = { version = "3", optional = true, features = [
   "socks-proxy",
 ] }
 native-tls = { version = "0.2.12", optional = true }
+unicode-width = "0.2.2"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.61"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -43,7 +43,12 @@ impl Progress for ProgressBar {
             );
         let maxlength = 30;
         let message = if filename.len() > maxlength {
-            format!("..{}", &filename[filename.len() - maxlength..])
+            // Fix CJK filename crash bug
+            let start = filename.char_indices()
+            .map(|(i, _)| i)
+            .find(|&i| filename.len() - i <= maxlength)
+            .unwrap_or(filename.len());        
+            format!("..{}", &filename[start..])
         } else {
             filename.to_string()
         };


### PR DESCRIPTION
If repo contains CJK filename, hf-hub will crash.