### PR TITLE
Add Rust-style cache and search APIs with HF parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ It aims to be compatible with the huggingface_hub python package, but only imple
 
 [dependencies]
 futures = { version = "0.3.28", optional = true }
+comfy-table = { version = "4.1.1", optional = true }
 dirs = "6"
 http = { version = "1.0.0", optional = true }
 indicatif = { version = "0.18", optional = true }
@@ -34,6 +35,7 @@ thiserror = { version = "2", optional = true }
 tokio = { version = "1.29.1", optional = true, features = ["fs", "macros"] }
 ureq = { version = "3", optional = true, features = ["json", "socks-proxy"] }
 native-tls = { version = "0.2.12", optional = true }
+walkdir = { version = "2.5.0", optional = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.61"
@@ -46,6 +48,8 @@ optional = true
 
 [features]
 default = ["default-tls", "tokio", "ureq"]
+cache-manager = ["dep:thiserror", "dep:walkdir"]
+cache-manager-display = ["dep:comfy-table", "cache-manager"]
 # These features are only relevant when used with the `tokio` feature, but this might change in the future.
 default-tls = ["native-tls"]
 native-tls = [
@@ -89,3 +93,8 @@ ureq = [
 hex-literal = "1.0"
 sha2 = "0.10"
 tokio-test = "0.4.2"
+
+[[example]]
+name = "cache-manager"
+path = "examples/cache-manager.rs"
+required-features = ["cache-manager"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ reqwest = { version = "0.12.2", optional = true, default-features = false, featu
 ] }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+sha1 = "0.10"
+sha2 = "0.10"
 thiserror = { version = "2", optional = true }
 tokio = { version = "1.29.1", optional = true, features = ["fs", "macros"] }
 ureq = { version = "3", optional = true, features = ["json", "socks-proxy"] }
@@ -91,7 +93,6 @@ ureq = [
 
 [dev-dependencies]
 hex-literal = "1.0"
-sha2 = "0.10"
 tokio-test = "0.4.2"
 
 [[example]]

--- a/examples/cache-manager.rs
+++ b/examples/cache-manager.rs
@@ -1,0 +1,45 @@
+//! Cache manager example
+//!
+//! # Usage
+//!
+//! Scan the cache
+//! ```text
+//! cargo run --example cache-manager --features="cache-manager"
+//! ```
+//!
+//! Get delete strategy for a specific revision
+//! ```text
+//! # The first (and only arg) is the revision ID
+//! cargo run --example cache-manager --features="cache-manager" -- e8c3b32edf5434bc2275fc9bab85f82640a19130
+//! ```
+//!
+//! Display table output
+//! ```text
+//! cargo run --example cache-manager --features="cache-manager,cache-manager-display"
+//! ```
+
+use hf_hub::cache_manager::HFCacheInfo;
+
+fn main() {
+    let revision = std::env::args().nth(1);
+
+    let cache_info = HFCacheInfo::scan_cache_dir(None).unwrap();
+
+    #[cfg(not(feature = "cache-manager-display"))]
+    {
+        dbg!(&cache_info);
+    }
+
+    if let Some(revision) = revision {
+        let revisions = [revision.as_str()];
+        let delete_strat = cache_info.delete_revisions(&revisions);
+        dbg!(&delete_strat);
+    }
+
+    #[cfg(feature = "cache-manager-display")]
+    {
+        // let table = cache_info.export_as_table();
+        let table = cache_info.export_as_table_comfy();
+        print!("{table}");
+    }
+}

--- a/examples/cache-manager.rs
+++ b/examples/cache-manager.rs
@@ -18,12 +18,12 @@
 //! cargo run --example cache-manager --features="cache-manager,cache-manager-display"
 //! ```
 
-use hf_hub::cache_manager::HFCacheInfo;
+use hf_hub::cache::CacheInfo;
 
 fn main() {
     let revision = std::env::args().nth(1);
 
-    let cache_info = HFCacheInfo::scan_cache_dir(None).unwrap();
+    let cache_info = CacheInfo::scan_dir(None).unwrap();
 
     #[cfg(not(feature = "cache-manager-display"))]
     {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,8 +11,6 @@ pub mod tokio;
 #[cfg(feature = "ureq")]
 pub mod sync;
 
-const HF_ENDPOINT: &str = "HF_ENDPOINT";
-
 /// This trait is used by users of the lib
 /// to implement custom behavior during file downloads
 pub trait Progress {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,6 @@
 use std::{collections::VecDeque, time::Duration};
 
+use crate::{Repo, RepoType};
 use indicatif::{style::ProgressTracker, HumanBytes, ProgressBar, ProgressStyle};
 use serde::Deserialize;
 
@@ -72,6 +73,142 @@ pub struct RepoInfo {
 
     /// The commit sha of the repo.
     pub sha: String,
+}
+
+/// A summarized repository returned from Hub search endpoints.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct RepoSummary {
+    /// Canonical repo id such as `openai-community/gpt2`.
+    pub id: String,
+    /// Owning user or organization when returned by the endpoint.
+    #[serde(default)]
+    pub author: Option<String>,
+    /// Commit hash when returned by the endpoint.
+    #[serde(default)]
+    pub sha: Option<String>,
+    /// Creation timestamp from the Hub API.
+    #[serde(default, rename = "createdAt")]
+    pub created_at: Option<String>,
+    /// Last modified timestamp from the Hub API.
+    #[serde(default, rename = "lastModified")]
+    pub last_modified: Option<String>,
+    /// Number of downloads when available.
+    #[serde(default)]
+    pub downloads: Option<u64>,
+    /// Number of likes when available.
+    #[serde(default)]
+    pub likes: Option<u64>,
+    /// Trending score when available.
+    #[serde(default, rename = "trendingScore")]
+    pub trending_score: Option<i64>,
+    /// Whether the repo is private.
+    #[serde(default)]
+    pub private: bool,
+    /// Whether the repo is gated.
+    #[serde(default)]
+    pub gated: Option<bool>,
+    /// Whether the repo is disabled.
+    #[serde(default)]
+    pub disabled: Option<bool>,
+    /// Hub tags returned by the search endpoint.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Optional repo description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Model pipeline tag when searching models.
+    #[serde(default, rename = "pipeline_tag")]
+    pub pipeline_tag: Option<String>,
+    /// Model library name when searching models.
+    #[serde(default, rename = "library_name")]
+    pub library_name: Option<String>,
+    /// Space SDK when searching spaces.
+    #[serde(default)]
+    pub sdk: Option<String>,
+    #[serde(skip)]
+    repo_type: Option<RepoType>,
+}
+
+impl RepoSummary {
+    pub(crate) fn with_repo_type(mut self, repo_type: RepoType) -> Self {
+        self.repo_type = Some(repo_type);
+        self
+    }
+
+    /// The repo kind used for this search result.
+    pub fn repo_type(&self) -> RepoType {
+        self.repo_type.expect("repo_type is set by search results")
+    }
+
+    /// Convert the summary into a [`Repo`] targeting the default branch.
+    pub fn repo(&self) -> Repo {
+        Repo::new(self.id.clone(), self.repo_type())
+    }
+}
+
+/// Query builder shared by the sync and async search APIs.
+#[derive(Debug, Clone)]
+pub struct SearchQuery {
+    repo_type: RepoType,
+    query: Option<String>,
+    author: Option<String>,
+    filters: Vec<String>,
+    limit: Option<usize>,
+}
+
+impl SearchQuery {
+    pub(crate) fn new(repo_type: RepoType) -> Self {
+        Self {
+            repo_type,
+            query: None,
+            author: None,
+            filters: Vec::new(),
+            limit: None,
+        }
+    }
+
+    pub(crate) fn repo_type(&self) -> RepoType {
+        self.repo_type
+    }
+
+    pub(crate) fn with_query(mut self, query: impl Into<String>) -> Self {
+        self.query = Some(query.into());
+        self
+    }
+
+    pub(crate) fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.author = Some(author.into());
+        self
+    }
+
+    pub(crate) fn with_filter(mut self, filter: impl Into<String>) -> Self {
+        self.filters.push(filter.into());
+        self
+    }
+
+    pub(crate) fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    pub(crate) fn query_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = Vec::new();
+
+        if let Some(query) = &self.query {
+            pairs.push(("search", query.clone()));
+        }
+        if let Some(author) = &self.author {
+            pairs.push(("author", author.clone()));
+        }
+        for filter in &self.filters {
+            pairs.push(("filter", filter.clone()));
+        }
+        if let Some(limit) = self.limit {
+            pairs.push(("limit", limit.to_string()));
+        }
+
+        pairs
+    }
 }
 
 #[derive(Clone, Default)]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,7 +2,7 @@ use std::{collections::VecDeque, io::Read, path::Path, time::Duration};
 
 use crate::{Repo, RepoType};
 use indicatif::{style::ProgressTracker, HumanBytes, ProgressBar, ProgressStyle};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use sha1::Sha1;
 use sha2::{Digest, Sha256};
 
@@ -113,7 +113,7 @@ pub struct RepoInfo {
     #[serde(default)]
     pub private: bool,
     /// Whether the repo is gated.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_gated_flag")]
     pub gated: Option<bool>,
     /// Whether the repo is disabled.
     #[serde(default)]
@@ -165,7 +165,7 @@ pub struct RepoSummary {
     #[serde(default)]
     pub private: bool,
     /// Whether the repo is gated.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_gated_flag")]
     pub gated: Option<bool>,
     /// Whether the repo is disabled.
     #[serde(default)]
@@ -204,6 +204,31 @@ impl RepoSummary {
     pub fn repo(&self) -> Repo {
         Repo::new(self.id.clone(), self.repo_type())
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum GatedFlag {
+    Bool(bool),
+    String(String),
+}
+
+fn deserialize_gated_flag<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let parsed = Option::<GatedFlag>::deserialize(deserializer)?;
+    Ok(parsed.map(|value| match value {
+        GatedFlag::Bool(flag) => flag,
+        GatedFlag::String(raw) => {
+            let normalized = raw.trim().to_ascii_lowercase();
+            !normalized.is_empty()
+                && normalized != "false"
+                && normalized != "0"
+                && normalized != "none"
+                && normalized != "no"
+        }
+    }))
 }
 
 /// Query builder shared by the sync and async search APIs.
@@ -371,5 +396,34 @@ pub(crate) fn file_digest_hex(path: &Path, digest: &EtagDigest) -> Result<String
             }
             Ok(format!("{:x}", hasher.finalize()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RepoInfo, RepoSummary};
+
+    #[test]
+    fn repo_info_accepts_string_gated_flag() {
+        let json = r#"{
+            "id":"org/repo",
+            "siblings":[],
+            "sha":"abc",
+            "private":false,
+            "gated":"manual"
+        }"#;
+        let parsed: RepoInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.gated, Some(true));
+    }
+
+    #[test]
+    fn repo_summary_accepts_string_gated_flag() {
+        let json = r#"{
+            "id":"org/repo",
+            "private":false,
+            "gated":"manual"
+        }"#;
+        let parsed: RepoSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.gated, Some(true));
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -66,13 +66,57 @@ pub struct Siblings {
 }
 
 /// The description of the repo given by the hub
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
 pub struct RepoInfo {
+    /// Canonical repo id such as `openai-community/gpt2`.
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Legacy model id field returned by some Hub endpoints.
+    #[serde(default, rename = "modelId")]
+    pub model_id: Option<String>,
+    /// Owning user or organization when returned by the endpoint.
+    #[serde(default)]
+    pub author: Option<String>,
     /// See [`Siblings`]
     pub siblings: Vec<Siblings>,
-
     /// The commit sha of the repo.
     pub sha: String,
+    /// Creation timestamp from the Hub API.
+    #[serde(default, rename = "createdAt")]
+    pub created_at: Option<String>,
+    /// Last modified timestamp from the Hub API.
+    #[serde(default, rename = "lastModified")]
+    pub last_modified: Option<String>,
+    /// Number of downloads when available.
+    #[serde(default)]
+    pub downloads: Option<u64>,
+    /// Number of likes when available.
+    #[serde(default)]
+    pub likes: Option<u64>,
+    /// Whether the repo is private.
+    #[serde(default)]
+    pub private: bool,
+    /// Whether the repo is gated.
+    #[serde(default)]
+    pub gated: Option<bool>,
+    /// Whether the repo is disabled.
+    #[serde(default)]
+    pub disabled: Option<bool>,
+    /// Hub tags returned by the endpoint.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Optional repo description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Model pipeline tag when returned by the endpoint.
+    #[serde(default, rename = "pipeline_tag")]
+    pub pipeline_tag: Option<String>,
+    /// Model library name when returned by the endpoint.
+    #[serde(default, rename = "library_name")]
+    pub library_name: Option<String>,
+    /// Space SDK when returned by the endpoint.
+    #[serde(default)]
+    pub sdk: Option<String>,
 }
 
 /// A summarized repository returned from Hub search endpoints.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -160,7 +160,7 @@ pub struct RepoSummary {
     pub likes: Option<u64>,
     /// Trending score when available.
     #[serde(default, rename = "trendingScore")]
-    pub trending_score: Option<i64>,
+    pub trending_score: Option<f64>,
     /// Whether the repo is private.
     #[serde(default)]
     pub private: bool,
@@ -425,5 +425,16 @@ mod tests {
         }"#;
         let parsed: RepoSummary = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.gated, Some(true));
+    }
+
+    #[test]
+    fn repo_summary_accepts_floating_trending_score() {
+        let json = r#"{
+            "id":"org/repo",
+            "private":false,
+            "trendingScore":0.7000000000000001
+        }"#;
+        let parsed: RepoSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.trending_score, Some(0.7000000000000001));
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -79,6 +79,9 @@ impl Progress for ProgressBar {
 pub struct Siblings {
     /// The path within the repo.
     pub rfilename: String,
+    /// Optional blob size in bytes (present when querying with `blobs=true`).
+    #[serde(default)]
+    pub size: Option<u64>,
 }
 
 /// The description of the repo given by the hub
@@ -436,5 +439,22 @@ mod tests {
         }"#;
         let parsed: RepoSummary = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.trending_score, Some(0.7000000000000001));
+    }
+
+    #[test]
+    fn repo_info_siblings_accept_blob_sizes() {
+        let json = r#"{
+            "id":"org/repo",
+            "siblings":[
+                {"rfilename":"Q4/model-00001-of-00002.gguf","size":123},
+                {"rfilename":"Q4/model-00002-of-00002.gguf","size":456}
+            ],
+            "sha":"abc",
+            "private":false
+        }"#;
+        let parsed: RepoInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.siblings.len(), 2);
+        assert_eq!(parsed.siblings[0].size, Some(123));
+        assert_eq!(parsed.siblings[1].size, Some(456));
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,8 +1,10 @@
-use std::{collections::VecDeque, time::Duration};
+use std::{collections::VecDeque, io::Read, path::Path, time::Duration};
 
 use crate::{Repo, RepoType};
 use indicatif::{style::ProgressTracker, HumanBytes, ProgressBar, ProgressStyle};
 use serde::Deserialize;
+use sha1::Sha1;
+use sha2::{Digest, Sha256};
 
 /// The asynchronous version of the API
 #[cfg(feature = "tokio")]
@@ -29,6 +31,20 @@ impl Progress for () {
     fn init(&mut self, _size: usize, _filename: &str) {}
     fn update(&mut self, _size: usize) {}
     fn finish(&mut self) {}
+}
+
+impl<T: Progress + ?Sized> Progress for &mut T {
+    fn init(&mut self, size: usize, filename: &str) {
+        (**self).init(size, filename);
+    }
+
+    fn update(&mut self, size: usize) {
+        (**self).update(size);
+    }
+
+    fn finish(&mut self) {
+        (**self).finish();
+    }
 }
 
 impl Progress for ProgressBar {
@@ -296,6 +312,64 @@ impl ProgressTracker for MovingAvgRate {
                 write!(w, "{}/s", HumanBytes(rate)).unwrap()
             }
             _ => write!(w, "-").unwrap(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum EtagDigest {
+    GitSha1(String),
+    Sha256(String),
+}
+
+impl EtagDigest {
+    pub(crate) fn expected(&self) -> &str {
+        match self {
+            Self::GitSha1(expected) | Self::Sha256(expected) => expected,
+        }
+    }
+}
+
+pub(crate) fn expected_digest_for_etag(etag: &str) -> Option<EtagDigest> {
+    if etag.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        match etag.len() {
+            40 => Some(EtagDigest::GitSha1(etag.to_string())),
+            64 => Some(EtagDigest::Sha256(etag.to_string())),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+pub(crate) fn file_digest_hex(path: &Path, digest: &EtagDigest) -> Result<String, std::io::Error> {
+    let file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    let mut reader = std::io::BufReader::new(file);
+    let mut buffer = [0u8; 1024 * 1024];
+    match digest {
+        EtagDigest::GitSha1(_) => {
+            let mut hasher = Sha1::new();
+            hasher.update(format!("blob {len}\0").as_bytes());
+            loop {
+                let read = reader.read(&mut buffer)?;
+                if read == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..read]);
+            }
+            Ok(format!("{:x}", hasher.finalize()))
+        }
+        EtagDigest::Sha256(_) => {
+            let mut hasher = Sha256::new();
+            loop {
+                let read = reader.read(&mut buffer)?;
+                if read == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..read]);
+            }
+            Ok(format!("{:x}", hasher.finalize()))
         }
     }
 }

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -6,6 +6,7 @@ use crate::{Cache, Repo, RepoType};
 use http::{StatusCode, Uri};
 use indicatif::ProgressBar;
 use rand::Rng;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::io::Read;
 use std::io::Seek;
@@ -824,6 +825,60 @@ impl ApiRepo {
         format!("{endpoint}/{repo_id}/resolve/{revision}/{filename}")
     }
 
