### PR TITLE
refactor: provide utils and constants for extensibility

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,8 +11,6 @@ pub mod tokio;
 #[cfg(feature = "ureq")]
 pub mod sync;
 
-const HF_ENDPOINT: &str = "HF_ENDPOINT";
-
 /// This trait is used by users of the lib
 /// to implement custom behavior during file downloads
 pub trait Progress {

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -1,6 +1,7 @@
-use super::{RepoInfo, HF_ENDPOINT};
+use super::RepoInfo;
 use crate::api::sync::ApiError::InvalidHeader;
 use crate::api::Progress;
+use crate::constants::{DEFAULT_ENDPOINT, HF_ENDPOINT};
 use crate::{Cache, Repo, RepoType};
 use http::{StatusCode, Uri};
 use indicatif::ProgressBar;
@@ -265,7 +266,7 @@ impl ApiBuilder {
         let max_retries = 0;
         let progress = true;
 
-        let endpoint = "https://huggingface.co".to_string();
+        let endpoint = DEFAULT_ENDPOINT.to_string();
 
         let user_agent = vec![
             ("unknown".to_string(), "None".to_string()),

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -1,5 +1,6 @@
 use super::Progress as SyncProgress;
-use super::{RepoInfo, HF_ENDPOINT};
+use super::RepoInfo;
+use crate::constants::{DEFAULT_ENDPOINT, HF_ENDPOINT};
 use crate::{Cache, Repo, RepoType};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -285,7 +286,7 @@ impl ApiBuilder {
         ];
 
         Self {
-            endpoint: "https://huggingface.co".to_string(),
+            endpoint: DEFAULT_ENDPOINT.to_string(),
             cache,
             token,
             max_files: 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,43 @@ use std::path::PathBuf;
 /// The actual Api to interact with the hub.
 #[cfg(any(feature = "tokio", feature = "ureq"))]
 pub mod api;
+pub mod paths;
 
-const HF_HOME: &str = "HF_HOME";
+/// Configuration constants
+pub(crate) mod constants {
+    /// HF home env var
+    pub(crate) const HF_HOME: &str = "HF_HOME";
+    /// HF endpoint env var
+    pub(crate) const HF_ENDPOINT: &str = "HF_ENDPOINT";
+    /// HF endpoint
+    pub(crate) const DEFAULT_ENDPOINT: &str = "https://huggingface.co";
+
+    /// Path separator used in repository names and URLs.
+    pub(crate) const REPO_ID_SEPARATOR: &str = "/";
+    /// Flattened separator used to replace path separators in repo names.
+    pub(crate) const FLAT_SEPARATOR: &str = "--";
+    /// URL-encoded separator.
+    pub(crate) const ENCODED_SEPARATOR: &str = "%2F";
+
+    /// Default cache directory name relative to the user's home directory.
+    pub(crate) const CACHE_DIR: &str = ".cache";
+    /// Top-level Hugging Face directory name within the cache.
+    pub(crate) const TOP_LEVEL_HF_DIR: &str = "huggingface";
+    /// Hub-specific directory name for storing data.
+    pub(crate) const HUB_DIR: &str = "hub";
+    /// Directory name for storing refs.
+    pub(crate) const REFS_DIR: &str = "refs";
+    /// Directory name for storing snapshots.
+    pub(crate) const SNAPSHOTS_DIR: &str = "snapshots";
+    /// Directory name for storing blobs.
+    pub(crate) const BLOBS_DIR: &str = "blobs";
+
+    /// Filename for storing authentication token.
+    pub(crate) const TOKEN_FILE: &str = "token";
+
+    /// Default branch name to use when none is specified.
+    pub(crate) const DEFAULT_BRANCH: &str = "main";
+}
 
 /// The type of repo to interact with
 #[derive(Debug, Clone, Copy)]
@@ -23,6 +58,42 @@ pub enum RepoType {
     Dataset,
     /// This is a space, usually a demo showcashing a given model or dataset
     Space,
+}
+
+impl RepoType {
+    /// Returns the plural form used in API routes, URLs, and cache folder names.
+    pub fn plural(&self) -> &'static str {
+        match self {
+            RepoType::Model => "models",
+            RepoType::Dataset => "datasets",
+            RepoType::Space => "spaces",
+        }
+    }
+}
+
+/// Display is for human-facing output (CLI logs, errors).
+impl std::fmt::Display for RepoType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RepoType::Model => write!(f, "model"),
+            RepoType::Dataset => write!(f, "dataset"),
+            RepoType::Space => write!(f, "space"),
+        }
+    }
+}
+
+/// Allows parsing from CLI args or config strings.
+impl std::str::FromStr for RepoType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "model" | "models" => Ok(RepoType::Model),
+            "dataset" | "datasets" => Ok(RepoType::Dataset),
+            "space" | "spaces" => Ok(RepoType::Space),
+            _ => Err(format!("Invalid repo type: '{}'", s)),
+        }
+    }
 }
 
 /// A local struct used to fetch information from the cache folder.
