### PR TITLE
Fallback to body length in `Api::metadata` if `Content-Range` is missing

### DIFF
--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -573,18 +573,17 @@ impl Api {
         } else {
             response
         };
-        let content_range = response
-            .headers()
-            .get(CONTENT_RANGE)
-            .ok_or(ApiError::MissingHeader(CONTENT_RANGE))?;
-        let content_range = std::str::from_utf8(content_range.as_bytes())
-            .map_err(|_| ApiError::InvalidHeader(CONTENT_RANGE))?;
-
-        let size = content_range
-            .split('/')
-            .next_back()
-            .ok_or(ApiError::InvalidHeader(CONTENT_RANGE))?
-            .parse()?;
+        let size = if let Some(content_range) = response.headers().get(CONTENT_RANGE) {
+            let content_range = std::str::from_utf8(content_range.as_bytes())
+                .map_err(|_| ApiError::InvalidHeader(CONTENT_RANGE))?;
+            content_range
+                .split('/')
+                .next_back()
+                .ok_or(ApiError::InvalidHeader(CONTENT_RANGE))?
+                .parse()?
+        } else {
+            response.into_body().read_to_vec().map_err(Box::new)?.len()
+        };
         Ok(Metadata {
             commit_hash,
             etag,

--- a/src/api/tokio.rs
+++ b/src/api/tokio.rs
@@ -553,17 +553,17 @@ impl Api {
         } else {
             response
         };
-        let headers = response.headers();
-        let content_range = headers
-            .get(CONTENT_RANGE)
-            .ok_or(ApiError::MissingHeader(CONTENT_RANGE))?
-            .to_str()?;
-
-        let size = content_range
-            .split('/')
-            .next_back()
-            .ok_or(ApiError::InvalidHeader(CONTENT_RANGE))?
-            .parse()?;
+        let size = if let Some(content_range) = response.headers().get(CONTENT_RANGE) {
+            let content_range = std::str::from_utf8(content_range.as_bytes())
+                .map_err(|_| ApiError::InvalidHeader(CONTENT_RANGE))?;
+            content_range
+                .split('/')
+                .next_back()
+                .ok_or(ApiError::InvalidHeader(CONTENT_RANGE))?
+                .parse()?
+        } else {
+            response.bytes().await?.len()
+        };
         Ok(Metadata {
             commit_hash,
             etag,


### PR DESCRIPTION
Some mirrors (e.g., `hf-mirror.com`) return `200 OK` without a `Content-Range` header for small files, causing `Api::metadata` to fail.

While the **Python SDK** handles this by making size `Option<usize>`, doing so in Rust would be a breaking change. Instead, this PR falls back to reading the body length if the header is missing.