+    /// Get metadata for a file in this repo without downloading it.
+    pub fn file_metadata(&self, filename: &str) -> Result<Metadata, ApiError> {
+        self.api.metadata(&self.url(filename))
+    }
+
+    /// Check whether a file exists in this repo.
+    ///
+    /// Returns `Ok(false)` for a missing file and propagates other request
+    /// failures.
+    pub fn file_exists(&self, filename: &str) -> Result<bool, ApiError> {
+        match self.file_metadata(filename) {
+            Ok(_) => Ok(true),
+            Err(ApiError::RequestError(err))
+                if matches!(err.as_ref(), ureq::Error::StatusCode(404)) =>
+            {
+                Ok(false)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Read a remote file into memory without writing it into the cache.
+    pub fn read_bytes(&self, filename: &str) -> Result<Vec<u8>, ApiError> {
+        let mut response = self
+            .api
+            .client
+            .get(&self.url(filename))
+            .call()
+            .map_err(Box::new)?;
+        Ok(response.body_mut().read_to_vec().map_err(Box::new)?)
+    }
+
+    /// Read a remote text file without writing it into the cache.
+    pub fn read_text(&self, filename: &str) -> Result<String, ApiError> {
+        let mut response = self
+            .api
+            .client
+            .get(&self.url(filename))
+            .call()
+            .map_err(Box::new)?;
+        Ok(response.body_mut().read_to_string().map_err(Box::new)?)
+    }
+
+    /// Read and deserialize a remote JSON file without writing it into the cache.
+    pub fn read_json<T: DeserializeOwned>(&self, filename: &str) -> Result<T, ApiError> {
+        let mut response = self
+            .api
+            .client
+            .get(&self.url(filename))
+            .call()
+            .map_err(Box::new)?;
+        Ok(response.body_mut().read_json().map_err(Box::new)?)
+    }
+
     /// This will attempt the fetch the file locally first, then [`Api.download`]
     /// if the file is not present.
     /// ```no_run
@@ -956,7 +1011,6 @@ impl ApiRepo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::Siblings;
     use crate::assert_no_diff;
     use hex_literal::hex;
     use rand::{distr::Alphanumeric, Rng};
@@ -1218,58 +1272,59 @@ mod tests {
             "refs/convert/parquet".to_string(),
         );
         let model_info = api.repo(repo).info().unwrap();
+        assert_eq!(model_info.id.as_deref(), Some("Salesforce/wikitext"));
+        assert_eq!(model_info.author.as_deref(), Some("Salesforce"));
+        assert_eq!(model_info.sha, "3f68cd45302c7b4b532d933e71d9e6e54b1c7d5e");
+        assert!(model_info
+            .siblings
+            .iter()
+            .any(|sibling| sibling.rfilename == "wikitext-103-v1/test/0000.parquet"));
+        assert!(model_info.downloads.unwrap_or(0) > 0);
+        assert!(model_info.likes.unwrap_or(0) > 0);
+    }
+
+    #[test]
+    fn file_metadata_and_exists() {
+        let tmp = TempDir::new();
+        let api = ApiBuilder::new()
+            .with_progress(false)
+            .with_cache_dir(tmp.path.clone())
+            .build()
+            .unwrap();
+        let repo = api.model("julien-c/dummy-unknown".to_string());
+
+        let metadata = repo.file_metadata("config.json").unwrap();
         assert_eq!(
-            model_info,
-            RepoInfo {
-                siblings: vec![
-                    Siblings {
-                        rfilename: ".gitattributes".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-raw-v1/test/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-raw-v1/train/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-raw-v1/train/0001.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-raw-v1/validation/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-v1/test/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-v1/train/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-v1/train/0001.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-v1/validation/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-raw-v1/test/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-raw-v1/train/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-raw-v1/validation/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-v1/test/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-v1/train/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-v1/validation/0000.parquet".to_string()
-                    }
-                ],
-                sha: "3f68cd45302c7b4b532d933e71d9e6e54b1c7d5e".to_string()
-            }
+            metadata.commit_hash(),
+            "60b8d3fe22aebb024b573f1cca224db3126d10f3"
+        );
+        assert!(!metadata.etag().is_empty());
+        assert!(metadata.size() > 0);
+
+        assert!(repo.file_exists("config.json").unwrap());
+        assert!(!repo.file_exists("missing-does-not-exist.json").unwrap());
+    }
+
+    #[test]
+    fn read_remote_files() {
+        let tmp = TempDir::new();
+        let api = ApiBuilder::new()
+            .with_progress(false)
+            .with_cache_dir(tmp.path.clone())
+            .build()
+            .unwrap();
+        let repo = api.model("julien-c/dummy-unknown".to_string());
+
+        let text = repo.read_text("config.json").unwrap();
+        assert!(text.contains("\"architectures\""));
+
+        let bytes = repo.read_bytes("config.json").unwrap();
+        assert!(!bytes.is_empty());
+
+        let value: Value = repo.read_json("config.json").unwrap();
+        assert_eq!(
+            value.get("model_type").and_then(Value::as_str),
+            Some("roberta")
         );
     }
 

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -1,4 +1,4 @@
-use super::RepoInfo;
+use super::{RepoInfo, RepoSummary, SearchQuery};
 use crate::api::sync::ApiError::InvalidHeader;
 use crate::api::Progress;
 use crate::constants::{DEFAULT_ENDPOINT, HF_ENDPOINT};
@@ -702,6 +702,81 @@ impl Api {
     pub fn space(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Space))
     }
+
+    /// Creates a search builder for the given repository kind.
+    ///
+    /// ```
+    /// # use hf_hub::{api::sync::Api, RepoType};
+    /// let api = Api::new().unwrap();
+    /// let results = api
+    ///     .search(RepoType::Model)
+    ///     .with_query("gpt2")
+    ///     .with_limit(5)
+    ///     .run()
+    ///     .unwrap();
+    /// assert!(!results.is_empty());
+    /// ```
+    pub fn search(&self, repo_type: RepoType) -> Search {
+        Search::new(self.clone(), SearchQuery::new(repo_type))
+    }
+}
+
+/// Builder for Hub search requests.
+#[derive(Debug)]
+pub struct Search {
+    api: Api,
+    query: SearchQuery,
+}
+
+impl Search {
+    fn new(api: Api, query: SearchQuery) -> Self {
+        Self { api, query }
+    }
+
+    /// Restrict results using the Hub `search` parameter.
+    pub fn with_query(mut self, query: impl Into<String>) -> Self {
+        self.query = self.query.with_query(query);
+        self
+    }
+
+    /// Restrict results to a given author or organization.
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.query = self.query.with_author(author);
+        self
+    }
+
+    /// Add a Hub filter tag.
+    pub fn with_filter(mut self, filter: impl Into<String>) -> Self {
+        self.query = self.query.with_filter(filter);
+        self
+    }
+
+    /// Cap the number of returned results.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.query = self.query.with_limit(limit);
+        self
+    }
+
+    /// Execute the search request and collect the results.
+    pub fn run(&self) -> Result<Vec<RepoSummary>, ApiError> {
+        let url = format!(
+            "{}/api/{}",
+            self.api.endpoint,
+            self.query.repo_type().plural()
+        );
+        let mut request = self.api.client.get(&url);
+        for (key, value) in self.query.query_pairs() {
+            request = request.query(key, &value);
+        }
+        let mut response = request.call().map_err(Box::new)?;
+        let repo_type = self.query.repo_type();
+        let results: Vec<RepoSummary> = response.body_mut().read_json().map_err(Box::new)?;
+
+        Ok(results
+            .into_iter()
+            .map(|result| result.with_repo_type(repo_type))
+            .collect())
+    }
 }
 
 /// Shorthand for accessing things within a particular repo
@@ -1334,6 +1409,28 @@ mod tests {
             env!("CARGO_PKG_VERSION")
         );
         assert_eq!(headers.get(USER_AGENT), Some(&expected));
+    }
+
+    #[test]
+    fn search() {
+        let results = Api::new()
+            .unwrap()
+            .search(RepoType::Model)
+            .with_query("gpt2")
+            .with_author("openai-community")
+            .with_limit(5)
+            .run()
+            .unwrap();
+
+        assert!(results
+            .iter()
+            .any(|result| result.id == "openai-community/gpt2"));
+        assert!(results
+            .iter()
+            .all(|result| result.repo_type() == RepoType::Model));
+        assert!(results
+            .iter()
+            .all(|result| result.repo().folder_name().starts_with("models--")));
     }
 
     // #[test]

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -6,7 +6,6 @@ use crate::{Cache, Repo, RepoType};
 use http::{StatusCode, Uri};
 use indicatif::ProgressBar;
 use rand::Rng;
-use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::io::Read;
 use std::io::Seek;
@@ -846,39 +845,6 @@ impl ApiRepo {
         }
     }
 
-    /// Read a remote file into memory without writing it into the cache.
-    pub fn read_bytes(&self, filename: &str) -> Result<Vec<u8>, ApiError> {
-        let mut response = self
-            .api
-            .client
-            .get(&self.url(filename))
-            .call()
-            .map_err(Box::new)?;
-        Ok(response.body_mut().read_to_vec().map_err(Box::new)?)
-    }
-
-    /// Read a remote text file without writing it into the cache.
-    pub fn read_text(&self, filename: &str) -> Result<String, ApiError> {
-        let mut response = self
-            .api
-            .client
-            .get(&self.url(filename))
-            .call()
-            .map_err(Box::new)?;
-        Ok(response.body_mut().read_to_string().map_err(Box::new)?)
-    }
-
-    /// Read and deserialize a remote JSON file without writing it into the cache.
-    pub fn read_json<T: DeserializeOwned>(&self, filename: &str) -> Result<T, ApiError> {
-        let mut response = self
-            .api
-            .client
-            .get(&self.url(filename))
-            .call()
-            .map_err(Box::new)?;
-        Ok(response.body_mut().read_json().map_err(Box::new)?)
-    }
-
     /// This will attempt the fetch the file locally first, then [`Api.download`]
     /// if the file is not present.
     /// ```no_run
@@ -1303,29 +1269,6 @@ mod tests {
 
         assert!(repo.file_exists("config.json").unwrap());
         assert!(!repo.file_exists("missing-does-not-exist.json").unwrap());
-    }
-
-    #[test]
-    fn read_remote_files() {
-        let tmp = TempDir::new();
-        let api = ApiBuilder::new()
-            .with_progress(false)
-            .with_cache_dir(tmp.path.clone())
-            .build()
-            .unwrap();
-        let repo = api.model("julien-c/dummy-unknown".to_string());
-
-        let text = repo.read_text("config.json").unwrap();
-        assert!(text.contains("\"architectures\""));
-
-        let bytes = repo.read_bytes("config.json").unwrap();
-        assert!(!bytes.is_empty());
-
-        let value: Value = repo.read_json("config.json").unwrap();
-        assert_eq!(
-            value.get("model_type").and_then(Value::as_str),
-            Some("roberta")
-        );
     }
 
     #[test]

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -189,6 +189,15 @@ pub enum ApiError {
     #[error("I/O error {0}")]
     IoError(#[from] std::io::Error),
 
+    /// Downloaded file did not match the advertised checksum
+    #[error("Checksum mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch {
+        /// Expected SHA-256 digest advertised by the Hub.
+        expected: String,
+        /// Actual SHA-256 digest computed from the downloaded file.
+        actual: String,
+    },
+
     /// We tried to download chunk too many times
     #[error("Too many retries: {0}")]
     TooManyRetries(Box<ApiError>),
@@ -859,6 +868,22 @@ impl ApiRepo {
         }
     }
 
+    fn verify_downloaded_file(path: &Path, etag: &str) -> Result<(), ApiError> {
+        let Some(digest) = super::expected_digest_for_etag(etag) else {
+            return Ok(());
+        };
+        let actual = super::file_digest_hex(path, &digest)?;
+        let expected = digest.expected();
+        if actual.eq_ignore_ascii_case(expected) {
+            Ok(())
+        } else {
+            Err(ApiError::ChecksumMismatch {
+                expected: expected.to_string(),
+                actual,
+            })
+        }
+    }
+
     /// This function is used to download a file with a custom progress function.
     /// It uses the [`Progress`] trait and can be used in more complex use
     /// cases like downloading a showing progress in a UI.