@@ -40,10 +111,10 @@ impl Cache {
     /// Creates cache from environment variable HF_HOME (if defined) otherwise
     /// defaults to [`home_dir`]/.cache/huggingface/
     pub fn from_env() -> Self {
-        match std::env::var(HF_HOME) {
+        match std::env::var(constants::HF_HOME) {
             Ok(home) => {
                 let mut path: PathBuf = home.into();
-                path.push("hub");
+                path.push(constants::HUB_DIR);
                 Self::new(path)
             }
             Err(_) => Self::default(),
@@ -57,11 +128,7 @@ impl Cache {
 
     /// Returns the location of the token file
     pub fn token_path(&self) -> PathBuf {
-        let mut path = self.path.clone();
-        // Remove `"hub"`
-        path.pop();
-        path.push("token");
-        path
+        paths::token_path(&self.path)
     }
 
     /// Returns the token value if it exists in the cache
@@ -124,6 +191,13 @@ impl Cache {
     }
 }
 
+impl Default for Cache {
+    fn default() -> Self {
+        let path = paths::get_hub_dir();
+        Self::new(path)
+    }
+}
+
 /// Shorthand for accessing things within a particular repo
 #[derive(Debug)]
 pub struct CacheRepo {
@@ -151,14 +225,13 @@ impl CacheRepo {
     }
 
     fn path(&self) -> PathBuf {
-        let mut ref_path = self.cache.path.clone();
-        ref_path.push(self.repo.folder_name());
-        ref_path
+        let mut cache_repo_path = self.cache.path.clone();
+        cache_repo_path.push(self.repo.folder_name());
+        cache_repo_path
     }
 
     fn ref_path(&self) -> PathBuf {
-        let mut ref_path = self.path();
-        ref_path.push("refs");
+        let mut ref_path = paths::refs_dir(&self.path());
         ref_path.push(self.repo.revision());
         ref_path
     }
@@ -181,31 +254,18 @@ impl CacheRepo {
     /// Get the path of the blob with the given etag.
     #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn blob_path(&self, etag: &str) -> PathBuf {
-        let mut blob_path = self.path();
-        blob_path.push("blobs");
+        let mut blob_path = paths::blobs_dir(&self.path());
         blob_path.push(etag);
         blob_path
     }
-
 
     /// Get the path of the snapshot with the given commit hash.
     ///
     /// This path contains symlink pointers to the files for this commit.
     pub fn pointer_path(&self, commit_hash: &str) -> PathBuf {
-        let mut pointer_path = self.path();
-        pointer_path.push("snapshots");
+        let mut pointer_path = paths::snapshots_dir(&self.path());
         pointer_path.push(commit_hash);
         pointer_path
-    }
-}
-
-impl Default for Cache {
-    fn default() -> Self {
-        let mut path = dirs::home_dir().expect("Cache directory cannot be found");
-        path.push(".cache");
-        path.push("huggingface");
-        path.push("hub");
-        Self::new(path)
     }
 }
 
@@ -220,7 +280,7 @@ pub struct Repo {
 impl Repo {
     /// Repo with the default branch ("main").
     pub fn new(repo_id: String, repo_type: RepoType) -> Self {
-        Self::with_revision(repo_id, repo_type, "main".to_string())
+        Self::with_revision(repo_id, repo_type, constants::DEFAULT_BRANCH.to_string())
     }
 
     /// fully qualified Repo
@@ -247,14 +307,9 @@ impl Repo {
         Self::new(repo_id, RepoType::Space)
     }
 
-    /// The normalized folder nameof the repo within the cache directory
+    /// The flattened folder name of the repo within the cache directory
     pub fn folder_name(&self) -> String {
-        let prefix = match self.repo_type {
-            RepoType::Model => "models",
-            RepoType::Dataset => "datasets",
-            RepoType::Space => "spaces",
-        };
-        format!("{prefix}--{}", self.repo_id).replace('/', "--")
+        paths::flattened_repo_folder_name(&self.repo_type, &self.repo_id)
     }
 
     /// The revision
@@ -267,30 +322,25 @@ impl Repo {
     pub fn url(&self) -> String {
         match self.repo_type {
             RepoType::Model => self.repo_id.to_string(),
-            RepoType::Dataset => {
-                format!("datasets/{}", self.repo_id)
-            }
-            RepoType::Space => {
-                format!("spaces/{}", self.repo_id)
-            }
+            _ => format!("{}/{}", self.repo_type.plural(), self.repo_id),
         }
     }
 
     /// Revision needs to be url escaped before being used in a URL
     #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn url_revision(&self) -> String {
-        self.revision.replace('/', "%2F")
+        paths::encode_separator(&self.revision)
     }
 
     /// Used to compute the repo's url part when accessing the metadata of the repo
     #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn api_url(&self) -> String {
-        let prefix = match self.repo_type {
-            RepoType::Model => "models",
-            RepoType::Dataset => "datasets",
-            RepoType::Space => "spaces",
-        };
-        format!("{prefix}/{}/revision/{}", self.repo_id, self.url_revision())
+        format!(
+            "{}/{}/revision/{}",
+            self.repo_type.plural(),
+            self.repo_id,
+            self.url_revision()
+        )
     }
 }
 
@@ -338,7 +388,7 @@ mod tests {
     fn token_path() {
         let cache = Cache::from_env();
         let token_path = cache.token_path().to_str().unwrap().to_string();
-        if let Ok(hf_home) = std::env::var(HF_HOME) {
+        if let Ok(hf_home) = std::env::var(constants::HF_HOME) {
             assert_eq!(token_path, format!("{hf_home}/token"));
         } else {
             let n = "huggingface/token".len();

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -10,66 +10,43 @@ use std::path::{Path, PathBuf};
 
 use crate::{constants, RepoType};
 
-/// Returns the user's home directory path.
-///
-/// # Panics
-///
-/// Panics if the user's home directory cannot be determined. This typically
-/// only happens in very restricted environments or when the HOME environment
-/// variable is not set.
-pub(crate) fn get_home_dir() -> PathBuf {
-    dirs::home_dir().expect("Home directory cannot be found")
-}
-
 /// Returns the user's cache directory path.
 ///
 /// This follows platform conventions for cache storage:
 /// - On Unix-like systems: `~/.cache`
 /// - On Windows: `%USERPROFILE%\.cache`
 /// - On macOS: `~/.cache` (not following macOS conventions for consistency)
-///
-/// # Panics
-///
-/// Panics if the underlying get_home_dir call panics
-pub(crate) fn get_cache_dir() -> PathBuf {
-    let mut path = get_home_dir();
+pub(crate) fn get_cache_dir() -> Option<PathBuf> {
+    let mut path = dirs::home_dir()?;
     path.push(constants::CACHE_DIR);
-    path
+    Some(path)
 }
 
 /// Returns the top-level Hugging Face directory within the cache.
 ///
 /// The path follows the pattern: `{cache_dir}/huggingface`
-///
-/// # Panics
-///
-/// Panics if the underlying get_home_dir call panics
-pub(crate) fn get_top_level_hf_dir() -> PathBuf {
-    let mut path = get_cache_dir();
+pub(crate) fn get_top_level_hf_dir() -> Option<PathBuf> {
+    let mut path = get_cache_dir()?;
     path.push(constants::TOP_LEVEL_HF_DIR);
-    path
+    Some(path)
 }
 
 /// Returns the Hugging Face Hub directory for repository storage.
 ///
 /// The path follows the pattern: `{cache_dir}/{top_level_hf_dir}/hub`
 ///
-/// # Panics
-///
-/// Panics if the underlying get_home_dir call panics
-///
 /// # Examples
 ///
 /// ```rust
 /// use hf_hub::paths::get_hub_dir;
 ///
-/// let hub_dir = get_hub_dir();
+/// let hub_dir = get_hub_dir().unwrap();
 /// assert!(hub_dir.ends_with(std::path::Path::new("huggingface/hub")));
 /// ```
-pub fn get_hub_dir() -> PathBuf {
-    let mut path = get_top_level_hf_dir();
+pub fn get_hub_dir() -> Option<PathBuf> {
+    let mut path = get_top_level_hf_dir()?;
     path.push(constants::HUB_DIR);
-    path
+    Some(path)
 }
 
 /// Convert path separators in a string to flattened separators.

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,146 @@
+//! General path utilities.
+//!
+//! This module provides helper functions for common operations like path
+//! construction and character encoding / normalization.
+//!
+//! These utilities are used internally by the library but are also exposed
+//! for use by other crates that need similar functionality.
+
+use std::path::{Path, PathBuf};
+
+use crate::{constants, RepoType};
+
+/// Returns the user's home directory path.
+///
+/// # Panics
+///
+/// Panics if the user's home directory cannot be determined. This typically
+/// only happens in very restricted environments or when the HOME environment
+/// variable is not set.
+pub(crate) fn get_home_dir() -> PathBuf {
+    dirs::home_dir().expect("Home directory cannot be found")
+}
+
+/// Returns the user's cache directory path.
+///
+/// This follows platform conventions for cache storage:
+/// - On Unix-like systems: `~/.cache`
+/// - On Windows: `%USERPROFILE%\.cache`
+/// - On macOS: `~/.cache` (not following macOS conventions for consistency)
+///
+/// # Panics
+///
+/// Panics if the underlying get_home_dir call panics
+pub(crate) fn get_cache_dir() -> PathBuf {
+    let mut path = get_home_dir();
+    path.push(constants::CACHE_DIR);
+    path
+}
+
+/// Returns the top-level Hugging Face directory within the cache.
+///
+/// The path follows the pattern: `{cache_dir}/huggingface`
+///
+/// # Panics
+///
+/// Panics if the underlying get_home_dir call panics
+pub(crate) fn get_top_level_hf_dir() -> PathBuf {
+    let mut path = get_cache_dir();
+    path.push(constants::TOP_LEVEL_HF_DIR);
+    path
+}
+
+/// Returns the Hugging Face Hub directory for repository storage.
+///
+/// The path follows the pattern: `{cache_dir}/{top_level_hf_dir}/hub`
+///
+/// # Panics
+///
+/// Panics if the underlying get_home_dir call panics
+///
+/// # Examples
+///
+/// ```rust
+/// use hf_hub::paths::get_hub_dir;
+///
+/// let hub_dir = get_hub_dir();
+/// assert!(hub_dir.ends_with(std::path::Path::new("huggingface/hub")));
+/// ```
+pub fn get_hub_dir() -> PathBuf {
+    let mut path = get_top_level_hf_dir();
+    path.push(constants::HUB_DIR);
+    path
+}
+
+/// Convert path separators in a string to flattened separators.
+///
+/// # Examples
+///
+/// ```rust
+/// use hf_hub::paths::flatten_separator;
+///
+/// let flattened = flatten_separator("HuggingFaceTB/SmolLM2-135M");
+/// assert_eq!(flattened, "HuggingFaceTB--SmolLM2-135M");
+///
+/// let no_change = flatten_separator("simple-name");
+/// assert_eq!(no_change, "simple-name");
+/// ```
+pub fn flatten_separator(input: &str) -> String {
+    input.replace(constants::REPO_ID_SEPARATOR, constants::FLAT_SEPARATOR)
+}
+
+/// Encodes path separators in a string.
+///
+/// # Examples
+///
+/// ```rust
+/// use hf_hub::paths::encode_separator;
+///
+/// let encoded = encode_separator("HuggingFaceTB/SmolLM2-135M");
+/// assert_eq!(encoded, "HuggingFaceTB%2FSmolLM2-135M");
+///
+/// let no_change = encode_separator("simple-name");
+/// assert_eq!(no_change, "simple-name");
+/// ```
+pub fn encode_separator(input: &str) -> String {
+    input.replace(constants::REPO_ID_SEPARATOR, constants::ENCODED_SEPARATOR)
+}
+
+/// Builds a repo folder name: "models--user--repo"
+pub fn flattened_repo_folder_name(repo_type: &RepoType, repo_id: &str) -> String {
+    let prefix = repo_type.plural();
+    let prefixed_repo_id = format!("{prefix}{}{repo_id}", constants::FLAT_SEPARATOR);
+    flatten_separator(&prefixed_repo_id)
+}
+
+/// Returns the path to the snapshots directory for a given repo root
+pub fn snapshots_dir(repo_path: &Path) -> PathBuf {
+    repo_path.join(constants::SNAPSHOTS_DIR)
+}
+
+/// Returns the path to the refs directory
+pub fn refs_dir(repo_path: &Path) -> PathBuf {
+    repo_path.join(constants::REFS_DIR)
+}
+
+/// Returns the path to the blobs directory
+pub fn blobs_dir(repo_path: &Path) -> PathBuf {
+    repo_path.join(constants::BLOBS_DIR)
+}
+
+/// Returns the location of the token file
+///
+/// # Panics
+///
+/// Panics if the provided dir doesn't have a parent
+pub fn token_path(hub_path: &Path) -> PathBuf {
+    hub_path
+        .parent()
+        .expect("hub path should have a parent directory")
+        .join(constants::TOKEN_FILE)
+}
+
+/// Returns the path to a specific ref
+pub fn get_ref_path(repo_path: &Path, repo_ref: &str) -> PathBuf {
+    refs_dir(repo_path).join(repo_ref)
+}


### PR DESCRIPTION
## Motivation
This is a prerequisite for https://github.com/huggingface/hf-hub/pull/142 (cache manager feat) but may also be useful for other downstream projects, like mistral.rs: https://github.com/EricLBuehler/mistral.rs/blob/2ed55750e24cc4cf0dfde2d4a2ad7352ed819d29/mistralrs-core/src/pipeline/hf.rs

## Summary
- Move hardcoded strings into constants mod
- Add path mod for FS path construction utils
- Implement display / str traits for RepoType
- Use path utils mod for path construction in lib