### PR TITLE
Allow HF endpoint override via HF_ENDPOINT env var

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -265,7 +265,7 @@ impl ApiBuilder {
         let max_retries = 0;
         let progress = true;
 
-        let endpoint = "https://huggingface.co".to_string();
+        let endpoint = std::env::var(HF_ENDPOINT).unwrap_or("https://huggingface.co".to_string());
 
         let user_agent = vec![
             ("unknown".to_string(), "None".to_string()),

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -284,8 +284,10 @@ impl ApiBuilder {
             ("rust".to_string(), "unknown".to_string()),
         ];
 
+        let endpoint = std::env::var(HF_ENDPOINT).unwrap_or("https://huggingface.co".to_string());
+
         Self {
-            endpoint: "https://huggingface.co".to_string(),
+            endpoint: endpoint,
             cache,
             token,
             max_files: 1,


### PR DESCRIPTION

### Summary
Allow `HF_ENDPOINT` environment variable to be respected when using local cache for model/dataset updates.

### Motivation / Problem Statement
Currently, when users specify a custom Hugging Face endpoint via `HF_ENDPOINT` environment variable for downloading models or datasets, this setting is not persisted or respected during subsequent cache operations.

**Scenario:**
1. User sets `HF_ENDPOINT=https://hf-mirror.com` to download a model from a mirror server
2. The model is cached locally in `~/.cache/huggingface/`
3. Later, when checking for model updates or refreshing cache, the system defaults to `https://huggingface.co` instead of respecting the originally configured `HF_ENDPOINT`

This breaks the expected behavior where users consistently want to use their specified mirror server for all Hugging Face Hub operations, including cache refresh and version updates.

**Proposed Changes**
Update endpoint resolution logic to read from environment variable with appropriate fallback:
```rust
let endpoint = std::env::var(HF_ENDPOINT).unwrap_or("https://huggingface.co".to_string());
```