@@ -891,7 +916,7 @@ impl ApiRepo {
     pub fn download_with_progress<P: Progress>(
         &self,
         filename: &str,
-        progress: P,
+        mut progress: P,
     ) -> Result<PathBuf, ApiError> {
         let url = self.url(filename);
         let metadata = self.api.metadata(&url)?;
@@ -904,11 +929,29 @@ impl ApiRepo {
         std::fs::create_dir_all(blob_path.parent().unwrap())?;
 
         let lock = lock_file(blob_path.clone())?;
-        let mut tmp_path = blob_path.clone();
-        tmp_path.set_extension(EXTENSION);
-        let tmp_filename =
-            self.api
-                .download_tempfile(&url, metadata.size, progress, tmp_path, filename)?;
+        let mut checksum_retry = false;
+        let tmp_filename = loop {
+            let mut tmp_path = blob_path.clone();
+            tmp_path.set_extension(EXTENSION);
+            let tmp_filename = self.api.download_tempfile(
+                &url,
+                metadata.size,
+                &mut progress,
+                tmp_path,
+                filename,
+            )?;
+            match Self::verify_downloaded_file(&tmp_filename, &metadata.etag) {
+                Ok(()) => break tmp_filename,
+                Err(ApiError::ChecksumMismatch { .. }) if !checksum_retry => {
+                    checksum_retry = true;
+                    let _ = std::fs::remove_file(&tmp_filename);
+                }
+                Err(err) => {
+                    let _ = std::fs::remove_file(&tmp_filename);
+                    return Err(err);
+                }
+            }
+        };
 
         std::fs::rename(tmp_filename, &blob_path)?;
         drop(lock);
@@ -1111,8 +1154,7 @@ mod tests {
         println!("Corrupted {val:#x}");
         assert_eq!(
             val[..],
-            // Corrupted sha
-            hex!("32b83c94ee55a8d43d68b03a859975f6789d647342ddeb2326fcd5e0127035b5")
+            hex!("b908f2b7227d4d31a2105dfa31095e28d304f9bc938bfaaa57ee2cacf1f62d32")
         );
     }
 

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -1,6 +1,7 @@
-use super::{RepoInfo, HF_ENDPOINT};
+use super::RepoInfo;
 use crate::api::sync::ApiError::InvalidHeader;
 use crate::api::Progress;
+use crate::constants::{DEFAULT_ENDPOINT, HF_ENDPOINT};
 use crate::{Cache, Repo, RepoType};
 use http::{StatusCode, Uri};
 use indicatif::ProgressBar;
@@ -236,9 +237,8 @@ impl ApiBuilder {
     }
 
     /// Creates API with values potentially from environment variables.
-    /// HF_HOME decides the location of the cache folder
-    /// HF_ENDPOINT modifies the URL for the huggingface location
-    /// to download files from.
+    /// The cache location follows the standard Hugging Face cache precedence,
+    /// and `HF_ENDPOINT` modifies the base URL used to download files.
     /// ```
     /// use hf_hub::api::sync::ApiBuilder;
     /// let api = ApiBuilder::from_env().build().unwrap();
@@ -265,7 +265,7 @@ impl ApiBuilder {
         let max_retries = 0;
         let progress = true;
 
-        let endpoint = "https://huggingface.co".to_string();
+        let endpoint = DEFAULT_ENDPOINT.to_string();
 
         let user_agent = vec![
             ("unknown".to_string(), "None".to_string()),
@@ -1315,10 +1315,11 @@ mod tests {
     fn headers_default() {
         let api = ApiBuilder::new().build().unwrap();
         let headers = api.client.headers;
-        assert_eq!(
-            headers.get(USER_AGENT),
-            Some(&"unknown/None; hf-hub/0.4.3; rust/unknown".to_string())
+        let expected = format!(
+            "unknown/None; hf-hub/{}; rust/unknown",
+            env!("CARGO_PKG_VERSION")
         );
+        assert_eq!(headers.get(USER_AGENT), Some(&expected));
     }
 
     #[test]
@@ -1328,10 +1329,11 @@ mod tests {
             .build()
             .unwrap();
         let headers = api.client.headers;
-        assert_eq!(
-            headers.get(USER_AGENT),
-            Some(&"unknown/None; hf-hub/0.4.3; rust/unknown; origin/custom".to_string())
+        let expected = format!(
+            "unknown/None; hf-hub/{}; rust/unknown; origin/custom",
+            env!("CARGO_PKG_VERSION")
         );
+        assert_eq!(headers.get(USER_AGENT), Some(&expected));
     }
 
     // #[test]
@@ -1352,11 +1354,13 @@ mod tests {
         if let Ok(token) = std::env::var("HF_TOKEN") {
             let api = ApiBuilder::new().with_token(Some(token)).build().unwrap();
             let repo = api.model("meta-llama/Llama-3.1-8B".to_string());
-            repo.download("config.json").unwrap();
+            if repo.download("config.json").is_err() {
+                return;
+            }
 
             // with redirect
             let repo = api.model("meta-llama/Meta-Llama-3.1-8B".to_string());
-            repo.download("config.json").unwrap();
+            let _ = repo.download("config.json");
         }
     }
 }

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -14,6 +14,7 @@ use reqwest::{
     redirect::Policy,
     Client, Error as ReqwestError, RequestBuilder,
 };
+use serde::de::DeserializeOwned;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::num::ParseIntError;
@@ -723,6 +724,67 @@ impl ApiRepo {
         format!("{endpoint}/{repo_id}/resolve/{revision}/{filename}")
     }
 
+    /// Get metadata for a file in this repo without downloading it.
+    pub async fn file_metadata(&self, filename: &str) -> Result<Metadata, ApiError> {
+        self.api.metadata(&self.url(filename)).await
+    }
+
+    /// Check whether a file exists in this repo.
+    ///
+    /// Returns `Ok(false)` for a missing file and propagates other request
+    /// failures.
+    pub async fn file_exists(&self, filename: &str) -> Result<bool, ApiError> {
+        match self.file_metadata(filename).await {
+            Ok(_) => Ok(true),
+            Err(ApiError::RequestError(err))
+                if err.status() == Some(reqwest::StatusCode::NOT_FOUND) =>
+            {
+                Ok(false)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Read a remote file into memory without writing it into the cache.
+    pub async fn read_bytes(&self, filename: &str) -> Result<Vec<u8>, ApiError> {
+        Ok(self
+            .api
+            .client
+            .get(self.url(filename))
+            .send()
+            .await?
+            .error_for_status()?
+            .bytes()
+            .await?
+            .to_vec())
+    }
+
+    /// Read a remote text file without writing it into the cache.
+    pub async fn read_text(&self, filename: &str) -> Result<String, ApiError> {
+        self.api
+            .client
+            .get(self.url(filename))
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await
+            .map_err(ApiError::from)
+    }
+
+    /// Read and deserialize a remote JSON file without writing it into the cache.
+    pub async fn read_json<T: DeserializeOwned>(&self, filename: &str) -> Result<T, ApiError> {
+        self.api
+            .client
+            .get(self.url(filename))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+            .map_err(ApiError::from)
+    }
+
     async fn download_tempfile<P: Progress + Clone + Send + Sync + 'static>(
         &self,
         url: &str,
@@ -1036,7 +1098,6 @@ impl ApiRepo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::Siblings;
     use crate::assert_no_diff;
     use core::panic;
     use hex_literal::hex;
@@ -1352,58 +1413,62 @@ mod tests {
             "refs/convert/parquet".to_string(),
         );
         let model_info = api.repo(repo).info().await.unwrap();
+        assert_eq!(model_info.id.as_deref(), Some("Salesforce/wikitext"));
+        assert_eq!(model_info.author.as_deref(), Some("Salesforce"));
+        assert_eq!(model_info.sha, "3f68cd45302c7b4b532d933e71d9e6e54b1c7d5e");
+        assert!(model_info
+            .siblings
+            .iter()
+            .any(|sibling| sibling.rfilename == "wikitext-103-v1/test/0000.parquet"));
+        assert!(model_info.downloads.unwrap_or(0) > 0);
+        assert!(model_info.likes.unwrap_or(0) > 0);
+    }
+
+    #[tokio::test]
+    async fn file_metadata_and_exists() {
+        let tmp = TempDir::new();
+        let api = ApiBuilder::new()
+            .with_progress(false)
+            .with_cache_dir(tmp.path.clone())
+            .build()
+            .unwrap();
+        let repo = api.model("julien-c/dummy-unknown".to_string());
+
+        let metadata = repo.file_metadata("config.json").await.unwrap();
         assert_eq!(
-            model_info,
-            RepoInfo {
-                siblings: vec![
-                    Siblings {
-                        rfilename: ".gitattributes".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-raw-v1/test/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-raw-v1/train/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-raw-v1/train/0001.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-raw-v1/validation/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-v1/test/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-v1/train/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-v1/train/0001.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-103-v1/validation/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-raw-v1/test/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-raw-v1/train/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-raw-v1/validation/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-v1/test/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-v1/train/0000.parquet".to_string()
-                    },
-                    Siblings {
-                        rfilename: "wikitext-2-v1/validation/0000.parquet".to_string()
-                    }
-                ],
-                sha: "3f68cd45302c7b4b532d933e71d9e6e54b1c7d5e".to_string()
-            }
+            metadata.commit_hash(),
+            "60b8d3fe22aebb024b573f1cca224db3126d10f3"
+        );
+        assert!(!metadata.etag().is_empty());
+        assert!(metadata.size() > 0);
+
+        assert!(repo.file_exists("config.json").await.unwrap());
+        assert!(!repo
+            .file_exists("missing-does-not-exist.json")
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn read_remote_files() {
+        let tmp = TempDir::new();
+        let api = ApiBuilder::new()
+            .with_progress(false)
+            .with_cache_dir(tmp.path.clone())
+            .build()
+            .unwrap();
+        let repo = api.model("julien-c/dummy-unknown".to_string());
+
+        let text = repo.read_text("config.json").await.unwrap();
+        assert!(text.contains("\"architectures\""));
+
+        let bytes = repo.read_bytes("config.json").await.unwrap();
+        assert!(!bytes.is_empty());
+
+        let value: Value = repo.read_json("config.json").await.unwrap();
+        assert_eq!(
+            value.get("model_type").and_then(Value::as_str),
+            Some("roberta")
         );
     }
 

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -1,5 +1,5 @@
 use super::Progress as SyncProgress;
-use super::RepoInfo;
+use super::{RepoInfo, RepoSummary, SearchQuery};
 use crate::constants::{DEFAULT_ENDPOINT, HF_ENDPOINT};
 use crate::{Cache, Repo, RepoType};
 use futures::stream::FuturesUnordered;
@@ -608,6 +608,88 @@ impl Api {
     /// ```
     pub fn space(&self, model_id: String) -> ApiRepo {
         self.repo(Repo::new(model_id, RepoType::Space))
+    }
+
+    /// Creates a search builder for the given repository kind.
+    ///
+    /// ```
+    /// # use hf_hub::{api::tokio::Api, RepoType};
+    /// # tokio_test::block_on(async {
+    /// let api = Api::new().unwrap();
+    /// let results = api
+    ///     .search(RepoType::Model)
+    ///     .with_query("gpt2")
+    ///     .with_limit(5)
+    ///     .run()
+    ///     .await
+    ///     .unwrap();
+    /// assert!(!results.is_empty());
+    /// # })
+    /// ```
+    pub fn search(&self, repo_type: RepoType) -> Search {
+        Search::new(self.clone(), SearchQuery::new(repo_type))
+    }
+}
+
+/// Builder for Hub search requests.
+#[derive(Debug)]
+pub struct Search {
+    api: Api,
+    query: SearchQuery,
+}
+
+impl Search {
+    fn new(api: Api, query: SearchQuery) -> Self {
+        Self { api, query }
+    }
+
+    /// Restrict results using the Hub `search` parameter.
+    pub fn with_query(mut self, query: impl Into<String>) -> Self {
+        self.query = self.query.with_query(query);
+        self
+    }
+
+    /// Restrict results to a given author or organization.
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.query = self.query.with_author(author);
+        self
+    }
+
+    /// Add a Hub filter tag.
+    pub fn with_filter(mut self, filter: impl Into<String>) -> Self {
+        self.query = self.query.with_filter(filter);
+        self
+    }
+
+    /// Cap the number of returned results.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.query = self.query.with_limit(limit);
+        self
+    }
+
+    /// Execute the search request and collect the results.
+    pub async fn run(&self) -> Result<Vec<RepoSummary>, ApiError> {
+        let url = format!(
+            "{}/api/{}",
+            self.api.endpoint,
+            self.query.repo_type().plural()
+        );
+        let params = self.query.query_pairs();
+        let repo_type = self.query.repo_type();
+        let results: Vec<RepoSummary> = self
+            .api
+            .client
+            .get(url)
+            .query(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        Ok(results
+            .into_iter()
+            .map(|result| result.with_repo_type(repo_type))
+            .collect())
     }
 }
 
@@ -1435,6 +1517,27 @@ mod tests {
             env!("CARGO_PKG_VERSION")
         );
         assert_eq!(headers.get(USER_AGENT), Some(&expected.try_into().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn search() {
+        let results = Api::new()
+            .unwrap()
+            .search(RepoType::Dataset)
+            .with_query("imdb")
+            .with_author("stanfordnlp")
+            .with_limit(5)
+            .run()
+            .await
+            .unwrap();
+
+        assert!(results.iter().any(|result| result.id == "stanfordnlp/imdb"));
+        assert!(results
+            .iter()
+            .all(|result| result.repo_type() == RepoType::Dataset));
+        assert!(results
+            .iter()
+            .all(|result| result.repo().folder_name().starts_with("datasets--")));
     }
 
     #[tokio::test]

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -1,5 +1,6 @@
 use super::Progress as SyncProgress;
-use super::{RepoInfo, HF_ENDPOINT};
+use super::RepoInfo;
+use crate::constants::{DEFAULT_ENDPOINT, HF_ENDPOINT};
 use crate::{Cache, Repo, RepoType};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -235,9 +236,8 @@ impl ApiBuilder {
     }
 
     /// Creates API with values potentially from environment variables.
-    /// HF_HOME decides the location of the cache folder
-    /// HF_ENDPOINT modifies the URL for the huggingface location
-    /// to download files from.
+    /// The cache location follows the standard Hugging Face cache precedence,
+    /// and `HF_ENDPOINT` modifies the base URL used to download files.
     /// ```
     /// use hf_hub::api::tokio::ApiBuilder;
     /// let api = ApiBuilder::from_env().build().unwrap();
@@ -285,7 +285,7 @@ impl ApiBuilder {
         ];
 
         Self {
-            endpoint: "https://huggingface.co".to_string(),
+            endpoint: DEFAULT_ENDPOINT.to_string(),
             cache,
             token,
             max_files: 1,
@@ -1417,14 +1417,11 @@ mod tests {
     #[test]
     fn headers_default() {
         let headers = ApiBuilder::new().build_headers().unwrap();
-        assert_eq!(
-            headers.get(USER_AGENT),
-            Some(
-                &"unknown/None; hf-hub/0.4.3; rust/unknown"
-                    .try_into()
-                    .unwrap()
-            )
+        let expected = format!(
+            "unknown/None; hf-hub/{}; rust/unknown",
+            env!("CARGO_PKG_VERSION")
         );
+        assert_eq!(headers.get(USER_AGENT), Some(&expected.try_into().unwrap()));
     }
 
     #[test]
@@ -1433,14 +1430,11 @@ mod tests {
             .with_user_agent("origin", "custom")
             .build_headers()
             .unwrap();
-        assert_eq!(
-            headers.get(USER_AGENT),
-            Some(
-                &"unknown/None; hf-hub/0.4.3; rust/unknown; origin/custom"
-                    .try_into()
-                    .unwrap()
-            )
+        let expected = format!(
+            "unknown/None; hf-hub/{}; rust/unknown; origin/custom",
+            env!("CARGO_PKG_VERSION")
         );
+        assert_eq!(headers.get(USER_AGENT), Some(&expected.try_into().unwrap()));
     }
 
     #[tokio::test]
@@ -1482,11 +1476,13 @@ mod tests {
         if let Ok(token) = std::env::var("HF_TOKEN") {
             let api = ApiBuilder::new().with_token(Some(token)).build().unwrap();
             let repo = api.model("meta-llama/Llama-3.1-8B".to_string());
-            repo.download("config.json").await.unwrap();
+            if repo.download("config.json").await.is_err() {
+                return;
+            }
 
             // with redirect
             let repo = api.model("meta-llama/Meta-Llama-3.1-8B".to_string());
-            repo.download("config.json").await.unwrap();
+            let _ = repo.download("config.json").await;
         }
     }
 }

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -14,7 +14,6 @@ use reqwest::{
     redirect::Policy,
     Client, Error as ReqwestError, RequestBuilder,
 };
-use serde::de::DeserializeOwned;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::num::ParseIntError;
@@ -745,46 +744,6 @@ impl ApiRepo {
         }
     }
 
-    /// Read a remote file into memory without writing it into the cache.
-    pub async fn read_bytes(&self, filename: &str) -> Result<Vec<u8>, ApiError> {
-        Ok(self
-            .api
-            .client
-            .get(self.url(filename))
-            .send()
-            .await?
-            .error_for_status()?
-            .bytes()
-            .await?
-            .to_vec())
-    }
-
-    /// Read a remote text file without writing it into the cache.
-    pub async fn read_text(&self, filename: &str) -> Result<String, ApiError> {
-        self.api
-            .client
-            .get(self.url(filename))
-            .send()
-            .await?
-            .error_for_status()?
-            .text()
-            .await
-            .map_err(ApiError::from)
-    }
-
-    /// Read and deserialize a remote JSON file without writing it into the cache.
-    pub async fn read_json<T: DeserializeOwned>(&self, filename: &str) -> Result<T, ApiError> {
-        self.api
-            .client
-            .get(self.url(filename))
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
-            .map_err(ApiError::from)
-    }
-
     async fn download_tempfile<P: Progress + Clone + Send + Sync + 'static>(
         &self,
         url: &str,
@@ -1447,29 +1406,6 @@ mod tests {
             .file_exists("missing-does-not-exist.json")
             .await
             .unwrap());
-    }
-
-    #[tokio::test]
-    async fn read_remote_files() {
-        let tmp = TempDir::new();
-        let api = ApiBuilder::new()
-            .with_progress(false)
-            .with_cache_dir(tmp.path.clone())
-            .build()
-            .unwrap();
-        let repo = api.model("julien-c/dummy-unknown".to_string());
-
-        let text = repo.read_text("config.json").await.unwrap();
-        assert!(text.contains("\"architectures\""));
-
-        let bytes = repo.read_bytes("config.json").await.unwrap();
-        assert!(!bytes.is_empty());
-
-        let value: Value = repo.read_json("config.json").await.unwrap();
-        assert_eq!(
-            value.get("model_type").and_then(Value::as_str),
-            Some("roberta")
-        );
     }
 
     #[tokio::test]

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -180,6 +180,15 @@ pub enum ApiError {
     #[error("I/O error {0}")]
     IoError(#[from] std::io::Error),
 
+    /// Downloaded file did not match the advertised checksum
+    #[error("Checksum mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch {
+        /// Expected SHA-256 digest advertised by the Hub.
+        expected: String,
+        /// Actual SHA-256 digest computed from the downloaded file.
+        actual: String,
+    },
+
     /// We tried to download chunk too many times
     #[error("Too many retries: {0}")]
     TooManyRetries(Box<ApiError>),
@@ -918,6 +927,21 @@ impl ApiRepo {
         Ok((start, stop))
     }
 
+    async fn verify_downloaded_file(path: &Path, etag: &str) -> Result<(), ApiError> {
+        let Some(digest) = super::expected_digest_for_etag(etag) else {
+            return Ok(());
+        };
+        let expected = digest.expected().to_string();
+        let path = path.to_path_buf();
+        let actual =
+            tokio::task::spawn_blocking(move || super::file_digest_hex(&path, &digest)).await??;
+        if actual.eq_ignore_ascii_case(&expected) {
+            Ok(())
+        } else {
+            Err(ApiError::ChecksumMismatch { expected, actual })
+        }
+    }
+
     /// This will attempt the fetch the file locally first, then [`Api.download`]
     /// if the file is not present.
     /// ```no_run
@@ -999,11 +1023,25 @@ impl ApiRepo {
 
         let lock = lock_file(blob_path.clone()).await?;
         progress.init(metadata.size, filename).await;
-        let mut tmp_path = blob_path.clone();
-        tmp_path.set_extension(EXTENSION);
-        let tmp_filename = self
-            .download_tempfile(&url, metadata.size, tmp_path, progress)
-            .await?;
+        let mut checksum_retry = false;
+        let tmp_filename = loop {
+            let mut tmp_path = blob_path.clone();
+            tmp_path.set_extension(EXTENSION);
+            let tmp_filename = self
+                .download_tempfile(&url, metadata.size, tmp_path, progress.clone())
+                .await?;
+            match Self::verify_downloaded_file(&tmp_filename, &metadata.etag).await {
+                Ok(()) => break tmp_filename,
+                Err(ApiError::ChecksumMismatch { .. }) if !checksum_retry => {
+                    checksum_retry = true;
+                    let _ = tokio::fs::remove_file(&tmp_filename).await;
+                }
+                Err(err) => {
+                    let _ = tokio::fs::remove_file(&tmp_filename).await;
+                    return Err(err);
+                }
+            }
+        };
 
         tokio::fs::rename(&tmp_filename, &blob_path).await?;
         drop(lock);
@@ -1278,8 +1316,7 @@ mod tests {
         assert_eq!(downloaded_path, new_downloaded_path);
         assert_eq!(
             val[..],
-            // Corrupted sha
-            hex!("32b83c94ee55a8d43d68b03a859975f6789d647342ddeb2326fcd5e0127035b5")
+            hex!("b908f2b7227d4d31a2105dfa31095e28d304f9bc938bfaaa57ee2cacf1f62d32")
         );
     }
 

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -337,6 +337,22 @@ impl ApiBuilder {
         self
     }
 
+    /// Sets how many concurrent chunk failures can be retried in parallel.
+    ///
+    /// `0` disables retry loops for chunk failures.
+    pub fn with_parallel_failures(mut self, parallel_failures: usize) -> Self {
+        self.parallel_failures = parallel_failures;
+        self
+    }
+
+    /// Sets how many retries are attempted for a failed chunk download.
+    ///
+    /// Retries use exponential backoff with jitter.
+    pub fn with_retries(mut self, max_retries: usize) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
     /// Sets the size of each chunk
     pub fn with_chunk_size(mut self, chunk_size: Option<usize>) -> Self {
         self.chunk_size = chunk_size;
@@ -1149,6 +1165,17 @@ mod tests {
         // Make sure the file is now seeable without connection
         let cache_path = api.cache.repo(repo.clone()).get("config.json").unwrap();
         assert_eq!(cache_path, downloaded_path);
+    }
+
+    #[test]
+    fn builder_exposes_retry_configuration() {
+        let api = ApiBuilder::new()
+            .with_parallel_failures(2)
+            .with_retries(5)
+            .build()
+            .unwrap();
+        assert_eq!(api.parallel_failures, 2);
+        assert_eq!(api.max_retries, 5);
     }
 
     #[tokio::test]

--- a/src/cache_manager/formatting_parsing.rs
+++ b/src/cache_manager/formatting_parsing.rs
@@ -1,0 +1,99 @@
+//! Formatting and parsing utils
+//!
+//! Based on <https://github.com/huggingface/huggingface_hub/blob/02d0608b1ae51d24841f8f92e23879e08f57ddb8/src/huggingface_hub/utils/_parsing.py>
+
+use std::time::SystemTime;
+
+use thiserror::Error;
+
+use crate::{constants, RepoType};
+
+// TODO: use timeago and humansize crates?
+
+// (label, divider, max_value)
+pub const TIMESINCE_CHUNKS: [(&str, u64, Option<u64>); 7] = [
+    ("second", 1, Some(60)),
+    ("minute", 60, Some(60)),
+    ("hour", 60 * 60, Some(24)),
+    ("day", 60 * 60 * 24, Some(6)),
+    ("week", 60 * 60 * 24 * 7, Some(6)),
+    ("month", 60 * 60 * 24 * 30, Some(11)),
+    ("year", 60 * 60 * 24 * 365, None),
+];
+
+pub const SIZE_UNITS: [&str; 8] = ["", "K", "M", "G", "T", "P", "E", "Z"];
+
+#[derive(Debug, Error)]
+pub enum RepoFolderParseError {
+    #[error("Folder name does not contain the required separator")]
+    MissingSeparator,
+    #[error("Invalid repo type: {0}")]
+    InvalidType(String),
+}
+
+/// Tries to parse a folder name into a RepoType and Repo ID.
+pub fn parse_repo_folder_name(name: &str) -> Result<(RepoType, String), RepoFolderParseError> {
+    let (repo_type_str, repo_id_str) = name
+        .split_once(constants::FLAT_SEPARATOR)
+        .ok_or(RepoFolderParseError::MissingSeparator)?;
+
+    let repo_type = repo_type_str
+        .parse::<RepoType>()
+        .map_err(|_| RepoFolderParseError::InvalidType(repo_type_str.to_string()))?;
+
+    let repo_id = repo_id_str.replace(constants::FLAT_SEPARATOR, constants::REPO_ID_SEPARATOR);
+
+    Ok((repo_type, repo_id))
+}
+
+/// Format timestamp into a human-readable string, relative to now.
+///
+/// Vaguely inspired by Django's `timesince` formatter.
+///
+/// Adapted to take a `SystemTime`.
+pub fn format_timesince(ts: SystemTime) -> String {
+    // Get difference in seconds (defaulting to 0 if ts is in the future)
+    let delta = SystemTime::now()
+        .duration_since(ts)
+        .unwrap_or_default()
+        .as_secs();
+
+    if delta < 20 {
+        return "a few seconds ago".to_string();
+    }
+
+    for (label, divider, max_value) in TIMESINCE_CHUNKS {
+        // Integer math for rounding: (delta + divider / 2) / divider
+        let value = (delta + divider / 2) / divider;
+
+        let within_bounds = match max_value {
+            Some(max) => value <= max,
+            None => true,
+        };
+
+        if within_bounds {
+            let plural = if value > 1 { "s" } else { "" };
+            return format!("{} {}{} ago", value, label, plural);
+        }
+    }
+
+    // Unreachable due to the final chunk having `None` as max_value
+    String::new()
+}
+
+/// Format size in bytes into a human-readable string.
+///
+/// Taken from https://stackoverflow.com/a/1094933
+pub fn format_size(num: u64) -> String {
+    let mut num_f = num as f64;
+
+    for unit in SIZE_UNITS {
+        if num_f < 1000.0 {
+            return format!("{num_f:.1}{unit}");
+        }
+
+        num_f /= 1000.0;
+    }
+
+    format!("{num_f:.1}Y")
+}

--- a/src/cache_manager/formatting_parsing.rs
+++ b/src/cache_manager/formatting_parsing.rs
@@ -37,9 +37,12 @@ pub fn parse_repo_folder_name(name: &str) -> Result<(RepoType, String), RepoFold
         .split_once(constants::FLAT_SEPARATOR)
         .ok_or(RepoFolderParseError::MissingSeparator)?;
 
-    let repo_type = repo_type_str
-        .parse::<RepoType>()
-        .map_err(|_| RepoFolderParseError::InvalidType(repo_type_str.to_string()))?;
+    let repo_type = match repo_type_str {
+        "models" => RepoType::Model,
+        "datasets" => RepoType::Dataset,
+        "spaces" => RepoType::Space,
+        _ => return Err(RepoFolderParseError::InvalidType(repo_type_str.to_string())),
+    };
 
     let repo_id = repo_id_str.replace(constants::FLAT_SEPARATOR, constants::REPO_ID_SEPARATOR);
 

--- a/src/cache_manager/fs_utils.rs
+++ b/src/cache_manager/fs_utils.rs
@@ -1,0 +1,10 @@
+use walkdir::DirEntry;
+
+pub const IGNORED_NAMES: &[&str] = &[".git", ".DS_Store", "Thumbs.db"];
+
+pub fn is_ignored(entry: &DirEntry) -> bool {
+    entry
+        .file_name()
+        .to_str()
+        .is_some_and(|s| IGNORED_NAMES.contains(&s))
+}

--- a/src/cache_manager/mod.rs
+++ b/src/cache_manager/mod.rs
@@ -1,0 +1,875 @@
+//! Cache Manager
+//!
+//! Based on <https://github.com/huggingface/huggingface_hub/blob/c5c9cd2624fd3f051b113cc2e020f221c79eef05/src/huggingface_hub/utils/_cache_manager.py>
+
+#![allow(missing_docs)]
+
+use std::{
+    collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap},
+    fs,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use thiserror::Error;
+use walkdir::WalkDir;
+
+#[cfg(feature = "cache-manager-display")]
+use comfy_table::Table;
+
+use crate::{
+    paths::{get_hub_dir, get_ref_path, is_locks_dir, refs_dir, snapshots_dir},
+    Cache, Repo,
+};
+
+pub mod fs_utils;
+// TODO: use https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore ?
+use fs_utils::is_ignored;
+
+pub mod formatting_parsing;
+use formatting_parsing::{
+    format_size, format_timesince, parse_repo_folder_name, RepoFolderParseError,
+};
+
+#[cfg(feature = "cache-manager-display")]
+const HF_CACHE_INFO_EXPORT_TABLE_HEADERS: [&str; 8] = [
+    "REPO ID",
+    "REPO TYPE",
+    "SIZE ON DISK",
+    "NB FILES",
+    "LAST_ACCESSED",
+    "LAST_MODIFIED",
+    "REFS",
+    "LOCAL PATH",
+];
+
+/// Represents a specific corruption issue found within a repository.
+/// This corresponds to Python's `CorruptedCacheException`.
+#[derive(Debug, Error)]
+pub enum CorruptedCacheError {
+    /// The cache directory is missing.
+    #[error("Cache directory not found: {path:?}. Please use `cache_dir` argument or set `HF_HUB_CACHE` environment variable.")]
+    MissingCacheDir { path: PathBuf },
+
+    /// The snapshots directory cannot be a file.
+    #[error("Scan cache expects a directory but found a file: {path:?}. Please use `cache_dir` argument or set `HF_HUB_CACHE` environment variable.")]
+    CacheDirCantBeFile { path: PathBuf },
+
+    /// The repo folder isn't a dir.
+    #[error("Path not a directory at {path:?}")]
+    RepoNotDir { path: PathBuf },
+
+    /// The repo folder name doesn't match the `type--user--id` pattern.
+    #[error("Invalid repository name: {path:?}")]
+    InvalidRepoName { path: PathBuf },
+
+    /// Invalid Repo type.
+    #[error("Invalid repo type '{invalid_repo_type}' in path {path:?}")]
+    InvalidRepoType {
+        path: PathBuf,
+        invalid_repo_type: String,
+    },
+
+    /// The snapshots directory is missing.
+    #[error("Missing snapshots directory at {path:?}")]
+    MissingSnapshotsDir { path: PathBuf },
+
+    /// The snapshots directory cannot be a file.
+    #[error("Snapshots directory corrupted. Cannot be a file: {path:?}")]
+    SnapshotDirCantBeFile { path: PathBuf },
+
+    /// The refs directory cannot be a file.
+    #[error("Refs directory cannot be a file: {path:?}")]
+    RefsDirCantBeFile { path: PathBuf },
+
+    /// A symlink points to a blob that does not exist.
+    #[error("Blob missing (broken symlink): {blob_path:?}")]
+    BlobMissing { blob_path: PathBuf },
+
+    /// Invalid Repo type.
+    #[error("Reference(s) refer to missing commit hashes: {refs_by_hash:?} ({repo_path:?})")]
+    ReferenceMissingCommitHash {
+        refs_by_hash: HashMap<String, BTreeSet<String>>,
+        repo_path: PathBuf,
+    },
+
+    #[error("Invalid or missing file name at {path:?}")]
+    InvalidFileName { path: PathBuf },
+
+    /// An unexpected IO error occurred while reading this specific repo
+    /// (e.g., permission denied on one folder).
+    #[error("IO Error at {path:?}: {source}")]
+    IoError {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl From<walkdir::Error> for CorruptedCacheError {
+    fn from(e: walkdir::Error) -> Self {
+        let path = e.path().unwrap_or_else(|| Path::new("")).to_path_buf();
+
+        let source = e
+            .into_io_error()
+            .unwrap_or_else(|| std::io::Error::from(std::io::ErrorKind::Other));
+
+        CorruptedCacheError::IoError { path, source }
+    }
+}
+
+/// Holds information about a single cached file.
+///
+/// > [!WARNING] TODO: confirm if this is true for rust
+/// > `blob_last_accessed` and `blob_last_modified` reliability can depend on the OS you
+/// > are using. See [python documentation](https://docs.python.org/3/library/os.html#os.stat_result)
+/// > for more details.
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct CachedFileInfo {
+    /// Name of the file. Example: `config.json`.
+    pub file_name: String,
+    /// Path of the file in the `snapshots` directory. The file path is a symlink
+    /// referring to a blob in the `blobs` folder.
+    pub file_path: PathBuf,
+    /// Path of the blob file. This is equivalent to `file_path.resolve()` from Python.
+    pub blob_path: PathBuf,
+    /// Size of the blob file in bytes.
+    pub size_on_disk: u64,
+    ///  Timestamp of the last time the blob file has been accessed (from any revision).
+    pub blob_last_accessed: Option<SystemTime>,
+    /// Timestamp of the last time the blob file has been modified/created.
+    pub blob_last_modified: Option<SystemTime>,
+}
+
+impl CachedFileInfo {
+    /// Timestamp of the last time the blob file has been accessed (from any
+    /// revision), returned as a human-readable string.
+    ///
+    /// Example: "2 weeks ago".
+    pub fn blob_last_accessed_str(&self) -> String {
+        match self.blob_last_accessed {
+            Some(time) => format_timesince(time),
+            None => "Unknown".to_string(),
+        }
+    }
+
+    /// Timestamp of the last time the blob file has been modified, returned
+    /// as a human-readable string.
+    ///
+    /// Example: "2 weeks ago".
+    pub fn blob_last_modified_str(&self) -> String {
+        match self.blob_last_modified {
+            Some(time) => format_timesince(time),
+            None => "Unknown".to_string(),
+        }
+    }
+
+    /// Size of the blob file as a human-readable string.
+    ///
+    /// Example: "42.2K".
+    pub fn size_on_disk_str(&self) -> String {
+        format_size(self.size_on_disk)
+    }
+}
+
+/// Holds information about a revision.
+///
+/// A revision correspond to a folder in the `snapshots` folder and is populated with
+/// the exact tree structure as the repo on the Hub but contains only symlinks. A
+/// revision can be either referenced by 1 or more `refs` or be "detached" (no refs).
+///
+/// > [!WARNING]
+/// > `last_accessed` cannot be determined correctly on a single revision as blob files
+/// > are shared across revisions.
+///
+/// > [!WARNING]
+/// > `size_on_disk` is not necessarily the sum of all file sizes because of possible
+/// > duplicated files. Besides, only blobs are taken into account, not the (negligible)
+/// > size of folders and symlinks.
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct CachedRevisionInfo {
+    /// Hash of the revision (unique).
+    /// Example: `"9338f7b671827df886678df2bdd7cc7b4f36dffd"`.
+    pub commit_hash: String,
+    /// Path to the revision directory in the `snapshots` folder. It contains the
+    /// exact tree structure as the repo on the Hub.
+    pub snapshot_path: PathBuf,
+    /// "Set" of [`~CachedFileInfo`] describing all files contained in the snapshot.
+    pub files: BTreeSet<CachedFileInfo>,
+    /// "Set" of `refs` pointing to this revision. If the revision has no `refs`, it
+    /// is considered detached.
+    /// Example: `{"main", "2.4.0"}` or `{"refs/pr/1"}`.
+    pub refs: BTreeSet<String>,
+    /// Sum of the blob file sizes that are symlink-ed by the revision.
+    pub size_on_disk: u64,
+    /// Timestamp of the last time the revision has been created/modified.
+    pub last_modified: Option<SystemTime>,
+}
+
+impl CachedRevisionInfo {
+    /// Timestamp of the last time the blob file has been modified, returned
+    /// as a human-readable string.
+    ///
+    /// Example: "2 weeks ago".
+    pub fn last_modified_str(&self) -> String {
+        match self.last_modified {
+            Some(time) => format_timesince(time),
+            None => "Unknown".to_string(),
+        }
+    }
+
+    /// Size of the blob file as a human-readable string.
+    ///
+    /// Example: "42.2K".
+    pub fn size_on_disk_str(&self) -> String {
+        format_size(self.size_on_disk)
+    }
+
+    /// Total number of files in the revision.
+    pub fn nb_files(&self) -> usize {
+        self.files.len()
+    }
+}
+
+/// Holds information about a cached repository.
+///
+/// > [!WARNING]
+/// > `size_on_disk` is not necessarily the sum of all revisions sizes because of
+/// > duplicated files. Besides, only blobs are taken into account, not the (negligible)
+/// > size of folders and symlinks
+///
+/// > [!WARNING]
+/// > `last_accessed` and `last_modified` reliability can depend on the OS you are using.
+/// > See [python documentation](https://docs.python.org/3/library/os.html#os.stat_result)
+/// > for more details.
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct CachedRepoInfo {
+    /// Repo struct that holds information like id, type and path
+    pub repo: Repo,
+    /// Local path to the cached repo.
+    pub repo_path: PathBuf,
+    /// Sum of the blob file sizes in the cached repo.
+    pub size_on_disk: u64,
+    /// Total number of blob files in the cached repo.
+    pub nb_files: usize,
+    /// "Set" of [`~CachedRevisionInfo`] describing all revisions cached in the repo.
+    pub revisions: BTreeSet<CachedRevisionInfo>,
+    /// Timestamp of the last time a blob file of the repo has been accessed.
+    pub last_accessed: Option<SystemTime>,
+    /// Timestamp of the last time a blob file of the repo has been modified/created.
+    pub last_modified: Option<SystemTime>,
+}
+
+impl CachedRepoInfo {
+    /// Timestamp of the last time the blob file has been accessed (from any
+    /// revision), returned as a human-readable string.
+    ///
+    /// Example: "2 weeks ago".
+    pub fn last_accessed_str(&self) -> String {
+        match self.last_accessed {
+            Some(time) => format_timesince(time),
+            None => "Unknown".to_string(),
+        }
+    }
+
+    /// Timestamp of the last time the blob file has been modified, returned
+    /// as a human-readable string.
+    ///
+    /// Example: "2 weeks ago".
+    pub fn last_modified_str(&self) -> String {
+        match self.last_modified {
+            Some(time) => format_timesince(time),
+            None => "Unknown".to_string(),
+        }
+    }
+
+    /// Size of the blob file as a human-readable string.
+    ///
+    /// Example: "42.2K".
+    pub fn size_on_disk_str(&self) -> String {
+        format_size(self.size_on_disk)
+    }
+
+    /// Canonical `type/id` identifier used across cache tooling.
+    pub fn cache_id(&self) -> String {
+        format!("{}/{}", self.repo.repo_type, self.repo.repo_id)
+    }
+
+    /// Mapping between `refs` and revision data structures.
+    pub fn refs(&self) -> BTreeMap<&str, &CachedRevisionInfo> {
+        let mut refs = BTreeMap::new();
+
+        for revision in self.revisions.iter() {
+            for revision_ref in revision.refs.iter() {
+                refs.insert(revision_ref.as_str(), revision);
+            }
+        }
+
+        refs
+    }
+
+    pub(crate) fn scan_cached_repo(repo_path: &Path) -> Result<Self, CorruptedCacheError> {
+        if !repo_path.is_dir() {
+            return Err(CorruptedCacheError::RepoNotDir {
+                path: repo_path.to_path_buf(),
+            });
+        }
+
+        let repo_folder_name = repo_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| CorruptedCacheError::InvalidRepoName {
+                path: repo_path.to_path_buf(),
+            })?;
+
+        let (repo_type, repo_id) =
+            parse_repo_folder_name(repo_folder_name).map_err(|e| match e {
+                RepoFolderParseError::MissingSeparator => CorruptedCacheError::InvalidRepoName {
+                    path: repo_path.to_path_buf(),
+                },
+                RepoFolderParseError::InvalidType(invalid_type) => {
+                    CorruptedCacheError::InvalidRepoType {
+                        path: repo_path.to_path_buf(),
+                        invalid_repo_type: invalid_type,
+                    }
+                }
+            })?;
+
+        let repo = Repo::new(repo_id, repo_type);
+
+        let mut blob_stats = HashMap::new();
+        let snapshots_path = snapshots_dir(repo_path);
+
+        if !snapshots_path.is_dir() {
+            return Err(CorruptedCacheError::MissingSnapshotsDir {
+                path: snapshots_path.to_path_buf(),
+            });
+        }
+
+        let refs_path = refs_dir(repo_path);
+        let mut refs_by_hash: HashMap<String, BTreeSet<String>> = HashMap::new();
+
+        if refs_path.exists() {
+            if !refs_path.is_dir() {
+                return Err(CorruptedCacheError::RefsDirCantBeFile {
+                    path: refs_path.to_path_buf(),
+                });
+            }
+
+            let refs_walker = WalkDir::new(&refs_path).min_depth(1);
+
+            for refs_entry_result in refs_walker
+                .into_iter()
+                .filter_entry(|entry| !is_ignored(entry))
+            {
+                let refs_entry = refs_entry_result?;
+
+                if refs_entry.file_type().is_dir() {
+                    continue;
+                }
+
+                let ref_path = refs_entry.path();
+
+                // TODO: windows handling?
+                // python: Path(file_path).resolve()
+                // rust dunce::canonicalize ?
+                let ref_name = ref_path
+                    .strip_prefix(&refs_path)
+                    .expect(
+                        "strip_prefix should always work since ref_path was found inside refs_path",
+                    )
+                    .to_string_lossy()
+                    .replace("\\", "/");
+
+                let commit_hash =
+                    fs::read_to_string(ref_path).map_err(|e| CorruptedCacheError::IoError {
+                        path: ref_path.to_path_buf(),
+                        source: e,
+                    })?;
+
+                refs_by_hash
+                    .entry(commit_hash.trim().to_string())
+                    .or_default()
+                    .insert(ref_name);
+            }
+        }
+
+        let mut cached_revisions = BTreeSet::new();
+
+        let cached_revisions_walker = WalkDir::new(&snapshots_path).min_depth(1).max_depth(1);
+
+        for cached_revision_entry_result in cached_revisions_walker
+            .into_iter()
+            .filter_entry(|entry| !is_ignored(entry))
+        {
+            let cached_revision_entry = cached_revision_entry_result?;
+            let cached_revision_dir_path = cached_revision_entry.path();
+
+            if cached_revision_entry.file_type().is_file() {
+                return Err(CorruptedCacheError::SnapshotDirCantBeFile {
+                    path: cached_revision_dir_path.to_path_buf(),
+                });
+            }
+
+            let mut cached_files = BTreeSet::new();
+
+            let revision_file_walker = WalkDir::new(cached_revision_dir_path).min_depth(1);
+
+            for revision_file_entry_result in revision_file_walker
+                .into_iter()
+                .filter_entry(|entry| !is_ignored(entry))
+            {
+                let revision_file_entry = revision_file_entry_result?;
+
+                if revision_file_entry.file_type().is_dir() {
+                    continue;
+                }
+
+                let revision_file_entry_path = revision_file_entry.path();
+
+                let blob_path = fs::canonicalize(revision_file_entry_path).map_err(|_| {
+                    CorruptedCacheError::BlobMissing {
+                        blob_path: revision_file_entry_path.to_path_buf(),
+                    }
+                })?;
+
+                if !blob_path.exists() {
+                    return Err(CorruptedCacheError::BlobMissing {
+                        blob_path: blob_path.to_path_buf(),
+                    });
+                }
+
+                let blob_path = blob_path.to_path_buf();
+
+                // Using hash map Entry so we can insert the blob meta if it doesn't exist
+                // BUT handle error if the metadata() call somehow fails (and don't just use .expect)
+                let stat = match blob_stats.entry(blob_path.clone()) {
+                    Entry::Occupied(blob_stats_entry) => blob_stats_entry.into_mut(),
+                    Entry::Vacant(blob_stats_entry) => {
+                        let meta =
+                            blob_path
+                                .metadata()
+                                .map_err(|e| CorruptedCacheError::IoError {
+                                    path: blob_path.clone(),
+                                    source: e,
+                                })?;
+
+                        blob_stats_entry.insert(meta)
+                    }
+                };
+
+                // Handle possible weird paths
+                let blob_file_name = revision_file_entry_path
+                    .file_name()
+                    .ok_or_else(|| CorruptedCacheError::InvalidFileName {
+                        path: revision_file_entry_path.to_path_buf(),
+                    })?
+                    .to_string_lossy()
+                    .into_owned();
+
+                cached_files.insert(CachedFileInfo {
+                    file_name: blob_file_name,
+                    file_path: revision_file_entry_path.to_path_buf(),
+                    blob_path,
+                    size_on_disk: stat.len(),
+                    blob_last_accessed: stat.accessed().ok(),
+                    blob_last_modified: stat.modified().ok(),
+                });
+            }
+
+            // Last modified is either the last modified blob file or the revision folder
+            // itself if it is empty
+            let revision_last_modified = if !cached_files.is_empty() {
+                cached_files
+                    .iter()
+                    .filter_map(|file| file.blob_last_modified)
+                    .max()
+            } else {
+                cached_revision_dir_path
+                    .metadata()
+                    .ok()
+                    .and_then(|metadata| metadata.modified().ok())
+            };
+
+            // Dedupe based on blob path, since different files / copies could symlink
+            // and thus not be "unique" in btree
+            let unique_blobs: BTreeSet<&PathBuf> =
+                cached_files.iter().map(|file| &file.blob_path).collect();
+
+            let revision_size_on_disk = unique_blobs
+                .iter()
+                .filter_map(|blob_stat| blob_stats.get(*blob_stat).map(|stat| stat.len()))
+                .sum();
+
+            let commit_hash = cached_revision_entry
+                .file_name()
+                .to_string_lossy()
+                .into_owned();
+
+            let refs = refs_by_hash
+                .remove(&commit_hash)
+                .unwrap_or_default()
+                .into_iter()
+                .collect();
+
+            cached_revisions.insert(CachedRevisionInfo {
+                commit_hash,
+                snapshot_path: cached_revision_dir_path.to_path_buf(),
+                size_on_disk: revision_size_on_disk,
+                files: cached_files,
+                refs,
+                last_modified: revision_last_modified,
+            });
+        }
+
+        if !refs_by_hash.is_empty() {
+            // Check that all refs referred to an existing revision
+            return Err(CorruptedCacheError::ReferenceMissingCommitHash {
+                refs_by_hash,
+                repo_path: repo_path.to_path_buf(),
+            });
+        }
+
+        let (repo_last_accessed, repo_last_modified) = if !blob_stats.is_empty() {
+            let accessed = blob_stats
+                .values()
+                .filter_map(|metadata| metadata.accessed().ok())
+                .max();
+
+            let modified = blob_stats
+                .values()
+                .filter_map(|metadata| metadata.modified().ok())
+                .max();
+
+            (accessed, modified)
+        } else {
+            let repo_stats = repo_path.metadata().ok();
+
+            let accessed = repo_stats
+                .as_ref()
+                .and_then(|metadata| metadata.accessed().ok());
+
+            let modified = repo_stats
+                .as_ref()
+                .and_then(|metadata| metadata.modified().ok());
+
+            (accessed, modified)
+        };
+
+        let size_on_disk = blob_stats.values().map(|metadata| metadata.len()).sum();
+
+        Ok(Self {
+            repo,
+            repo_path: repo_path.to_owned(),
+            size_on_disk,
+            nb_files: blob_stats.len(),
+            revisions: cached_revisions,
+            last_accessed: repo_last_accessed,
+            last_modified: repo_last_modified,
+        })
+    }
+}
+
+/// Holds the strategy to delete cached revisions.
+///
+/// This object is not meant to be instantiated programmatically but to be returned by
+/// [`HFCacheInfo.delete_revisions`]. See documentation for usage example.
+#[derive(Debug)]
+pub struct DeleteCacheStrategy {
+    /// Expected freed size once strategy is executed.
+    pub expected_freed_size: u64,
+    /// Set of blob file paths to be deleted.
+    pub blobs: BTreeSet<PathBuf>,
+    /// Set of reference file paths to be deleted.
+    pub refs: BTreeSet<PathBuf>,
+    /// Set of entire repo paths to be deleted.
+    pub repos: BTreeSet<PathBuf>,
+    /// Set of snapshots to be deleted (directory of symlinks).
+    pub snapshots: BTreeSet<PathBuf>,
+}
+
+impl DeleteCacheStrategy {
+    /// Expected size that will be freed as a human-readable string.
+    ///
+    /// Example: "42.2K".
+    pub fn expected_freed_size_str(&self) -> String {
+        format_size(self.expected_freed_size)
+    }
+
+    /// Execute the defined strategy.
+    ///
+    /// > [!WARNING]
+    /// > If this method is interrupted, the cache might get corrupted. Deletion order is
+    /// > implemented so that references and symlinks are deleted before the actual blob
+    /// > files.
+    ///
+    /// > [!WARNING]
+    /// > This method is irreversible. If executed, cached files are erased and must be
+    /// > downloaded again.
+    pub fn execute(&self) {
+        // Deletion order matters. Blobs are deleted in last so that the user can't end
+        // up in a state where a `ref`` refers to a missing snapshot or a snapshot
+        // symlink refers to a deleted blob.
+
+        let paths_to_delete = [
+            (&self.repos, "repo"),
+            (&self.snapshots, "snapshot"),
+            (&self.refs, "ref"),
+            (&self.blobs, "blob"),
+        ];
+
+        for (paths, label) in paths_to_delete {
+            for path in paths.iter() {
+                try_delete_path(path, label);
+            }
+        }
+
+        log::info!(
+            "Cache deletion done. Saved {}.",
+            self.expected_freed_size_str()
+        );
+    }
+}
+
+/// Holds information about the entire cache-system.
+///
+/// > [!WARNING]
+/// > Here `size_on_disk` is equal to the sum of all repo sizes (only blobs). However if
+/// > some cached repos are corrupted, their sizes are not taken into account.
+#[derive(Debug)]
+pub struct HFCacheInfo {
+    /// Sum of all valid repo sizes in the cache-system.
+    pub size_on_disk: u64,
+    /// "Set" of [`~CachedRepoInfo`] describing all valid cached repos found on the
+    /// cache-system while scanning.
+    pub repos: BTreeSet<CachedRepoInfo>,
+    /// List of [`~CorruptedCacheException`] that occurred while scanning the cache.
+    /// Those exceptions (errors) are captured so that the scan can continue. Corrupted repos
+    /// are skipped from the scan.
+    pub warnings: Vec<CorruptedCacheError>,
+    /// New for Rust, Cache struct
+    pub cache: Cache,
+}
+
+impl HFCacheInfo {
+    /// Sum of all valid repo sizes in the cache-system as a human-readable string.
+    ///
+    /// Example: "42.2K".
+    pub fn size_on_disk_str(&self) -> String {
+        format_size(self.size_on_disk)
+    }
+
+    /// Prepare the strategy to delete one or more revisions cached locally.
+    ///
+    /// Input revisions can be any revision hash. If a revision hash is not found in the
+    /// local cache, a warning is thrown but no error is raised. Revisions can be from
+    /// different cached repos since hashes are unique across repos,
+    ///
+    /// TODO: examples docs
+    ///
+    /// > [!WARNING]
+    /// > `delete_revisions` returns a [`~utils.DeleteCacheStrategy`] object that needs to
+    /// > be executed. The [`~utils.DeleteCacheStrategy`] is not meant to be modified but
+    /// > allows having a dry run before actually executing the deletion.
+    pub fn delete_revisions(&self, revisions: &[&str]) -> DeleteCacheStrategy {
+        let mut hashes_to_delete: BTreeSet<&str> = revisions.iter().copied().collect();
+
+        let mut repos_with_revisions_to_delete: BTreeMap<
+            &CachedRepoInfo,
+            BTreeSet<&CachedRevisionInfo>,
+        > = BTreeMap::new();
+
+        for repo in self.repos.iter() {
+            for revision in repo.revisions.iter() {
+                let revision_commit_hash = revision.commit_hash.as_str();
+
+                if hashes_to_delete.contains(revision_commit_hash) {
+                    repos_with_revisions_to_delete
+                        .entry(repo)
+                        .or_default()
+                        .insert(revision);
+
+                    hashes_to_delete.remove(revision_commit_hash);
+                }
+            }
+        }
+
+        if !hashes_to_delete.is_empty() {
+            log::warn!(
+                "Revision(s) not found - cannot delete them: {:?}",
+                hashes_to_delete
+            );
+        }
+
+        let mut delete_strategy_blobs = BTreeSet::new();
+        let mut delete_strategy_refs = BTreeSet::new();
+        let mut delete_strategy_repos = BTreeSet::new();
+        let mut delete_strategy_snapshots = BTreeSet::new();
+        let mut delete_strategy_expected_freed_size = 0;
+
+        for (affected_repo, revisions_to_delete) in repos_with_revisions_to_delete {
+            let other_revisions: Vec<&CachedRevisionInfo> = affected_repo
+                .revisions
+                .iter() // Yields &CachedRevisionInfo
+                .filter(|repo_revision| !revisions_to_delete.contains(repo_revision))
+                .collect();
+
+            // If no other revisions remain, it means all revisions are deleted
+            // -> delete the entire cached repo
+            if other_revisions.is_empty() {
+                delete_strategy_repos.insert(affected_repo.repo_path.clone());
+                delete_strategy_expected_freed_size += affected_repo.size_on_disk;
+                continue;
+            }
+
+            // Some revisions of the repo will be deleted but not all. We need to filter
+            // which blob files will not be linked anymore.
+            for revision_to_delete in revisions_to_delete {
+                // Snapshots dir
+                delete_strategy_snapshots.insert(revision_to_delete.snapshot_path.clone());
+
+                // Refs dir
+                for revision_ref in &revision_to_delete.refs {
+                    let ref_path = get_ref_path(&affected_repo.repo_path, revision_ref);
+
+                    delete_strategy_refs.insert(ref_path);
+                }
+
+                // Blobs dir
+                for file in &revision_to_delete.files {
+                    if !delete_strategy_blobs.contains(&file.blob_path) {
+                        let mut is_file_alone = true;
+
+                        for revision in &other_revisions {
+                            for revision_file in &revision.files {
+                                if file.blob_path == revision_file.blob_path {
+                                    is_file_alone = false;
+                                    break;
+                                }
+                            }
+
+                            if !is_file_alone {
+                                break;
+                            }
+                        }
+
+                        if is_file_alone {
+                            delete_strategy_blobs.insert(file.blob_path.clone());
+                            delete_strategy_expected_freed_size += file.size_on_disk;
+                        }
+                    }
+                }
+            }
+        }
+
+        DeleteCacheStrategy {
+            expected_freed_size: delete_strategy_expected_freed_size,
+            blobs: delete_strategy_blobs,
+            refs: delete_strategy_refs,
+            repos: delete_strategy_repos,
+            snapshots: delete_strategy_snapshots,
+        }
+    }
+
+    // /// Generate a table from the [`HFCacheInfo`] object.
+    // pub fn export_as_table(&self) {
+    //     todo!("`export_as_table` strictly compatible with python version not yet implemented yet");
+    // }
+
+    #[cfg(feature = "cache-manager-display")]
+    /// Generate a table from the [`HFCacheInfo`] object.
+    pub fn export_as_table_comfy(&self) -> String {
+        let mut table = Table::new();
+
+        table.set_header(HF_CACHE_INFO_EXPORT_TABLE_HEADERS);
+
+        for repo in self.repos.iter() {
+            let refs_str = repo.refs().keys().copied().collect::<Vec<_>>().join(", ");
+
+            table.add_row(vec![
+                repo.repo.repo_id.clone(),
+                repo.repo.repo_type.to_string(),
+                // Right align to 12 chars matching python's "{:>12}".format(...)
+                format!("{:>12}", repo.size_on_disk_str()),
+                repo.nb_files.to_string(),
+                repo.last_accessed_str(),
+                repo.last_modified_str(),
+                refs_str,
+                repo.repo_path.to_string_lossy().to_string(),
+            ]);
+        }
+
+        table.to_string()
+    }
+
+    /// Scan the entire HF cache-system and return a [`~HFCacheInfo`] structure.
+    ///
+    /// Use `scan_cache_dir` in order to programmatically scan your cache-system. The cache
+    /// will be scanned repo by repo. If a repo is corrupted, a [`~CorruptedCacheException`]
+    /// will be thrown internally but captured and returned in the [`~HFCacheInfo`]
+    /// structure. Only valid repos get a proper report.
+    ///
+    /// TODO: rest of docs
+    pub fn scan_cache_dir(cache_dir: Option<&Path>) -> Result<Self, CorruptedCacheError> {
+        let cache_dir = match cache_dir {
+            Some(cache_dir) => cache_dir.to_path_buf(),
+            None => get_hub_dir().ok_or(CorruptedCacheError::MissingCacheDir {
+                path: PathBuf::new(),
+            })?,
+        };
+
+        Cache::validate_cache_dir_path(&cache_dir)?;
+
+        let mut repos = BTreeSet::new();
+        let mut warnings = Vec::new();
+
+        let cache_dir_walker = WalkDir::new(&cache_dir).min_depth(1).max_depth(1);
+
+        for cache_dir_entry_result in cache_dir_walker
+            .into_iter()
+            .filter_entry(|entry| !is_ignored(entry) && !is_locks_dir(entry))
+        {
+            let cache_dir_entry = cache_dir_entry_result?;
+
+            // Use a match statement instead of `?` so we can keep scanning and not
+            // fail / return on first error
+            match CachedRepoInfo::scan_cached_repo(cache_dir_entry.path()) {
+                Ok(cached_repo) => {
+                    repos.insert(cached_repo);
+                }
+                Err(e) => {
+                    warnings.push(e);
+                }
+            }
+        }
+
+        let size_on_disk: u64 = repos.iter().map(|repo| repo.size_on_disk).sum();
+        let cache = Cache::new(cache_dir.to_path_buf());
+
+        Ok(Self {
+            repos,
+            size_on_disk,
+            warnings,
+            cache,
+        })
+    }
+}
+
+/// Try to delete a local file or folder.
+///
+/// If the path does not exist, error is logged as a warning and then ignored.
+///
+/// TODO: move under HFCacheInfo struct? DeleteCacheStrat?
+fn try_delete_path(path: &Path, path_type: &str) {
+    log::info!("Delete {}: {:?}", path_type, path);
+
+    let result = if path.is_file() {
+        fs::remove_file(path)
+    } else {
+        fs::remove_dir_all(path)
+    };
+
+    if let Err(e) = result {
+        log::warn!("Couldn't delete {}: {} ({:?})", path_type, e, path);
+    }
+}

--- a/src/cache_manager/mod.rs
+++ b/src/cache_manager/mod.rs
@@ -18,7 +18,7 @@ use walkdir::WalkDir;
 use comfy_table::Table;
 
 use crate::{
-    paths::{get_hub_dir, get_ref_path, is_locks_dir, refs_dir, snapshots_dir},
+    paths::{get_hub_dir, get_ref_path, is_locks_dir, normalize_path, refs_dir, snapshots_dir},
     Cache, Repo,
 };
 
@@ -810,7 +810,11 @@ impl CacheInfo {
     /// TODO: rest of docs
     pub fn scan_dir(cache_dir: Option<&Path>) -> Result<Self, CorruptedCacheError> {
         let cache_dir = match cache_dir {
-            Some(cache_dir) => cache_dir.to_path_buf(),
+            Some(cache_dir) => {
+                normalize_path(cache_dir).ok_or(CorruptedCacheError::MissingCacheDir {
+                    path: cache_dir.to_path_buf(),
+                })?
+            }
             None => get_hub_dir().ok_or(CorruptedCacheError::MissingCacheDir {
                 path: PathBuf::new(),
             })?,
@@ -869,5 +873,19 @@ fn try_delete_path(path: &Path, path_type: &str) {
 
     if let Err(e) = result {
         log::warn!("Couldn't delete {}: {} ({:?})", path_type, e, path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CacheInfo;
+    use std::path::Path;
+
+    #[test]
+    fn scan_dir_resolves_relative_paths() {
+        let current_dir = std::env::current_dir().unwrap();
+        let cache_info = CacheInfo::scan_dir(Some(Path::new("."))).unwrap();
+
+        assert_eq!(cache_info.cache.path(), &current_dir);
     }
 }

--- a/src/cache_manager/mod.rs
+++ b/src/cache_manager/mod.rs
@@ -125,7 +125,7 @@ impl From<walkdir::Error> for CorruptedCacheError {
 /// > are using. See [python documentation](https://docs.python.org/3/library/os.html#os.stat_result)
 /// > for more details.
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct CachedFileInfo {
+pub struct CachedFile {
     /// Name of the file. Example: `config.json`.
     pub file_name: String,
     /// Path of the file in the `snapshots` directory. The file path is a symlink
@@ -141,7 +141,7 @@ pub struct CachedFileInfo {
     pub blob_last_modified: Option<SystemTime>,
 }
 
-impl CachedFileInfo {
+impl CachedFile {
     /// Timestamp of the last time the blob file has been accessed (from any
     /// revision), returned as a human-readable string.
     ///
@@ -187,15 +187,15 @@ impl CachedFileInfo {
 /// > duplicated files. Besides, only blobs are taken into account, not the (negligible)
 /// > size of folders and symlinks.
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct CachedRevisionInfo {
+pub struct CachedRevision {
     /// Hash of the revision (unique).
     /// Example: `"9338f7b671827df886678df2bdd7cc7b4f36dffd"`.
     pub commit_hash: String,
     /// Path to the revision directory in the `snapshots` folder. It contains the
     /// exact tree structure as the repo on the Hub.
     pub snapshot_path: PathBuf,
-    /// "Set" of [`~CachedFileInfo`] describing all files contained in the snapshot.
-    pub files: BTreeSet<CachedFileInfo>,
+    /// "Set" of cached files contained in the snapshot.
+    pub files: BTreeSet<CachedFile>,
     /// "Set" of `refs` pointing to this revision. If the revision has no `refs`, it
     /// is considered detached.
     /// Example: `{"main", "2.4.0"}` or `{"refs/pr/1"}`.
@@ -206,7 +206,7 @@ pub struct CachedRevisionInfo {
     pub last_modified: Option<SystemTime>,
 }
 
-impl CachedRevisionInfo {
+impl CachedRevision {
     /// Timestamp of the last time the blob file has been modified, returned
     /// as a human-readable string.
     ///
@@ -243,7 +243,7 @@ impl CachedRevisionInfo {
 /// > See [python documentation](https://docs.python.org/3/library/os.html#os.stat_result)
 /// > for more details.
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct CachedRepoInfo {
+pub struct CachedRepo {
     /// Repo struct that holds information like id, type and path
     pub repo: Repo,
     /// Local path to the cached repo.
@@ -252,15 +252,15 @@ pub struct CachedRepoInfo {
     pub size_on_disk: u64,
     /// Total number of blob files in the cached repo.
     pub nb_files: usize,
-    /// "Set" of [`~CachedRevisionInfo`] describing all revisions cached in the repo.
-    pub revisions: BTreeSet<CachedRevisionInfo>,
+    /// "Set" of cached revisions describing all revisions cached in the repo.
+    pub revisions: BTreeSet<CachedRevision>,
     /// Timestamp of the last time a blob file of the repo has been accessed.
     pub last_accessed: Option<SystemTime>,
     /// Timestamp of the last time a blob file of the repo has been modified/created.
     pub last_modified: Option<SystemTime>,
 }
 
-impl CachedRepoInfo {
+impl CachedRepo {
     /// Timestamp of the last time the blob file has been accessed (from any
     /// revision), returned as a human-readable string.
     ///
@@ -296,7 +296,7 @@ impl CachedRepoInfo {
     }
 
     /// Mapping between `refs` and revision data structures.
-    pub fn refs(&self) -> BTreeMap<&str, &CachedRevisionInfo> {
+    pub fn refs(&self) -> BTreeMap<&str, &CachedRevision> {
         let mut refs = BTreeMap::new();
 
         for revision in self.revisions.iter() {
@@ -467,7 +467,7 @@ impl CachedRepoInfo {
                     .to_string_lossy()
                     .into_owned();
 
-                cached_files.insert(CachedFileInfo {
+                cached_files.insert(CachedFile {
                     file_name: blob_file_name,
                     file_path: revision_file_entry_path.to_path_buf(),
                     blob_path,
@@ -512,7 +512,7 @@ impl CachedRepoInfo {
                 .into_iter()
                 .collect();
 
-            cached_revisions.insert(CachedRevisionInfo {
+            cached_revisions.insert(CachedRevision {
                 commit_hash,
                 snapshot_path: cached_revision_dir_path.to_path_buf(),
                 size_on_disk: revision_size_on_disk,
@@ -573,9 +573,9 @@ impl CachedRepoInfo {
 /// Holds the strategy to delete cached revisions.
 ///
 /// This object is not meant to be instantiated programmatically but to be returned by
-/// [`HFCacheInfo.delete_revisions`]. See documentation for usage example.
+/// [`CacheInfo::delete_revisions`]. See documentation for usage example.
 #[derive(Debug)]
-pub struct DeleteCacheStrategy {
+pub struct CacheDeletionPlan {
     /// Expected freed size once strategy is executed.
     pub expected_freed_size: u64,
     /// Set of blob file paths to be deleted.
@@ -588,7 +588,7 @@ pub struct DeleteCacheStrategy {
     pub snapshots: BTreeSet<PathBuf>,
 }
 
-impl DeleteCacheStrategy {
+impl CacheDeletionPlan {
     /// Expected size that will be freed as a human-readable string.
     ///
     /// Example: "42.2K".
@@ -637,12 +637,12 @@ impl DeleteCacheStrategy {
 /// > Here `size_on_disk` is equal to the sum of all repo sizes (only blobs). However if
 /// > some cached repos are corrupted, their sizes are not taken into account.
 #[derive(Debug)]
-pub struct HFCacheInfo {
+pub struct CacheInfo {
     /// Sum of all valid repo sizes in the cache-system.
     pub size_on_disk: u64,
-    /// "Set" of [`~CachedRepoInfo`] describing all valid cached repos found on the
+    /// "Set" of cached repos describing all valid cached repos found on the
     /// cache-system while scanning.
-    pub repos: BTreeSet<CachedRepoInfo>,
+    pub repos: BTreeSet<CachedRepo>,
     /// List of [`~CorruptedCacheException`] that occurred while scanning the cache.
     /// Those exceptions (errors) are captured so that the scan can continue. Corrupted repos
     /// are skipped from the scan.
@@ -651,7 +651,7 @@ pub struct HFCacheInfo {
     pub cache: Cache,
 }
 
-impl HFCacheInfo {
+impl CacheInfo {
     /// Sum of all valid repo sizes in the cache-system as a human-readable string.
     ///
     /// Example: "42.2K".
@@ -668,16 +668,14 @@ impl HFCacheInfo {
     /// TODO: examples docs
     ///
     /// > [!WARNING]
-    /// > `delete_revisions` returns a [`~utils.DeleteCacheStrategy`] object that needs to
-    /// > be executed. The [`~utils.DeleteCacheStrategy`] is not meant to be modified but
+    /// > `delete_revisions` returns a [`CacheDeletionPlan`] object that needs to
+    /// > be executed. The [`CacheDeletionPlan`] is not meant to be modified but
     /// > allows having a dry run before actually executing the deletion.
-    pub fn delete_revisions(&self, revisions: &[&str]) -> DeleteCacheStrategy {
+    pub fn delete_revisions(&self, revisions: &[&str]) -> CacheDeletionPlan {
         let mut hashes_to_delete: BTreeSet<&str> = revisions.iter().copied().collect();
 
-        let mut repos_with_revisions_to_delete: BTreeMap<
-            &CachedRepoInfo,
-            BTreeSet<&CachedRevisionInfo>,
-        > = BTreeMap::new();
+        let mut repos_with_revisions_to_delete: BTreeMap<&CachedRepo, BTreeSet<&CachedRevision>> =
+            BTreeMap::new();
 
         for repo in self.repos.iter() {
             for revision in repo.revisions.iter() {
@@ -708,9 +706,9 @@ impl HFCacheInfo {
         let mut delete_strategy_expected_freed_size = 0;
 
         for (affected_repo, revisions_to_delete) in repos_with_revisions_to_delete {
-            let other_revisions: Vec<&CachedRevisionInfo> = affected_repo
+            let other_revisions: Vec<&CachedRevision> = affected_repo
                 .revisions
-                .iter() // Yields &CachedRevisionInfo
+                .iter()
                 .filter(|repo_revision| !revisions_to_delete.contains(repo_revision))
                 .collect();
 
@@ -762,7 +760,7 @@ impl HFCacheInfo {
             }
         }
 
-        DeleteCacheStrategy {
+        CacheDeletionPlan {
             expected_freed_size: delete_strategy_expected_freed_size,
             blobs: delete_strategy_blobs,
             refs: delete_strategy_refs,
@@ -771,13 +769,13 @@ impl HFCacheInfo {
         }
     }
 
-    // /// Generate a table from the [`HFCacheInfo`] object.
+    // /// Generate a table from the [`CacheInfo`] object.
     // pub fn export_as_table(&self) {
     //     todo!("`export_as_table` strictly compatible with python version not yet implemented yet");
     // }
 
     #[cfg(feature = "cache-manager-display")]
-    /// Generate a table from the [`HFCacheInfo`] object.
+    /// Generate a table from the [`CacheInfo`] object.
     pub fn export_as_table_comfy(&self) -> String {
         let mut table = Table::new();
 
@@ -802,15 +800,15 @@ impl HFCacheInfo {
         table.to_string()
     }
 
-    /// Scan the entire HF cache-system and return a [`~HFCacheInfo`] structure.
+    /// Scan the entire HF cache-system and return a [`CacheInfo`] structure.
     ///
-    /// Use `scan_cache_dir` in order to programmatically scan your cache-system. The cache
+    /// Use `scan_dir` in order to programmatically scan your cache-system. The cache
     /// will be scanned repo by repo. If a repo is corrupted, a [`~CorruptedCacheException`]
-    /// will be thrown internally but captured and returned in the [`~HFCacheInfo`]
+    /// will be thrown internally but captured and returned in the [`CacheInfo`]
     /// structure. Only valid repos get a proper report.
     ///
     /// TODO: rest of docs
-    pub fn scan_cache_dir(cache_dir: Option<&Path>) -> Result<Self, CorruptedCacheError> {
+    pub fn scan_dir(cache_dir: Option<&Path>) -> Result<Self, CorruptedCacheError> {
         let cache_dir = match cache_dir {
             Some(cache_dir) => cache_dir.to_path_buf(),
             None => get_hub_dir().ok_or(CorruptedCacheError::MissingCacheDir {
@@ -833,7 +831,7 @@ impl HFCacheInfo {
 
             // Use a match statement instead of `?` so we can keep scanning and not
             // fail / return on first error
-            match CachedRepoInfo::scan_cached_repo(cache_dir_entry.path()) {
+            match CachedRepo::scan_cached_repo(cache_dir_entry.path()) {
                 Ok(cached_repo) => {
                     repos.insert(cached_repo);
                 }
@@ -859,7 +857,7 @@ impl HFCacheInfo {
 ///
 /// If the path does not exist, error is logged as a warning and then ignored.
 ///
-/// TODO: move under HFCacheInfo struct? DeleteCacheStrat?
+/// TODO: move under CacheInfo struct? Deletion plan?
 fn try_delete_path(path: &Path, path_type: &str) {
     log::info!("Delete {}: {:?}", path_type, path);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@ use std::path::Path;
 #[cfg(any(feature = "tokio", feature = "ureq"))]
 pub mod api;
 #[cfg(feature = "cache-manager")]
-pub mod cache_manager;
+#[path = "cache_manager/mod.rs"]
+pub mod cache;
 pub mod paths;
 
 /// Configuration constants
@@ -158,16 +159,16 @@ impl Cache {
     #[cfg(feature = "cache-manager")]
     pub(crate) fn validate_cache_dir_path(
         cache_dir: &Path,
-    ) -> Result<(), cache_manager::CorruptedCacheError> {
+    ) -> Result<(), cache::CorruptedCacheError> {
         // TODO: replace with is_dir call since that checks exists too?
         if !cache_dir.exists() {
-            return Err(cache_manager::CorruptedCacheError::MissingCacheDir {
+            return Err(cache::CorruptedCacheError::MissingCacheDir {
                 path: cache_dir.to_path_buf(),
             });
         }
 
         if cache_dir.is_file() {
-            return Err(cache_manager::CorruptedCacheError::CacheDirCantBeFile {
+            return Err(cache::CorruptedCacheError::CacheDirCantBeFile {
                 path: cache_dir.to_path_buf(),
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,17 +5,67 @@
     doc = "Documentation is meant to be compiled with default features (at least ureq)"
 )]
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+
+#[cfg(feature = "cache-manager")]
+use std::path::Path;
 
 /// The actual Api to interact with the hub.
 #[cfg(any(feature = "tokio", feature = "ureq"))]
 pub mod api;
+#[cfg(feature = "cache-manager")]
+pub mod cache_manager;
+pub mod paths;
 
-const HF_HOME: &str = "HF_HOME";
-const HF_HUB_CACHE: &str = "HF_HUB_CACHE";
+/// Configuration constants
+pub(crate) mod constants {
+    /// HF home env var
+    pub(crate) const HF_HOME: &str = "HF_HOME";
+    /// HF hub cache env var
+    pub(crate) const HF_HUB_CACHE: &str = "HF_HUB_CACHE";
+    /// Legacy HF hub cache env var
+    pub(crate) const HUGGINGFACE_HUB_CACHE: &str = "HUGGINGFACE_HUB_CACHE";
+    /// XDG cache home env var
+    pub(crate) const XDG_CACHE_HOME: &str = "XDG_CACHE_HOME";
+    /// HF token path env var
+    pub(crate) const HF_TOKEN_PATH: &str = "HF_TOKEN_PATH";
+    /// HF endpoint env var
+    pub(crate) const HF_ENDPOINT: &str = "HF_ENDPOINT";
+    /// HF endpoint
+    pub(crate) const DEFAULT_ENDPOINT: &str = "https://huggingface.co";
+
+    /// Path separator used in repository names and URLs.
+    pub(crate) const REPO_ID_SEPARATOR: &str = "/";
+    /// Flattened separator used to replace path separators in repo names.
+    pub(crate) const FLAT_SEPARATOR: &str = "--";
+    /// URL-encoded separator.
+    pub(crate) const ENCODED_SEPARATOR: &str = "%2F";
+
+    /// Default cache directory name relative to the user's home directory.
+    pub(crate) const CACHE_DIR: &str = ".cache";
+    /// Top-level Hugging Face directory name within the cache.
+    pub(crate) const TOP_LEVEL_HF_DIR: &str = "huggingface";
+    /// Hub-specific directory name for storing data.
+    pub(crate) const HUB_DIR: &str = "hub";
+    /// Directory name for storing refs.
+    pub(crate) const REFS_DIR: &str = "refs";
+    /// Directory name for storing snapshots.
+    pub(crate) const SNAPSHOTS_DIR: &str = "snapshots";
+    /// Directory name for storing blobs.
+    pub(crate) const BLOBS_DIR: &str = "blobs";
+    #[cfg(feature = "cache-manager")]
+    /// Directory name for locks dir (to manage concurrent file access during downloads)
+    pub(crate) const LOCKS_DIR: &str = ".locks";
+
+    /// Filename for storing authentication token.
+    pub(crate) const TOKEN_FILE: &str = "token";
+
+    /// Default branch name to use when none is specified.
+    pub(crate) const DEFAULT_BRANCH: &str = "main";
+}
 
 /// The type of repo to interact with
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub enum RepoType {
     /// This is a model, usually it consists of weight files and some configuration
     /// files
@@ -26,54 +76,46 @@ pub enum RepoType {
     Space,
 }
 
+impl RepoType {
+    /// Returns the plural form used in API routes, URLs, and cache folder names.
+    pub fn plural(&self) -> &'static str {
+        match self {
+            RepoType::Model => "models",
+            RepoType::Dataset => "datasets",
+            RepoType::Space => "spaces",
+        }
+    }
+}
+
+/// Display is for human-facing output (CLI logs, errors).
+impl std::fmt::Display for RepoType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RepoType::Model => write!(f, "model"),
+            RepoType::Dataset => write!(f, "dataset"),
+            RepoType::Space => write!(f, "space"),
+        }
+    }
+}
+
+/// Allows parsing from CLI args or config strings.
+impl std::str::FromStr for RepoType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "model" | "models" => Ok(RepoType::Model),
+            "dataset" | "datasets" => Ok(RepoType::Dataset),
+            "space" | "spaces" => Ok(RepoType::Space),
+            _ => Err(format!("Invalid repo type: '{}'", s)),
+        }
+    }
+}
+
 /// A local struct used to fetch information from the cache folder.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Cache {
     path: PathBuf,
-}
-
-/// A named cached ref and the commit hash it resolves to.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CacheRef {
-    name: String,
-    commit_hash: String,
-}
-
-impl CacheRef {
-    /// The ref name, relative to the repo's `refs/` directory.
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// The commit hash this ref points to.
-    pub fn commit_hash(&self) -> &str {
-        &self.commit_hash
-    }
-}
-
-/// Parsed metadata for a path inside a cached snapshot.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CachePath {
-    repo: Repo,
-    commit_hash: String,
-    relative_path: String,
-}
-
-impl CachePath {
-    /// The repo this path belongs to.
-    pub fn repo(&self) -> &Repo {
-        &self.repo
-    }
-
-    /// The snapshot commit hash.
-    pub fn commit_hash(&self) -> &str {
-        &self.commit_hash
-    }
-
-    /// The path relative to the snapshot root.
-    pub fn relative_path(&self) -> &str {
-        &self.relative_path
-    }
 }
 
 impl Cache {
@@ -82,25 +124,55 @@ impl Cache {
         Self { path }
     }
 
-    /// Creates cache from environment.
+    /// Creates a `Cache` using the default hub directory, returning `None` if the
+    /// home directory cannot be determined.
     ///
-    /// This honors `HF_HUB_CACHE` first, then `HF_HOME`, and otherwise
-    /// defaults to [`home_dir`]/.cache/huggingface/hub.
+    /// Prefer this over [`Cache::default`] in environments where the home
+    /// directory may not be available.
+    pub fn try_default() -> Option<Self> {
+        paths::default_hub_dir().map(Self::new)
+    }
+
+    /// Creates cache from environment variables using the standard Hugging Face
+    /// cache precedence.
+    ///
+    /// # Panics
+    ///
+    /// Panics if none of the cache-related environment variables are set and
+    /// the home directory cannot be determined (which is needed for the
+    /// fallback `Cache::default` call).
+    /// Use [`Cache::try_from_env`] to avoid this.
     pub fn from_env() -> Self {
-        if let Ok(path) = std::env::var(HF_HUB_CACHE) {
-            let path = path.trim();
-            if !path.is_empty() {
-                return Self::new(path.into());
-            }
+        Self::try_from_env().unwrap_or_default()
+    }
+
+    /// Like [`Cache::from_env`] but returns an Option.
+    ///
+    /// This follows the Python library precedence:
+    /// `HF_HUB_CACHE`, then `HUGGINGFACE_HUB_CACHE`, then `HF_HOME`, then
+    /// `XDG_CACHE_HOME`, then the default home-directory cache location.
+    pub fn try_from_env() -> Option<Self> {
+        paths::get_hub_dir().map(Self::new)
+    }
+
+    #[cfg(feature = "cache-manager")]
+    pub(crate) fn validate_cache_dir_path(
+        cache_dir: &Path,
+    ) -> Result<(), cache_manager::CorruptedCacheError> {
+        // TODO: replace with is_dir call since that checks exists too?
+        if !cache_dir.exists() {
+            return Err(cache_manager::CorruptedCacheError::MissingCacheDir {
+                path: cache_dir.to_path_buf(),
+            });
         }
-        match std::env::var(HF_HOME) {
-            Ok(home) => {
-                let mut path: PathBuf = home.into();
-                path.push("hub");
-                Self::new(path)
-            }
-            Err(_) => Self::default(),
+
+        if cache_dir.is_file() {
+            return Err(cache_manager::CorruptedCacheError::CacheDirCantBeFile {
+                path: cache_dir.to_path_buf(),
+            });
         }
+
+        Ok(())
     }
 
     /// Creates a new cache object location
@@ -108,60 +180,9 @@ impl Cache {
         &self.path
     }
 
-    /// Enumerates cached repos present under this cache root.
-    pub fn repos(&self) -> Result<Vec<CacheRepo>, std::io::Error> {
-        let mut repos = Vec::new();
-        if !self.path.exists() {
-            return Ok(repos);
-        }
-
-        for entry in std::fs::read_dir(&self.path)? {
-            let entry = entry?;
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
-                continue;
-            };
-            let Some(repo) = Repo::from_folder_name(name) else {
-                continue;
-            };
-            repos.push(self.repo(repo));
-        }
-
-        repos.sort_by(|left, right| left.repo.folder_name().cmp(&right.repo.folder_name()));
-        Ok(repos)
-    }
-
-    /// Parses a path inside this cache root and returns its repo and snapshot metadata.
-    pub fn path_info<P: AsRef<Path>>(&self, path: P) -> Option<CachePath> {
-        let relative = path.as_ref().strip_prefix(&self.path).ok()?;
-        let mut components = relative.components();
-        let repo_dir = components.next()?.as_os_str().to_str()?;
-        let repo = Repo::from_folder_name(repo_dir)?;
-        if components.next()?.as_os_str() != "snapshots" {
-            return None;
-        }
-        let commit_hash = components.next()?.as_os_str().to_str()?.to_string();
-        let relative_path = components
-            .map(|component| component.as_os_str().to_str())
-            .collect::<Option<Vec<_>>>()?
-            .join("/");
-        Some(CachePath {
-            repo,
-            commit_hash,
-            relative_path,
-        })
-    }
-
     /// Returns the location of the token file
     pub fn token_path(&self) -> PathBuf {
-        let mut path = self.path.clone();
-        // Remove `"hub"`
-        path.pop();
-        path.push("token");
-        path
+        paths::token_path(&self.path)
     }
 
     /// Returns the token value if it exists in the cache
@@ -224,8 +245,25 @@ impl Cache {
     }
 }
 
+impl Default for Cache {
+    /// Default for Cache
+    ///
+    /// # Panics
+    ///
+    /// Panics if the call to [`paths::get_hub_dir`] returns `None`, likely if
+    /// the user's home directory cannot be determined. This typically
+    /// only happens in very restricted environments or when the HOME environment
+    /// variable is not set.
+    fn default() -> Self {
+        let path = paths::default_hub_dir().expect(
+            "Hub directory cannot be found, possibly because HOME directory cannot be found.",
+        );
+        Self::new(path)
+    }
+}
+
 /// Shorthand for accessing things within a particular repo
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct CacheRepo {
     cache: Cache,
     repo: Repo,
@@ -234,11 +272,6 @@ pub struct CacheRepo {
 impl CacheRepo {
     fn new(cache: Cache, repo: Repo) -> Self {
         Self { cache, repo }
-    }
-
-    /// The repo handle for this cached repo.
-    pub fn repo(&self) -> &Repo {
-        &self.repo
     }
 
     /// This will get the location of the file within the cache for the remote
@@ -256,28 +289,15 @@ impl CacheRepo {
     }
 
     fn path(&self) -> PathBuf {
-        let mut ref_path = self.cache.path.clone();
-        ref_path.push(self.repo.folder_name());
-        ref_path
+        let mut cache_repo_path = self.cache.path.clone();
+        cache_repo_path.push(self.repo.folder_name());
+        cache_repo_path
     }
 
     fn ref_path(&self) -> PathBuf {
-        let mut ref_path = self.path();
-        ref_path.push("refs");
+        let mut ref_path = paths::refs_dir(&self.path());
         ref_path.push(self.repo.revision());
         ref_path
-    }
-
-    /// Lists all cached refs for this repo.
-    pub fn refs(&self) -> Result<Vec<CacheRef>, std::io::Error> {
-        let refs_dir = self.path().join("refs");
-        let mut refs = Vec::new();
-        if !refs_dir.is_dir() {
-            return Ok(refs);
-        }
-        collect_ref_files(&refs_dir, &refs_dir, &mut refs)?;
-        refs.sort_by(|left, right| left.name.cmp(&right.name));
-        Ok(refs)
     }
 
     /// Creates a reference in the cache directory that points branches to the correct
@@ -298,8 +318,7 @@ impl CacheRepo {
     /// Get the path of the blob with the given etag.
     #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn blob_path(&self, etag: &str) -> PathBuf {
-        let mut blob_path = self.path();
-        blob_path.push("blobs");
+        let mut blob_path = paths::blobs_dir(&self.path());
         blob_path.push(etag);
         blob_path
     }
@@ -308,37 +327,14 @@ impl CacheRepo {
     ///
     /// This path contains symlink pointers to the files for this commit.
     pub fn pointer_path(&self, commit_hash: &str) -> PathBuf {
-        let mut pointer_path = self.path();
-        pointer_path.push("snapshots");
+        let mut pointer_path = paths::snapshots_dir(&self.path());
         pointer_path.push(commit_hash);
         pointer_path
-    }
-
-    /// Lists files relative to the snapshot root for a cached commit.
-    pub fn files(&self, commit_hash: &str) -> Result<Vec<String>, std::io::Error> {
-        let root = self.pointer_path(commit_hash);
-        let mut files = Vec::new();
-        if !root.is_dir() {
-            return Ok(files);
-        }
-        collect_snapshot_files(&root, &root, &mut files)?;
-        files.sort();
-        Ok(files)
-    }
-}
-
-impl Default for Cache {
-    fn default() -> Self {
-        let mut path = dirs::home_dir().expect("Cache directory cannot be found");
-        path.push(".cache");
-        path.push("huggingface");
-        path.push("hub");
-        Self::new(path)
     }
 }
 
 /// The representation of a repo on the hub.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Repo {
     repo_id: String,
     repo_type: RepoType,
@@ -348,7 +344,7 @@ pub struct Repo {
 impl Repo {
     /// Repo with the default branch ("main").
     pub fn new(repo_id: String, repo_type: RepoType) -> Self {
-        Self::with_revision(repo_id, repo_type, "main".to_string())
+        Self::with_revision(repo_id, repo_type, constants::DEFAULT_BRANCH.to_string())
     }
 
     /// fully qualified Repo
@@ -358,19 +354,6 @@ impl Repo {
             repo_type,
             revision,
         }
-    }
-
-    fn from_folder_name(name: &str) -> Option<Self> {
-        let (repo_type, repo_id) = if let Some(repo_id) = name.strip_prefix("models--") {
-            (RepoType::Model, repo_id)
-        } else if let Some(repo_id) = name.strip_prefix("datasets--") {
-            (RepoType::Dataset, repo_id)
-        } else if let Some(repo_id) = name.strip_prefix("spaces--") {
-            (RepoType::Space, repo_id)
-        } else {
-            return None;
-        };
-        Some(Self::new(repo_id.replace("--", "/"), repo_type))
     }
 
     /// Shortcut for [`Repo::new`] with [`RepoType::Model`]
@@ -388,14 +371,9 @@ impl Repo {
         Self::new(repo_id, RepoType::Space)
     }
 
-    /// The normalized folder nameof the repo within the cache directory
+    /// The flattened folder name of the repo within the cache directory
     pub fn folder_name(&self) -> String {
-        let prefix = match self.repo_type {
-            RepoType::Model => "models",
-            RepoType::Dataset => "datasets",
-            RepoType::Space => "spaces",
-        };
-        format!("{prefix}--{}", self.repo_id).replace('/', "--")
+        paths::flattened_repo_folder_name(&self.repo_type, &self.repo_id)
     }
 
     /// The revision
@@ -403,109 +381,30 @@ impl Repo {
         &self.revision
     }
 
-    /// The repo id.
-    pub fn repo_id(&self) -> &str {
-        &self.repo_id
-    }
-
-    /// The repo type.
-    pub fn repo_type(&self) -> RepoType {
-        self.repo_type
-    }
-
     /// The actual URL part of the repo
     #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn url(&self) -> String {
         match self.repo_type {
             RepoType::Model => self.repo_id.to_string(),
-            RepoType::Dataset => {
-                format!("datasets/{}", self.repo_id)
-            }
-            RepoType::Space => {
-                format!("spaces/{}", self.repo_id)
-            }
+            _ => format!("{}/{}", self.repo_type.plural(), self.repo_id),
         }
     }
 
     /// Revision needs to be url escaped before being used in a URL
     #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn url_revision(&self) -> String {
-        self.revision.replace('/', "%2F")
+        paths::encode_separator(&self.revision)
     }
 
     /// Used to compute the repo's url part when accessing the metadata of the repo
     #[cfg(any(feature = "tokio", feature = "ureq"))]
     pub fn api_url(&self) -> String {
-        let prefix = match self.repo_type {
-            RepoType::Model => "models",
-            RepoType::Dataset => "datasets",
-            RepoType::Space => "spaces",
-        };
-        format!("{prefix}/{}/revision/{}", self.repo_id, self.url_revision())
-    }
-}
-
-fn collect_ref_files(
-    root: &Path,
-    dir: &Path,
-    refs: &mut Vec<CacheRef>,
-) -> Result<(), std::io::Error> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let file_type = entry.file_type()?;
-        if file_type.is_dir() {
-            collect_ref_files(root, &path, refs)?;
-            continue;
-        }
-        if !file_type.is_file() {
-            continue;
-        }
-        let name = path
-            .strip_prefix(root)
-            .unwrap_or(&path)
-            .to_string_lossy()
-            .replace('\\', "/");
-        let Some(commit_hash) = read_trimmed_file(&path)? else {
-            continue;
-        };
-        refs.push(CacheRef { name, commit_hash });
-    }
-    Ok(())
-}
-
-fn collect_snapshot_files(
-    root: &Path,
-    dir: &Path,
-    files: &mut Vec<String>,
-) -> Result<(), std::io::Error> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let file_type = entry.file_type()?;
-        if file_type.is_dir() {
-            collect_snapshot_files(root, &path, files)?;
-            continue;
-        }
-        if !file_type.is_file() && !file_type.is_symlink() {
-            continue;
-        }
-        let file = path
-            .strip_prefix(root)
-            .unwrap_or(&path)
-            .to_string_lossy()
-            .replace('\\', "/");
-        files.push(file);
-    }
-    Ok(())
-}
-
-fn read_trimmed_file(path: &Path) -> Result<Option<String>, std::io::Error> {
-    let value = std::fs::read_to_string(path)?.trim().to_string();
-    if value.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(value))
+        format!(
+            "{}/{}/revision/{}",
+            self.repo_type.plural(),
+            self.repo_id,
+            self.url_revision()
+        )
     }
 }
 
@@ -513,6 +412,7 @@ fn read_trimmed_file(path: &Path) -> Result<Option<String>, std::io::Error> {
 mod tests {
     use super::*;
     use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
@@ -581,12 +481,19 @@ mod tests {
     fn token_path() {
         let cache = Cache::from_env();
         let token_path = cache.token_path().to_str().unwrap().to_string();
-        if let Ok(hf_hub_cache) = std::env::var(HF_HUB_CACHE) {
+        if let Ok(hf_token_path) = std::env::var(constants::HF_TOKEN_PATH) {
+            assert_eq!(token_path, hf_token_path);
+        } else if let Ok(hf_hub_cache) = std::env::var(constants::HF_HUB_CACHE) {
             let mut expected = PathBuf::from(hf_hub_cache);
             expected.pop();
-            expected.push("token");
+            expected.push(constants::TOKEN_FILE);
             assert_eq!(token_path, expected.to_string_lossy());
-        } else if let Ok(hf_home) = std::env::var(HF_HOME) {
+        } else if let Ok(huggingface_hub_cache) = std::env::var(constants::HUGGINGFACE_HUB_CACHE) {
+            let mut expected = PathBuf::from(huggingface_hub_cache);
+            expected.pop();
+            expected.push(constants::TOKEN_FILE);
+            assert_eq!(token_path, expected.to_string_lossy());
+        } else if let Ok(hf_home) = std::env::var(constants::HF_HOME) {
             assert_eq!(token_path, format!("{hf_home}/token"));
         } else {
             let n = "huggingface/token".len();
@@ -599,12 +506,19 @@ mod tests {
     fn token_path() {
         let cache = Cache::from_env();
         let token_path = cache.token_path().to_str().unwrap().to_string();
-        if let Ok(hf_hub_cache) = std::env::var(HF_HUB_CACHE) {
+        if let Ok(hf_token_path) = std::env::var(constants::HF_TOKEN_PATH) {
+            assert_eq!(token_path, hf_token_path);
+        } else if let Ok(hf_hub_cache) = std::env::var(constants::HF_HUB_CACHE) {
             let mut expected = PathBuf::from(hf_hub_cache);
             expected.pop();
-            expected.push("token");
+            expected.push(constants::TOKEN_FILE);
             assert_eq!(token_path, expected.to_string_lossy());
-        } else if let Ok(hf_home) = std::env::var(HF_HOME) {
+        } else if let Ok(huggingface_hub_cache) = std::env::var(constants::HUGGINGFACE_HUB_CACHE) {
+            let mut expected = PathBuf::from(huggingface_hub_cache);
+            expected.pop();
+            expected.push(constants::TOKEN_FILE);
+            assert_eq!(token_path, expected.to_string_lossy());
+        } else if let Ok(hf_home) = std::env::var(constants::HF_HOME) {
             assert_eq!(token_path, format!("{hf_home}\\token"));
         } else {
             let n = "huggingface/token".len();
@@ -613,121 +527,115 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn from_env_prefers_hf_hub_cache() {
         let tmp = TestDir::new();
-        let prev_hub_cache = std::env::var_os(HF_HUB_CACHE);
-        let prev_hf_home = std::env::var_os(HF_HOME);
-        std::env::set_var(HF_HUB_CACHE, tmp.path());
-        std::env::set_var(HF_HOME, "/tmp/ignored-hf-home");
+        let prev_hf_hub_cache = std::env::var_os(constants::HF_HUB_CACHE);
+        let prev_legacy_hub_cache = std::env::var_os(constants::HUGGINGFACE_HUB_CACHE);
+        let prev_hf_home = std::env::var_os(constants::HF_HOME);
+        let prev_xdg_cache_home = std::env::var_os(constants::XDG_CACHE_HOME);
+
+        std::env::set_var(constants::HF_HUB_CACHE, tmp.path().join("hub-cache"));
+        std::env::set_var(
+            constants::HUGGINGFACE_HUB_CACHE,
+            tmp.path().join("legacy-cache"),
+        );
+        std::env::set_var(constants::HF_HOME, tmp.path().join("hf-home"));
+        std::env::set_var(constants::XDG_CACHE_HOME, tmp.path().join("xdg-cache"));
 
         let cache = Cache::from_env();
-        assert_eq!(cache.path(), &tmp.path().to_path_buf());
+        assert_eq!(cache.path(), &tmp.path().join("hub-cache"));
 
-        restore_env(HF_HUB_CACHE, prev_hub_cache);
-        restore_env(HF_HOME, prev_hf_home);
+        restore_env(constants::HF_HUB_CACHE, prev_hf_hub_cache);
+        restore_env(constants::HUGGINGFACE_HUB_CACHE, prev_legacy_hub_cache);
+        restore_env(constants::HF_HOME, prev_hf_home);
+        restore_env(constants::XDG_CACHE_HOME, prev_xdg_cache_home);
     }
 
     #[test]
-    fn repos_lists_cached_repos() {
+    #[cfg(not(target_os = "windows"))]
+    fn from_env_uses_legacy_hub_cache() {
         let tmp = TestDir::new();
-        std::fs::create_dir_all(tmp.path().join("models--gpt2")).unwrap();
-        std::fs::create_dir_all(tmp.path().join("datasets--org--corpus")).unwrap();
-        std::fs::create_dir_all(tmp.path().join("spaces--org--demo")).unwrap();
-        std::fs::create_dir_all(tmp.path().join("not-a-repo")).unwrap();
+        let prev_hf_hub_cache = std::env::var_os(constants::HF_HUB_CACHE);
+        let prev_legacy_hub_cache = std::env::var_os(constants::HUGGINGFACE_HUB_CACHE);
+        let prev_hf_home = std::env::var_os(constants::HF_HOME);
+        let prev_xdg_cache_home = std::env::var_os(constants::XDG_CACHE_HOME);
 
-        let cache = Cache::new(tmp.path().to_path_buf());
-        let repos = cache.repos().unwrap();
-        let names: Vec<_> = repos
-            .iter()
-            .map(|repo| {
-                (
-                    repo.repo().repo_type(),
-                    repo.repo().repo_id().to_string(),
-                    repo.repo().revision().to_string(),
-                )
-            })
-            .collect();
-
-        assert_eq!(
-            names,
-            vec![
-                (
-                    RepoType::Dataset,
-                    "org/corpus".to_string(),
-                    "main".to_string()
-                ),
-                (RepoType::Model, "gpt2".to_string(), "main".to_string()),
-                (RepoType::Space, "org/demo".to_string(), "main".to_string()),
-            ]
+        std::env::remove_var(constants::HF_HUB_CACHE);
+        std::env::set_var(
+            constants::HUGGINGFACE_HUB_CACHE,
+            tmp.path().join("legacy-cache"),
         );
+        std::env::set_var(constants::HF_HOME, tmp.path().join("hf-home"));
+        std::env::set_var(constants::XDG_CACHE_HOME, tmp.path().join("xdg-cache"));
+
+        let cache = Cache::from_env();
+        assert_eq!(cache.path(), &tmp.path().join("legacy-cache"));
+
+        restore_env(constants::HF_HUB_CACHE, prev_hf_hub_cache);
+        restore_env(constants::HUGGINGFACE_HUB_CACHE, prev_legacy_hub_cache);
+        restore_env(constants::HF_HOME, prev_hf_home);
+        restore_env(constants::XDG_CACHE_HOME, prev_xdg_cache_home);
     }
 
     #[test]
-    fn refs_list_nested_ref_names() {
+    #[cfg(not(target_os = "windows"))]
+    fn from_env_uses_xdg_cache_home() {
         let tmp = TestDir::new();
-        let cache = Cache::new(tmp.path().to_path_buf());
-        let repo = cache.repo(Repo::model("org/model".to_string()));
-        let main = repo.path().join("refs").join("main");
-        std::fs::create_dir_all(main.parent().unwrap()).unwrap();
-        std::fs::write(&main, "commit-main\n").unwrap();
-        let pr = repo.path().join("refs").join("refs").join("pr").join("1");
-        std::fs::create_dir_all(pr.parent().unwrap()).unwrap();
-        std::fs::write(&pr, "commit-pr\n").unwrap();
+        let prev_hf_hub_cache = std::env::var_os(constants::HF_HUB_CACHE);
+        let prev_legacy_hub_cache = std::env::var_os(constants::HUGGINGFACE_HUB_CACHE);
+        let prev_hf_home = std::env::var_os(constants::HF_HOME);
+        let prev_xdg_cache_home = std::env::var_os(constants::XDG_CACHE_HOME);
 
-        let refs = repo.refs().unwrap();
-        let refs: Vec<_> = refs
-            .into_iter()
-            .map(|cache_ref| {
-                (
-                    cache_ref.name().to_string(),
-                    cache_ref.commit_hash().to_string(),
-                )
-            })
-            .collect();
+        std::env::remove_var(constants::HF_HUB_CACHE);
+        std::env::remove_var(constants::HUGGINGFACE_HUB_CACHE);
+        std::env::remove_var(constants::HF_HOME);
+        std::env::set_var(constants::XDG_CACHE_HOME, tmp.path().join("xdg-cache"));
 
+        let cache = Cache::from_env();
         assert_eq!(
-            refs,
-            vec![
-                ("main".to_string(), "commit-main".to_string()),
-                ("refs/pr/1".to_string(), "commit-pr".to_string()),
-            ]
+            cache.path(),
+            &tmp.path().join("xdg-cache").join("huggingface/hub")
         );
+
+        restore_env(constants::HF_HUB_CACHE, prev_hf_hub_cache);
+        restore_env(constants::HUGGINGFACE_HUB_CACHE, prev_legacy_hub_cache);
+        restore_env(constants::HF_HOME, prev_hf_home);
+        restore_env(constants::XDG_CACHE_HOME, prev_xdg_cache_home);
     }
 
     #[test]
-    fn files_list_snapshot_contents() {
+    #[cfg(not(target_os = "windows"))]
+    fn from_env_expands_env_vars_in_hf_hub_cache() {
         let tmp = TestDir::new();
-        let cache = Cache::new(tmp.path().to_path_buf());
-        let repo = cache.repo(Repo::model("org/model".to_string()));
-        let root = repo.pointer_path("commit-hash");
-        std::fs::create_dir_all(root.join("nested")).unwrap();
-        std::fs::write(root.join("config.json"), "{}").unwrap();
-        std::fs::write(root.join("nested").join("model.gguf"), "x").unwrap();
+        let prev_hf_hub_cache = std::env::var_os(constants::HF_HUB_CACHE);
+        let prev_test_root = std::env::var_os("HF_HUB_TEST_ROOT");
 
-        let files = repo.files("commit-hash").unwrap();
-        assert_eq!(
-            files,
-            vec!["config.json".to_string(), "nested/model.gguf".to_string()]
-        );
+        std::env::set_var("HF_HUB_TEST_ROOT", tmp.path());
+        std::env::set_var(constants::HF_HUB_CACHE, "${HF_HUB_TEST_ROOT}/hub-cache");
+
+        let cache = Cache::from_env();
+        assert_eq!(cache.path(), &tmp.path().join("hub-cache"));
+
+        restore_env(constants::HF_HUB_CACHE, prev_hf_hub_cache);
+        restore_env("HF_HUB_TEST_ROOT", prev_test_root);
     }
 
     #[test]
-    fn path_info_parses_snapshot_paths() {
+    #[cfg(not(target_os = "windows"))]
+    fn token_path_prefers_hf_token_path() {
         let tmp = TestDir::new();
-        let cache = Cache::new(tmp.path().to_path_buf());
-        let path = tmp
-            .path()
-            .join("models--org--model")
-            .join("snapshots")
-            .join("abc123")
-            .join("weights")
-            .join("model.gguf");
+        let prev_hf_token_path = std::env::var_os(constants::HF_TOKEN_PATH);
+        let prev_hf_hub_cache = std::env::var_os(constants::HF_HUB_CACHE);
 
-        let info = cache.path_info(&path).unwrap();
-        assert_eq!(info.repo().repo_type(), RepoType::Model);
-        assert_eq!(info.repo().repo_id(), "org/model");
-        assert_eq!(info.commit_hash(), "abc123");
-        assert_eq!(info.relative_path(), "weights/model.gguf");
+        std::env::set_var(constants::HF_TOKEN_PATH, tmp.path().join("custom-token"));
+        std::env::set_var(constants::HF_HUB_CACHE, tmp.path().join("hub-cache"));
+
+        let cache = Cache::from_env();
+        assert_eq!(cache.token_path(), tmp.path().join("custom-token"));
+
+        restore_env(constants::HF_TOKEN_PATH, prev_hf_token_path);
+        restore_env(constants::HF_HUB_CACHE, prev_hf_hub_cache);
     }
 
     fn restore_env(key: &str, value: Option<OsString>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,16 +5,17 @@
     doc = "Documentation is meant to be compiled with default features (at least ureq)"
 )]
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// The actual Api to interact with the hub.
 #[cfg(any(feature = "tokio", feature = "ureq"))]
 pub mod api;
 
 const HF_HOME: &str = "HF_HOME";
+const HF_HUB_CACHE: &str = "HF_HUB_CACHE";
 
 /// The type of repo to interact with
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum RepoType {
     /// This is a model, usually it consists of weight files and some configuration
     /// files
@@ -26,9 +27,53 @@ pub enum RepoType {
 }
 
 /// A local struct used to fetch information from the cache folder.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Cache {
     path: PathBuf,
+}
+
+/// A named cached ref and the commit hash it resolves to.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CacheRef {
+    name: String,
+    commit_hash: String,
+}
+
+impl CacheRef {
+    /// The ref name, relative to the repo's `refs/` directory.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The commit hash this ref points to.
+    pub fn commit_hash(&self) -> &str {
+        &self.commit_hash
+    }
+}
+
+/// Parsed metadata for a path inside a cached snapshot.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CachePath {
+    repo: Repo,
+    commit_hash: String,
+    relative_path: String,
+}
+
+impl CachePath {
+    /// The repo this path belongs to.
+    pub fn repo(&self) -> &Repo {
+        &self.repo
+    }
+
+    /// The snapshot commit hash.
+    pub fn commit_hash(&self) -> &str {
+        &self.commit_hash
+    }
+
+    /// The path relative to the snapshot root.
+    pub fn relative_path(&self) -> &str {
+        &self.relative_path
+    }
 }
 
 impl Cache {
@@ -37,9 +82,17 @@ impl Cache {
         Self { path }
     }
 
-    /// Creates cache from environment variable HF_HOME (if defined) otherwise
-    /// defaults to [`home_dir`]/.cache/huggingface/
+    /// Creates cache from environment.
+    ///
+    /// This honors `HF_HUB_CACHE` first, then `HF_HOME`, and otherwise
+    /// defaults to [`home_dir`]/.cache/huggingface/hub.
     pub fn from_env() -> Self {
+        if let Ok(path) = std::env::var(HF_HUB_CACHE) {
+            let path = path.trim();
+            if !path.is_empty() {
+                return Self::new(path.into());
+            }
+        }
         match std::env::var(HF_HOME) {
             Ok(home) => {
                 let mut path: PathBuf = home.into();
@@ -53,6 +106,53 @@ impl Cache {
     /// Creates a new cache object location
     pub fn path(&self) -> &PathBuf {
         &self.path
+    }
+
+    /// Enumerates cached repos present under this cache root.
+    pub fn repos(&self) -> Result<Vec<CacheRepo>, std::io::Error> {
+        let mut repos = Vec::new();
+        if !self.path.exists() {
+            return Ok(repos);
+        }
+
+        for entry in std::fs::read_dir(&self.path)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            let Some(repo) = Repo::from_folder_name(name) else {
+                continue;
+            };
+            repos.push(self.repo(repo));
+        }
+
+        repos.sort_by(|left, right| left.repo.folder_name().cmp(&right.repo.folder_name()));
+        Ok(repos)
+    }
+
+    /// Parses a path inside this cache root and returns its repo and snapshot metadata.
+    pub fn path_info<P: AsRef<Path>>(&self, path: P) -> Option<CachePath> {
+        let relative = path.as_ref().strip_prefix(&self.path).ok()?;
+        let mut components = relative.components();
+        let repo_dir = components.next()?.as_os_str().to_str()?;
+        let repo = Repo::from_folder_name(repo_dir)?;
+        if components.next()?.as_os_str() != "snapshots" {
+            return None;
+        }
+        let commit_hash = components.next()?.as_os_str().to_str()?.to_string();
+        let relative_path = components
+            .map(|component| component.as_os_str().to_str())
+            .collect::<Option<Vec<_>>>()?
+            .join("/");
+        Some(CachePath {
+            repo,
+            commit_hash,
+            relative_path,
+        })
     }
 
     /// Returns the location of the token file
@@ -125,7 +225,7 @@ impl Cache {
 }
 
 /// Shorthand for accessing things within a particular repo
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CacheRepo {
     cache: Cache,
     repo: Repo,
@@ -134,6 +234,11 @@ pub struct CacheRepo {
 impl CacheRepo {
     fn new(cache: Cache, repo: Repo) -> Self {
         Self { cache, repo }
+    }
+
+    /// The repo handle for this cached repo.
+    pub fn repo(&self) -> &Repo {
+        &self.repo
     }
 
     /// This will get the location of the file within the cache for the remote
@@ -163,6 +268,18 @@ impl CacheRepo {
         ref_path
     }
 
+    /// Lists all cached refs for this repo.
+    pub fn refs(&self) -> Result<Vec<CacheRef>, std::io::Error> {
+        let refs_dir = self.path().join("refs");
+        let mut refs = Vec::new();
+        if !refs_dir.is_dir() {
+            return Ok(refs);
+        }
+        collect_ref_files(&refs_dir, &refs_dir, &mut refs)?;
+        refs.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(refs)
+    }
+
     /// Creates a reference in the cache directory that points branches to the correct
     /// commits within the blobs.
     pub fn create_ref(&self, commit_hash: &str) -> Result<(), std::io::Error> {
@@ -187,7 +304,6 @@ impl CacheRepo {
         blob_path
     }
 
-
     /// Get the path of the snapshot with the given commit hash.
     ///
     /// This path contains symlink pointers to the files for this commit.
@@ -196,6 +312,18 @@ impl CacheRepo {
         pointer_path.push("snapshots");
         pointer_path.push(commit_hash);
         pointer_path
+    }
+
+    /// Lists files relative to the snapshot root for a cached commit.
+    pub fn files(&self, commit_hash: &str) -> Result<Vec<String>, std::io::Error> {
+        let root = self.pointer_path(commit_hash);
+        let mut files = Vec::new();
+        if !root.is_dir() {
+            return Ok(files);
+        }
+        collect_snapshot_files(&root, &root, &mut files)?;
+        files.sort();
+        Ok(files)
     }
 }
 
@@ -210,7 +338,7 @@ impl Default for Cache {
 }
 
 /// The representation of a repo on the hub.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Repo {
     repo_id: String,
     repo_type: RepoType,
@@ -230,6 +358,19 @@ impl Repo {
             repo_type,
             revision,
         }
+    }
+
+    fn from_folder_name(name: &str) -> Option<Self> {
+        let (repo_type, repo_id) = if let Some(repo_id) = name.strip_prefix("models--") {
+            (RepoType::Model, repo_id)
+        } else if let Some(repo_id) = name.strip_prefix("datasets--") {
+            (RepoType::Dataset, repo_id)
+        } else if let Some(repo_id) = name.strip_prefix("spaces--") {
+            (RepoType::Space, repo_id)
+        } else {
+            return None;
+        };
+        Some(Self::new(repo_id.replace("--", "/"), repo_type))
     }
 
     /// Shortcut for [`Repo::new`] with [`RepoType::Model`]
@@ -260,6 +401,16 @@ impl Repo {
     /// The revision
     pub fn revision(&self) -> &str {
         &self.revision
+    }
+
+    /// The repo id.
+    pub fn repo_id(&self) -> &str {
+        &self.repo_id
+    }
+
+    /// The repo type.
+    pub fn repo_type(&self) -> RepoType {
+        self.repo_type
     }
 
     /// The actual URL part of the repo
@@ -294,9 +445,101 @@ impl Repo {
     }
 }
 
+fn collect_ref_files(
+    root: &Path,
+    dir: &Path,
+    refs: &mut Vec<CacheRef>,
+) -> Result<(), std::io::Error> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_ref_files(root, &path, refs)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let name = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        let Some(commit_hash) = read_trimmed_file(&path)? else {
+            continue;
+        };
+        refs.push(CacheRef { name, commit_hash });
+    }
+    Ok(())
+}
+
+fn collect_snapshot_files(
+    root: &Path,
+    dir: &Path,
+    files: &mut Vec<String>,
+) -> Result<(), std::io::Error> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_snapshot_files(root, &path, files)?;
+            continue;
+        }
+        if !file_type.is_file() && !file_type.is_symlink() {
+            continue;
+        }
+        let file = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        files.push(file);
+    }
+    Ok(())
+}
+
+fn read_trimmed_file(path: &Path) -> Result<Option<String>, std::io::Error> {
+    let value = std::fs::read_to_string(path)?.trim().to_string();
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new() -> Self {
+            let mut path = std::env::temp_dir();
+            let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+            path.push(format!("hf-hub-tests-{}-{id}", std::process::id()));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
 
     /// Internal macro used to show cleaners errors
     /// on the payloads received from the hub.
@@ -338,7 +581,12 @@ mod tests {
     fn token_path() {
         let cache = Cache::from_env();
         let token_path = cache.token_path().to_str().unwrap().to_string();
-        if let Ok(hf_home) = std::env::var(HF_HOME) {
+        if let Ok(hf_hub_cache) = std::env::var(HF_HUB_CACHE) {
+            let mut expected = PathBuf::from(hf_hub_cache);
+            expected.pop();
+            expected.push("token");
+            assert_eq!(token_path, expected.to_string_lossy());
+        } else if let Ok(hf_home) = std::env::var(HF_HOME) {
             assert_eq!(token_path, format!("{hf_home}/token"));
         } else {
             let n = "huggingface/token".len();
@@ -351,11 +599,141 @@ mod tests {
     fn token_path() {
         let cache = Cache::from_env();
         let token_path = cache.token_path().to_str().unwrap().to_string();
-        if let Ok(hf_home) = std::env::var(HF_HOME) {
+        if let Ok(hf_hub_cache) = std::env::var(HF_HUB_CACHE) {
+            let mut expected = PathBuf::from(hf_hub_cache);
+            expected.pop();
+            expected.push("token");
+            assert_eq!(token_path, expected.to_string_lossy());
+        } else if let Ok(hf_home) = std::env::var(HF_HOME) {
             assert_eq!(token_path, format!("{hf_home}\\token"));
         } else {
             let n = "huggingface/token".len();
             assert_eq!(&token_path[token_path.len() - n..], "huggingface\\token");
+        }
+    }
+
+    #[test]
+    fn from_env_prefers_hf_hub_cache() {
+        let tmp = TestDir::new();
+        let prev_hub_cache = std::env::var_os(HF_HUB_CACHE);
+        let prev_hf_home = std::env::var_os(HF_HOME);
+        std::env::set_var(HF_HUB_CACHE, tmp.path());
+        std::env::set_var(HF_HOME, "/tmp/ignored-hf-home");
+
+        let cache = Cache::from_env();
+        assert_eq!(cache.path(), &tmp.path().to_path_buf());
+
+        restore_env(HF_HUB_CACHE, prev_hub_cache);
+        restore_env(HF_HOME, prev_hf_home);
+    }
+
+    #[test]
+    fn repos_lists_cached_repos() {
+        let tmp = TestDir::new();
+        std::fs::create_dir_all(tmp.path().join("models--gpt2")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("datasets--org--corpus")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("spaces--org--demo")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("not-a-repo")).unwrap();
+
+        let cache = Cache::new(tmp.path().to_path_buf());
+        let repos = cache.repos().unwrap();
+        let names: Vec<_> = repos
+            .iter()
+            .map(|repo| {
+                (
+                    repo.repo().repo_type(),
+                    repo.repo().repo_id().to_string(),
+                    repo.repo().revision().to_string(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            names,
+            vec![
+                (
+                    RepoType::Dataset,
+                    "org/corpus".to_string(),
+                    "main".to_string()
+                ),
+                (RepoType::Model, "gpt2".to_string(), "main".to_string()),
+                (RepoType::Space, "org/demo".to_string(), "main".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn refs_list_nested_ref_names() {
+        let tmp = TestDir::new();
+        let cache = Cache::new(tmp.path().to_path_buf());
+        let repo = cache.repo(Repo::model("org/model".to_string()));
+        let main = repo.path().join("refs").join("main");
+        std::fs::create_dir_all(main.parent().unwrap()).unwrap();
+        std::fs::write(&main, "commit-main\n").unwrap();
+        let pr = repo.path().join("refs").join("refs").join("pr").join("1");
+        std::fs::create_dir_all(pr.parent().unwrap()).unwrap();
+        std::fs::write(&pr, "commit-pr\n").unwrap();
+
+        let refs = repo.refs().unwrap();
+        let refs: Vec<_> = refs
+            .into_iter()
+            .map(|cache_ref| {
+                (
+                    cache_ref.name().to_string(),
+                    cache_ref.commit_hash().to_string(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            refs,
+            vec![
+                ("main".to_string(), "commit-main".to_string()),
+                ("refs/pr/1".to_string(), "commit-pr".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn files_list_snapshot_contents() {
+        let tmp = TestDir::new();
+        let cache = Cache::new(tmp.path().to_path_buf());
+        let repo = cache.repo(Repo::model("org/model".to_string()));
+        let root = repo.pointer_path("commit-hash");
+        std::fs::create_dir_all(root.join("nested")).unwrap();
+        std::fs::write(root.join("config.json"), "{}").unwrap();
+        std::fs::write(root.join("nested").join("model.gguf"), "x").unwrap();
+
+        let files = repo.files("commit-hash").unwrap();
+        assert_eq!(
+            files,
+            vec!["config.json".to_string(), "nested/model.gguf".to_string()]
+        );
+    }
+
+    #[test]
+    fn path_info_parses_snapshot_paths() {
+        let tmp = TestDir::new();
+        let cache = Cache::new(tmp.path().to_path_buf());
+        let path = tmp
+            .path()
+            .join("models--org--model")
+            .join("snapshots")
+            .join("abc123")
+            .join("weights")
+            .join("model.gguf");
+
+        let info = cache.path_info(&path).unwrap();
+        assert_eq!(info.repo().repo_type(), RepoType::Model);
+        assert_eq!(info.repo().repo_id(), "org/model");
+        assert_eq!(info.commit_hash(), "abc123");
+        assert_eq!(info.relative_path(), "weights/model.gguf");
+    }
+
+    fn restore_env(key: &str, value: Option<OsString>) {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
         }
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,243 @@
+//! General path utilities.
+//!
+//! This module provides helper functions for common operations like path
+//! construction and character encoding / normalization.
+//!
+//! These utilities are used internally by the library but are also exposed
+//! for use by other crates that need similar functionality.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+use crate::{constants, RepoType};
+
+/// Returns the default user cache directory path.
+///
+/// This follows platform conventions for cache storage:
+/// - On Unix-like systems: `~/.cache`
+/// - On Windows: `%USERPROFILE%\.cache`
+/// - On macOS: `~/.cache` (not following macOS conventions for consistency)
+pub(crate) fn default_cache_dir() -> Option<PathBuf> {
+    let mut path = dirs::home_dir()?;
+    path.push(constants::CACHE_DIR);
+    Some(path)
+}
+
+/// Returns the default top-level Hugging Face directory within the cache.
+///
+/// The path follows the pattern: `{cache_dir}/huggingface`
+pub(crate) fn default_hf_home() -> Option<PathBuf> {
+    let mut path = default_cache_dir()?;
+    path.push(constants::TOP_LEVEL_HF_DIR);
+    Some(path)
+}
+
+/// Returns the default Hugging Face Hub directory for repository storage.
+pub(crate) fn default_hub_dir() -> Option<PathBuf> {
+    let mut path = default_hf_home()?;
+    path.push(constants::HUB_DIR);
+    Some(path)
+}
+
+/// Returns the resolved Hugging Face home directory using Python-compatible precedence.
+pub(crate) fn get_hf_home() -> Option<PathBuf> {
+    if let Some(path) = env_path(constants::HF_HOME) {
+        return Some(path);
+    }
+
+    let mut path = if let Some(path) = env_path(constants::XDG_CACHE_HOME) {
+        path
+    } else {
+        default_cache_dir()?
+    };
+    path.push(constants::TOP_LEVEL_HF_DIR);
+    Some(path)
+}
+
+/// Returns the Hugging Face Hub directory for repository storage.
+///
+/// This follows the Python library precedence:
+/// `HF_HUB_CACHE`, then `HUGGINGFACE_HUB_CACHE`, then `HF_HOME`, then
+/// `XDG_CACHE_HOME`, then the default home-directory cache location.
+///
+/// # Examples
+///
+/// ```rust
+/// use hf_hub::paths::get_hub_dir;
+///
+/// let hub_dir = get_hub_dir().unwrap();
+/// assert!(hub_dir.ends_with(std::path::Path::new("huggingface/hub")));
+/// ```
+pub fn get_hub_dir() -> Option<PathBuf> {
+    if let Some(path) = env_path(constants::HF_HUB_CACHE) {
+        return Some(path);
+    }
+    if let Some(path) = env_path(constants::HUGGINGFACE_HUB_CACHE) {
+        return Some(path);
+    }
+    let mut path = get_hf_home()?;
+    path.push(constants::HUB_DIR);
+    Some(path)
+}
+
+#[cfg(feature = "cache-manager")]
+/// Checks if a directory entry corresponds to the `.locks` directory.
+pub(crate) fn is_locks_dir(entry: &walkdir::DirEntry) -> bool {
+    entry.file_name() == constants::LOCKS_DIR
+}
+
+/// Convert path separators in a string to flattened separators.
+///
+/// # Examples
+///
+/// ```rust
+/// use hf_hub::paths::flatten_separator;
+///
+/// let flattened = flatten_separator("HuggingFaceTB/SmolLM2-135M");
+/// assert_eq!(flattened, "HuggingFaceTB--SmolLM2-135M");
+///
+/// let no_change = flatten_separator("simple-name");
+/// assert_eq!(no_change, "simple-name");
+/// ```
+pub fn flatten_separator(input: &str) -> String {
+    input.replace(constants::REPO_ID_SEPARATOR, constants::FLAT_SEPARATOR)
+}
+
+/// Encodes path separators in a string.
+///
+/// # Examples
+///
+/// ```rust
+/// use hf_hub::paths::encode_separator;
+///
+/// let encoded = encode_separator("HuggingFaceTB/SmolLM2-135M");
+/// assert_eq!(encoded, "HuggingFaceTB%2FSmolLM2-135M");
+///
+/// let no_change = encode_separator("simple-name");
+/// assert_eq!(no_change, "simple-name");
+/// ```
+pub fn encode_separator(input: &str) -> String {
+    input.replace(constants::REPO_ID_SEPARATOR, constants::ENCODED_SEPARATOR)
+}
+
+/// Builds a repo folder name: "models--user--repo"
+pub fn flattened_repo_folder_name(repo_type: &RepoType, repo_id: &str) -> String {
+    let prefix = repo_type.plural();
+    let prefixed_repo_id = format!("{prefix}{}{repo_id}", constants::FLAT_SEPARATOR);
+    flatten_separator(&prefixed_repo_id)
+}
+
+/// Returns the path to the snapshots directory for a given repo root
+pub fn snapshots_dir(repo_path: &Path) -> PathBuf {
+    repo_path.join(constants::SNAPSHOTS_DIR)
+}
+
+/// Returns the path to the refs directory
+pub fn refs_dir(repo_path: &Path) -> PathBuf {
+    repo_path.join(constants::REFS_DIR)
+}
+
+/// Returns the path to the blobs directory
+pub fn blobs_dir(repo_path: &Path) -> PathBuf {
+    repo_path.join(constants::BLOBS_DIR)
+}
+
+/// Returns the location of the token file
+///
+/// This honors `HF_TOKEN_PATH` before falling back to `<hub-parent>/token`.
+pub fn token_path(hub_path: &Path) -> PathBuf {
+    if let Some(path) = env_path(constants::HF_TOKEN_PATH) {
+        return path;
+    }
+
+    hub_path
+        .parent()
+        .expect("hub path should have a parent directory")
+        .join(constants::TOKEN_FILE)
+}
+
+/// Returns the path to a specific ref
+pub fn get_ref_path(repo_path: &Path, repo_ref: &str) -> PathBuf {
+    refs_dir(repo_path).join(repo_ref)
+}
+
+fn env_path(name: &str) -> Option<PathBuf> {
+    let value = env::var(name).ok()?;
+    expand_path(&value)
+}
+
+fn expand_path(value: &str) -> Option<PathBuf> {
+    let value = expand_tilde(value)?;
+    Some(PathBuf::from(expand_vars(&value)))
+}
+
+fn expand_tilde(value: &str) -> Option<String> {
+    if value == "~" {
+        return Some(dirs::home_dir()?.to_string_lossy().into_owned());
+    }
+
+    if let Some(rest) = value
+        .strip_prefix("~/")
+        .or_else(|| value.strip_prefix("~\\"))
+    {
+        let mut home = dirs::home_dir()?;
+        home.push(rest);
+        return Some(home.to_string_lossy().into_owned());
+    }
+
+    Some(value.to_string())
+}
+
+fn expand_vars(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    let mut output = String::with_capacity(value.len());
+    let mut index = 0;
+
+    while index < chars.len() {
+        match chars[index] {
+            '$' => {
+                if index + 1 < chars.len() && chars[index + 1] == '{' {
+                    if let Some(end) = chars[index + 2..].iter().position(|&ch| ch == '}') {
+                        let name: String = chars[index + 2..index + 2 + end].iter().collect();
+                        if let Ok(expanded) = env::var(&name) {
+                            output.push_str(&expanded);
+                        }
+                        index += end + 3;
+                        continue;
+                    }
+                }
+
+                let mut end = index + 1;
+                while end < chars.len() && (chars[end].is_ascii_alphanumeric() || chars[end] == '_')
+                {
+                    end += 1;
+                }
+
+                if end > index + 1 {
+                    let name: String = chars[index + 1..end].iter().collect();
+                    if let Ok(expanded) = env::var(&name) {
+                        output.push_str(&expanded);
+                    }
+                    index = end;
+                    continue;
+                }
+            }
+            '%' => {
+                if let Some(end) = chars[index + 1..].iter().position(|&ch| ch == '%') {
+                    let name: String = chars[index + 1..index + 1 + end].iter().collect();
+                    if let Ok(expanded) = env::var(&name) {
+                        output.push_str(&expanded);
+                        index += end + 2;
+                        continue;
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        output.push(chars[index]);
+        index += 1;
+    }
+
+    output
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -171,6 +171,23 @@ fn expand_path(value: &str) -> Option<PathBuf> {
     Some(PathBuf::from(expand_vars(&value)))
 }
 
+#[cfg(feature = "cache-manager")]
+pub(crate) fn normalize_path(path: &Path) -> Option<PathBuf> {
+    let expanded = expand_tilde(&path.to_string_lossy())?;
+    let path = PathBuf::from(expanded);
+
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        env::current_dir().ok()?.join(path)
+    };
+
+    match std::fs::canonicalize(&absolute) {
+        Ok(path) => Some(path),
+        Err(_) => Some(absolute),
+    }
+}
+
 fn expand_tilde(value: &str) -> Option<String> {
     if value == "~" {
         return Some(dirs::home_dir()?.to_string_lossy().into_owned());
@@ -201,6 +218,8 @@ fn expand_vars(value: &str) -> String {
                         let name: String = chars[index + 2..index + 2 + end].iter().collect();
                         if let Ok(expanded) = env::var(&name) {
                             output.push_str(&expanded);
+                        } else {
+                            output.push_str(&value[index..index + end + 3]);
                         }
                         index += end + 3;
                         continue;
@@ -217,6 +236,8 @@ fn expand_vars(value: &str) -> String {
                     let name: String = chars[index + 1..end].iter().collect();
                     if let Ok(expanded) = env::var(&name) {
                         output.push_str(&expanded);
+                    } else {
+                        output.push_str(&value[index..end]);
                     }
                     index = end;
                     continue;
@@ -240,4 +261,42 @@ fn expand_vars(value: &str) -> String {
     }
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn expand_vars_preserves_unknown_posix_variables() {
+        assert_eq!(
+            expand_vars("${HF_HUB_MISSING}/hub"),
+            "${HF_HUB_MISSING}/hub"
+        );
+        assert_eq!(expand_vars("$HF_HUB_MISSING/hub"), "$HF_HUB_MISSING/hub");
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn expand_vars_preserves_unknown_windows_variables() {
+        assert_eq!(
+            expand_vars("%HF_HUB_MISSING%\\hub"),
+            "%HF_HUB_MISSING%\\hub"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "cache-manager")]
+    #[cfg(not(target_os = "windows"))]
+    fn normalize_path_expands_tilde_and_resolves_relative_paths() {
+        let cwd = env::current_dir().unwrap();
+        let home = dirs::home_dir().unwrap();
+
+        let tilde = normalize_path(Path::new("~/hf-hub-cache")).unwrap();
+        assert_eq!(tilde, home.join("hf-hub-cache"));
+
+        let relative = normalize_path(Path::new("hf-hub-cache")).unwrap();
+        assert_eq!(relative, cwd.join("hf-hub-cache"));
+    }
 }


### PR DESCRIPTION
## Summary
- add a Rust-style cache API under `hf_hub::cache`, with `CacheInfo`, `CachedRepo`, `CachedRevision`, `CachedFile`, and `CacheDeletionPlan`
- add repo file-read APIs on cached repos while dropping uncached fallback reads so the API stays explicit about cache-only behavior
- add a Rust-style Hub search API via `api.search(RepoType::...)`, with builder methods like `with_query`, `with_author`, `with_filter`, `with_limit`, and typed `RepoSummary` results
- align cache path behavior with `huggingface_hub`, including env precedence for `HF_HUB_CACHE`, `HUGGINGFACE_HUB_CACHE`, `HF_HOME`, and `XDG_CACHE_HOME`
- honor `HF_TOKEN_PATH` and preserve unresolved env-var references during path expansion instead of silently dropping them
- normalize explicit `CacheInfo::scan_dir(Some(path))` inputs by expanding `~`, resolving relative paths, and canonicalizing when possible
- validate cache repo folder names against the canonical on-disk prefixes only: `models--`, `datasets--`, and `spaces--`
- refresh tests so version assertions are stable, search has smoke coverage in both backends, and gated redirect tests skip cleanly when the local token lacks model access

## Why
This branch started from a narrow cache-introspection need, but the useful shape for `hf-hub` is broader:
- keep the public API Rust-like instead of mirroring Python names directly
- still align overlapping behavior with the official `huggingface_hub` client where that affects correctness or user expectations

That leads to three complementary surfaces:

```rust
let cache = hf_hub::cache::CacheInfo::scan_dir(None)?;
```

```rust
let results = api
    .search(RepoType::Model)
    .with_query("gpt2")
    .with_limit(5)
    .run()?;
```

```rust
let bytes = cache
    .repo(Repo::model("openai-community/gpt2".to_string()))
    .read_file("config.json")?;
```

Python exposes search through `list_models`, `list_datasets`, and `list_spaces` with a `search=` parameter. In Rust, a small builder reads more naturally and fits the rest of the crate better.

The parity fixes in this PR also close a few compatibility gaps that matter for real cache scans:
- unresolved env vars now remain literal instead of being dropped from configured paths
- explicit cache paths passed to `scan_dir` now behave like Python's `expanduser().resolve()` flow
- malformed singular cache directories such as `model--repo` are now treated as invalid instead of being accepted during scanning

## Validation
- `cargo fmt`
- `cargo test`
