### PR TITLE
feat: explore generic HFRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,21 +50,13 @@ This builds in release mode by default. Once installed, run `hfrs --help` to see
 
 ```rust,no_run
 use hf_hub::HFClient;
-use hf_hub::repository::RepoInfo;
 
 #[tokio::main]
 async fn main() -> hf_hub::HFResult<()> {
     let client = HFClient::new()?;
 
     // Get model info
-    let RepoInfo::Model(info) = client
-        .model("openai-community", "gpt2")
-        .info()
-        .send()
-        .await?
-    else {
-        unreachable!("handle type guarantees the Model variant");
-    };
+    let info = client.model("openai-community", "gpt2").info().send().await?;
     println!("Model: {} (downloads: {:?})", info.id, info.downloads);
 
     Ok(())
@@ -77,18 +69,11 @@ Requires the `blocking` feature. `HFClientSync` manages a dedicated tokio runtim
 
 ```rust,ignore
 use hf_hub::HFClientSync;
-use hf_hub::repository::RepoInfo;
 
 fn main() -> hf_hub::HFResult<()> {
     let client = HFClientSync::new()?;
 
-    let RepoInfo::Model(info) = client
-        .model("openai-community", "gpt2")
-        .info()
-        .send()?
-    else {
-        unreachable!("handle type guarantees the Model variant");
-    };
+    let info = client.model("openai-community", "gpt2").info().send()?;
     println!("Model: {} (downloads: {:?})", info.id, info.downloads);
 
     Ok(())
@@ -129,17 +114,13 @@ async fn main() -> hf_hub::HFResult<()> {
 
 ```rust,no_run
 use hf_hub::HFClient;
-use hf_hub::repository::RepoInfo;
 
 #[tokio::main]
 async fn main() -> hf_hub::HFResult<()> {
     let client = HFClient::new()?;
     let repo = client.model("openai-community", "gpt2");
 
-    let RepoInfo::Model(model_info) = repo.info().send().await? else {
-        println!("error, not a model");
-        return Ok(());
-    };
+    let model_info = repo.info().send().await?;
     println!("Model: {}", model_info.id);
 
     let exists = repo

--- a/examples/blocking_read.rs
+++ b/examples/blocking_read.rs
@@ -16,7 +16,7 @@ fn main() -> hf_hub::HFResult<()> {
 
     let model = client.model("openai-community", "gpt2");
     let dataset = client.dataset("rajpurkar", "squad");
-    let space = client.space("huggingface", "transformers-benchmarks");
+    let space = client.space("huggingface-projects", "diffusers-gallery");
 
     let info = model.info().send()?;
     println!("Model: {} (downloads: {:?})", info.id, info.downloads);

--- a/examples/blocking_read.rs
+++ b/examples/blocking_read.rs
@@ -18,13 +18,13 @@ fn main() -> hf_hub::HFResult<()> {
     let dataset = client.dataset("rajpurkar", "squad");
     let space = client.space("huggingface", "transformers-benchmarks");
 
-    let info = model.info().send()?.into_model_info()?;
+    let info = model.info().send()?;
     println!("Model: {} (downloads: {:?})", info.id, info.downloads);
 
-    let info = dataset.info().send()?.into_dataset_info()?;
+    let info = dataset.info().send()?;
     println!("Dataset: {} (downloads: {:?})", info.id, info.downloads);
 
-    let info = space.info().send()?.into_space_info()?;
+    let info = space.info().send()?;
     println!("Space: {} (sdk: {:?})", info.id, info.sdk);
 
     let exists = model.exists().send()?;

--- a/examples/blocking_repository_handles.rs
+++ b/examples/blocking_repository_handles.rs
@@ -24,13 +24,13 @@ fn main() -> hf_hub::HFResult<()> {
     let info = dataset.info().send()?;
     println!("Dataset info: {}", info.id);
 
-    let generic_space = client.repo(RepoType::Space, "huggingface", "transformers-benchmarks");
+    let generic_space = client.repo(RepoType::Space, "huggingface-projects", "diffusers-gallery");
     let space = HFSpaceSync::try_from(generic_space)?;
 
     let info = space.info().send()?;
     println!("Space info: {} (sdk: {:?})", info.id, info.sdk);
 
-    let direct_space = client.space("huggingface", "transformers-benchmarks");
+    let direct_space = client.space("huggingface-projects", "diffusers-gallery");
     println!("Direct space handle matches converted handle: {}", direct_space.repo_path() == space.repo_path());
 
     Ok(())

--- a/examples/blocking_repository_handles.rs
+++ b/examples/blocking_repository_handles.rs
@@ -14,20 +14,20 @@ fn main() -> hf_hub::HFResult<()> {
     let model = client.model("openai-community", "gpt2");
     println!("Model handle: owner={}, name={}", model.owner(), model.name());
 
-    let info = model.info().send()?.into_model_info()?;
+    let info = model.info().send()?;
     println!("Model info: {} (sha: {:?})", info.id, info.sha);
 
     let config_exists = model.file_exists().filename("config.json").send()?;
     println!("config.json exists on {}: {config_exists}", model.repo_path());
 
-    let dataset = client.repo(RepoType::Dataset, "rajpurkar", "squad");
-    let info = dataset.info().send()?.into_dataset_info()?;
+    let dataset = client.dataset("rajpurkar", "squad");
+    let info = dataset.info().send()?;
     println!("Dataset info: {}", info.id);
 
     let generic_space = client.repo(RepoType::Space, "huggingface", "transformers-benchmarks");
     let space = HFSpaceSync::try_from(generic_space)?;
 
-    let info = space.info().send()?.into_space_info()?;
+    let info = space.info().send()?;
     println!("Space info: {} (sdk: {:?})", info.id, info.sdk);
 
     let direct_space = client.space("huggingface", "transformers-benchmarks");

--- a/examples/blocking_spaces.rs
+++ b/examples/blocking_spaces.rs
@@ -12,7 +12,7 @@ fn main() -> hf_hub::HFResult<()> {
 
     // --- Read operations ---
 
-    let reference_space = client.space("huggingface", "transformers-benchmarks");
+    let reference_space = client.space("huggingface-projects", "diffusers-gallery");
     let runtime = reference_space.runtime().send()?;
     println!("Space runtime: {runtime:?}");
 

--- a/examples/repository.rs
+++ b/examples/repository.rs
@@ -13,15 +13,15 @@ async fn main() -> hf_hub::HFResult<()> {
     // --- Read operations ---
 
     let model = client.model("openai-community", "gpt2");
-    let info = model.info().send().await?.into_model_info()?;
+    let info = model.info().send().await?;
     println!("Model: {} (downloads: {:?})", info.id, info.downloads);
 
     let dataset = client.dataset("rajpurkar", "squad");
-    let info = dataset.info().send().await?.into_dataset_info()?;
+    let info = dataset.info().send().await?;
     println!("Dataset: {} (downloads: {:?})", info.id, info.downloads);
 
     let space = client.space("huggingface", "transformers-benchmarks");
-    let info = space.info().send().await?.into_space_info()?;
+    let info = space.info().send().await?;
     println!("Space: {} (sdk: {:?})", info.id, info.sdk);
 
     let exists = model.exists().send().await?;

--- a/examples/repository.rs
+++ b/examples/repository.rs
@@ -20,7 +20,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let info = dataset.info().send().await?;
     println!("Dataset: {} (downloads: {:?})", info.id, info.downloads);
 
-    let space = client.space("huggingface", "transformers-benchmarks");
+    let space = client.space("huggingface-projects", "diffusers-gallery");
     let info = space.info().send().await?;
     println!("Space: {} (sdk: {:?})", info.id, info.sdk);
 

--- a/examples/repository_handles.rs
+++ b/examples/repository_handles.rs
@@ -23,13 +23,13 @@ async fn main() -> hf_hub::HFResult<()> {
     let info = dataset.info().send().await?;
     println!("Dataset info: {}", info.id);
 
-    let generic_space = client.repo(RepoType::Space, "huggingface", "transformers-benchmarks");
+    let generic_space = client.repo(RepoType::Space, "huggingface-projects", "diffusers-gallery");
     let space = HFSpace::try_from(generic_space)?;
 
     let info = space.info().send().await?;
     println!("Space info: {} (sdk: {:?})", info.id, info.sdk);
 
-    let direct_space = client.space("huggingface", "transformers-benchmarks");
+    let direct_space = client.space("huggingface-projects", "diffusers-gallery");
     println!("Direct space handle matches converted handle: {}", direct_space.repo_path() == space.repo_path());
 
     Ok(())

--- a/examples/repository_handles.rs
+++ b/examples/repository_handles.rs
@@ -13,20 +13,20 @@ async fn main() -> hf_hub::HFResult<()> {
     let model = client.model("openai-community", "gpt2");
     println!("Model handle: owner={}, name={}", model.owner(), model.name());
 
-    let info = model.info().send().await?.into_model_info()?;
+    let info = model.info().send().await?;
     println!("Model info: {} (sha: {:?})", info.id, info.sha);
 
     let config_exists = model.file_exists().filename("config.json").send().await?;
     println!("config.json exists on {}: {config_exists}", model.repo_path());
 
-    let dataset = client.repo(RepoType::Dataset, "rajpurkar", "squad");
-    let info = dataset.info().send().await?.into_dataset_info()?;
+    let dataset = client.dataset("rajpurkar", "squad");
+    let info = dataset.info().send().await?;
     println!("Dataset info: {}", info.id);
 
     let generic_space = client.repo(RepoType::Space, "huggingface", "transformers-benchmarks");
     let space = HFSpace::try_from(generic_space)?;
 
-    let info = space.info().send().await?.into_space_info()?;
+    let info = space.info().send().await?;
     println!("Space info: {} (sdk: {:?})", info.id, info.sdk);
 
     let direct_space = client.space("huggingface", "transformers-benchmarks");

--- a/examples/spaces.rs
+++ b/examples/spaces.rs
@@ -11,7 +11,7 @@ async fn main() -> hf_hub::HFResult<()> {
 
     // --- Read operations ---
 
-    let reference_space = client.space("huggingface", "transformers-benchmarks");
+    let reference_space = client.space("huggingface-projects", "diffusers-gallery");
     let runtime = reference_space.runtime().send().await?;
     println!("Space runtime: {runtime:?}");
 

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -304,7 +304,7 @@ mod tests {
     fn test_sync_repo_constructors() {
         let client = HFClientSync::from_inner(HFClient::builder().build().unwrap()).unwrap();
         let repo = client.model("openai-community", "gpt2");
-        let space = client.space("huggingface", "transformers-benchmarks");
+        let space = client.space("huggingface-projects", "diffusers-gallery");
 
         assert_eq!(repo.owner(), "openai-community");
         assert_eq!(repo.name(), "gpt2");

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::client::HFClient;
 use crate::error::{HFError, HFResult};
-use crate::repository::{HFRepository, RepoType};
+use crate::repository::{DatasetRepo, DynamicRepo, HFRepository, ModelRepo, RepoType, SpaceRepo};
 use crate::spaces::HFSpace;
 
 fn build_runtime() -> HFResult<Arc<tokio::runtime::Runtime>> {
@@ -41,8 +41,8 @@ pub struct HFClientSync {
 /// See [`HFRepository`] for method semantics.
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 #[derive(Clone)]
-pub struct HFRepositorySync {
-    pub(crate) inner: Arc<HFRepository>,
+pub struct HFRepositorySync<K = DynamicRepo> {
+    pub(crate) inner: Arc<HFRepository<K>>,
     pub(crate) runtime: Arc<tokio::runtime::Runtime>,
 }
 
@@ -55,12 +55,12 @@ pub struct HFRepositorySync {
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 #[derive(Clone)]
 pub struct HFSpaceSync {
-    pub(crate) repo_sync: Arc<HFRepositorySync>,
+    pub(crate) repo_sync: Arc<HFRepositorySync<SpaceRepo>>,
     pub(crate) inner: Arc<HFSpace>,
 }
 
 impl std::ops::Deref for HFSpaceSync {
-    type Target = HFRepositorySync;
+    type Target = HFRepositorySync<SpaceRepo>;
 
     fn deref(&self) -> &Self::Target {
         &self.repo_sync
@@ -86,7 +86,7 @@ impl std::fmt::Debug for HFClientSync {
     }
 }
 
-impl std::fmt::Debug for HFRepositorySync {
+impl<K> std::fmt::Debug for HFRepositorySync<K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HFRepositorySync").field("inner", &self.inner).finish()
     }
@@ -144,15 +144,15 @@ impl HFClientSync {
     /// Creates a blocking handle for a model repository.
     ///
     /// See [`HFClient::model`].
-    pub fn model(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync {
-        self.repo(RepoType::Model, owner, name)
+    pub fn model(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync<ModelRepo> {
+        HFRepositorySync::from_repo(self.clone(), HFRepository::new_model(self.inner.clone(), owner, name))
     }
 
     /// Creates a blocking handle for a dataset repository.
     ///
     /// See [`HFClient::dataset`].
-    pub fn dataset(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync {
-        self.repo(RepoType::Dataset, owner, name)
+    pub fn dataset(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync<DatasetRepo> {
+        HFRepositorySync::from_repo(self.clone(), HFRepository::new_dataset(self.inner.clone(), owner, name))
     }
 
     /// Creates a blocking handle for a Space repository.
@@ -170,13 +170,20 @@ impl HFClientSync {
     }
 }
 
-impl HFRepositorySync {
+impl HFRepositorySync<DynamicRepo> {
     /// Creates a blocking repository handle.
     ///
     /// See [`HFRepository::new`].
     pub fn new(client: HFClientSync, repo_type: RepoType, owner: impl Into<String>, name: impl Into<String>) -> Self {
+        let repo = HFRepository::new(client.inner.clone(), repo_type, owner, name);
+        Self::from_repo(client, repo)
+    }
+}
+
+impl<K> HFRepositorySync<K> {
+    pub(crate) fn from_repo(client: HFClientSync, repo: HFRepository<K>) -> Self {
         Self {
-            inner: Arc::new(HFRepository::new(client.inner.clone(), repo_type, owner, name)),
+            inner: Arc::new(repo),
             runtime: client.runtime.clone(),
         }
     }
@@ -209,7 +216,10 @@ impl HFSpaceSync {
     ///
     /// See [`HFSpace::new`].
     pub fn new(client: HFClientSync, owner: impl Into<String>, name: impl Into<String>) -> Self {
-        let repo_sync = Arc::new(HFRepositorySync::new(client, RepoType::Space, owner, name));
+        let repo_sync = Arc::new(HFRepositorySync::from_repo(
+            client.clone(),
+            HFRepository::new_space(client.inner.clone(), owner, name),
+        ));
         let inner = Arc::new(HFSpace {
             repo: repo_sync.inner.clone(),
         });
@@ -219,7 +229,7 @@ impl HFSpaceSync {
     /// Returns the underlying blocking repository handle.
     ///
     /// See [`HFSpace::repo`].
-    pub fn repo(&self) -> &HFRepositorySync {
+    pub fn repo(&self) -> &HFRepositorySync<SpaceRepo> {
         &self.repo_sync
     }
 }
@@ -246,17 +256,28 @@ impl TryFrom<HFRepositorySync> for HFSpaceSync {
                 actual: repo.inner.repo_type(),
             });
         }
+        let typed_repo_sync = HFRepositorySync::from_repo(
+            HFClientSync {
+                inner: repo.inner.client().clone(),
+                runtime: repo.runtime.clone(),
+            },
+            HFRepository::new_space(
+                repo.inner.client().clone(),
+                repo.inner.owner().to_string(),
+                repo.inner.name().to_string(),
+            ),
+        );
         let inner = Arc::new(HFSpace {
-            repo: repo.inner.clone(),
+            repo: typed_repo_sync.inner.clone(),
         });
         Ok(Self {
-            repo_sync: Arc::new(repo),
+            repo_sync: Arc::new(typed_repo_sync),
             inner,
         })
     }
 }
 
-impl From<HFSpaceSync> for Arc<HFRepositorySync> {
+impl From<HFSpaceSync> for Arc<HFRepositorySync<SpaceRepo>> {
     fn from(space: HFSpaceSync) -> Self {
         space.repo_sync
     }

--- a/hf-hub/src/repository/commits.rs
+++ b/hf-hub/src/repository/commits.rs
@@ -111,7 +111,7 @@ pub struct DiffEntry {
 }
 
 #[bon]
-impl HFRepository {
+impl<K: 'static> HFRepository<K> {
     /// Stream commit history for the repository at a given revision.
     ///
     /// Returns `HFResult<impl Stream<Item = HFResult<GitCommitInfo>>>`. Pagination is automatic.
@@ -461,7 +461,7 @@ impl HFRepository {
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
+impl<K: 'static> crate::blocking::HFRepositorySync<K> {
     /// Blocking counterpart of [`HFRepository::list_commits`]. Collects the stream into a
     /// `Vec<GitCommitInfo>`.
     #[builder(finish_fn = send, derive(Debug, Clone))]

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -56,7 +56,7 @@ struct SnapshotDownloadParams {
     progress: Option<Progress>,
 }
 
-impl HFRepository {
+impl<K: 'static> HFRepository<K> {
     async fn download_file_impl(&self, params: DownloadFileParams) -> HFResult<PathBuf> {
         let result = self.download_file_inner(&params).await;
         if result.is_ok() {
@@ -874,8 +874,8 @@ fn build_download_params(
         .collect()
 }
 
-async fn download_concurrently(
-    api: &HFRepository,
+async fn download_concurrently<K: 'static>(
+    api: &HFRepository<K>,
     params: &[DownloadFileParams],
     max_workers: usize,
 ) -> HFResult<Vec<PathBuf>> {
@@ -968,7 +968,7 @@ fn wrap_stream_with_progress(
 }
 
 #[bon]
-impl HFRepository {
+impl<K: 'static> HFRepository<K> {
     /// Download a single file from a repository.
     ///
     /// When `local_dir` is `Some`, the file is downloaded directly to that directory
@@ -1178,7 +1178,7 @@ impl HFRepository {
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
+impl<K: 'static> crate::blocking::HFRepositorySync<K> {
     /// Blocking counterpart of [`HFRepository::download_file`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]

--- a/hf-hub/src/repository/listing.rs
+++ b/hf-hub/src/repository/listing.rs
@@ -18,7 +18,7 @@ use crate::error::{HFError, HFResult};
 use crate::{constants, retry};
 
 #[bon]
-impl HFRepository {
+impl<K: 'static> HFRepository<K> {
     /// Stream file and directory entries in the repository tree.
     ///
     /// Returns `HFResult<impl Stream<Item = HFResult<RepoTreeEntry>>>`.
@@ -177,7 +177,7 @@ use futures::stream::StreamExt as _;
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
+impl<K: 'static> crate::blocking::HFRepositorySync<K> {
     /// Blocking counterpart of [`HFRepository::list_tree`]. Returns the collected stream as a
     /// `Vec<RepoTreeEntry>`.
     #[builder(finish_fn = send, derive(Debug, Clone))]

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -25,6 +25,9 @@ pub mod listing;
 pub mod upload;
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
 use std::str::FromStr;
 
 use bon::bon;
@@ -56,6 +59,99 @@ pub enum RepoType {
     Space,
     /// A kernel repository.
     Kernel,
+}
+
+/// Typestate marker for a runtime-selected repository handle returned by [`HFClient::repo`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DynamicRepo;
+
+/// Typestate marker for model repository handles returned by [`HFClient::model`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ModelRepo;
+
+/// Typestate marker for dataset repository handles returned by [`HFClient::dataset`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DatasetRepo;
+
+/// Typestate marker for Space repository handles exposed through [`crate::HFSpace`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SpaceRepo;
+
+mod private {
+    pub trait Sealed {}
+}
+
+#[doc(hidden)]
+pub trait RepoKind: private::Sealed {
+    type Info;
+
+    fn fetch_info<'a>(
+        repo: &'a HFRepository<Self>,
+        revision: Option<String>,
+        expand: Option<Vec<String>>,
+    ) -> Pin<Box<dyn Future<Output = HFResult<Self::Info>> + 'a>>
+    where
+        Self: Sized;
+}
+
+impl private::Sealed for DynamicRepo {}
+impl private::Sealed for ModelRepo {}
+impl private::Sealed for DatasetRepo {}
+impl private::Sealed for SpaceRepo {}
+
+impl RepoKind for DynamicRepo {
+    type Info = RepoInfo;
+
+    fn fetch_info<'a>(
+        repo: &'a HFRepository<Self>,
+        revision: Option<String>,
+        expand: Option<Vec<String>>,
+    ) -> Pin<Box<dyn Future<Output = HFResult<Self::Info>> + 'a>> {
+        Box::pin(async move {
+            match repo.repo_type {
+                RepoType::Model => repo.model_info(revision, expand).await.map(RepoInfo::Model),
+                RepoType::Dataset => repo.dataset_info(revision, expand).await.map(RepoInfo::Dataset),
+                RepoType::Space => repo.space_info(revision, expand).await.map(RepoInfo::Space),
+                RepoType::Kernel => repo.kernel_info(revision, expand).await.map(RepoInfo::Kernel),
+            }
+        })
+    }
+}
+
+impl RepoKind for ModelRepo {
+    type Info = ModelInfo;
+
+    fn fetch_info<'a>(
+        repo: &'a HFRepository<Self>,
+        revision: Option<String>,
+        expand: Option<Vec<String>>,
+    ) -> Pin<Box<dyn Future<Output = HFResult<Self::Info>> + 'a>> {
+        Box::pin(async move { repo.model_info(revision, expand).await })
+    }
+}
+
+impl RepoKind for DatasetRepo {
+    type Info = DatasetInfo;
+
+    fn fetch_info<'a>(
+        repo: &'a HFRepository<Self>,
+        revision: Option<String>,
+        expand: Option<Vec<String>>,
+    ) -> Pin<Box<dyn Future<Output = HFResult<Self::Info>> + 'a>> {
+        Box::pin(async move { repo.dataset_info(revision, expand).await })
+    }
+}
+
+impl RepoKind for SpaceRepo {
+    type Info = SpaceInfo;
+
+    fn fetch_info<'a>(
+        repo: &'a HFRepository<Self>,
+        revision: Option<String>,
+        expand: Option<Vec<String>>,
+    ) -> Pin<Box<dyn Future<Output = HFResult<Self::Info>> + 'a>> {
+        Box::pin(async move { repo.space_info(revision, expand).await })
+    }
 }
 
 /// Access-gating mode for a repository.
@@ -112,8 +208,8 @@ impl GatedNotifications {
 
 /// Repo-type-tagged wrapper over [`ModelInfo`], [`DatasetInfo`], and [`SpaceInfo`].
 ///
-/// Returned by [`HFRepository::info`]; the active variant
-/// matches the repository's [`RepoType`].
+/// Returned by [`HFClient::repo`] handles through [`HFRepository::info`]; the active variant
+/// matches the repository's runtime [`RepoType`].
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum RepoInfo {
@@ -559,11 +655,12 @@ pub struct RepoUrl {
 /// # Ok(()) }
 /// ```
 #[derive(Clone)]
-pub struct HFRepository {
+pub struct HFRepository<K = DynamicRepo> {
     pub(crate) hf_client: HFClient,
     pub(super) owner: String,
     pub(super) name: String,
     pub(crate) repo_type: RepoType,
+    _kind: PhantomData<K>,
 }
 
 impl std::fmt::Display for RepoType {
@@ -699,7 +796,7 @@ impl RepoInfo {
     }
 }
 
-impl std::fmt::Debug for HFRepository {
+impl<K> std::fmt::Debug for HFRepository<K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HFRepository")
             .field("owner", &self.owner)
@@ -717,13 +814,13 @@ impl HFClient {
     }
 
     /// Create an [`HFRepository`] handle for a model repository.
-    pub fn model(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository {
-        self.repo(RepoType::Model, owner, name)
+    pub fn model(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository<ModelRepo> {
+        HFRepository::new_model(self.clone(), owner, name)
     }
 
     /// Create an [`HFRepository`] handle for a dataset repository.
-    pub fn dataset(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository {
-        self.repo(RepoType::Dataset, owner, name)
+    pub fn dataset(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository<DatasetRepo> {
+        HFRepository::new_dataset(self.clone(), owner, name)
     }
 
     /// List models on the Hub. Endpoint: `GET /api/models`.
@@ -1113,7 +1210,7 @@ impl HFClient {
     }
 }
 
-impl HFRepository {
+impl HFRepository<DynamicRepo> {
     /// Construct a new repository handle. Prefer the factory methods on [`HFClient`] instead.
     pub fn new(client: HFClient, repo_type: RepoType, owner: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
@@ -1121,6 +1218,37 @@ impl HFRepository {
             owner: owner.into(),
             name: name.into(),
             repo_type,
+            _kind: PhantomData,
+        }
+    }
+}
+
+impl HFRepository<ModelRepo> {
+    pub(crate) fn new_model(client: HFClient, owner: impl Into<String>, name: impl Into<String>) -> Self {
+        Self::new_typed(client, RepoType::Model, owner, name)
+    }
+}
+
+impl HFRepository<DatasetRepo> {
+    pub(crate) fn new_dataset(client: HFClient, owner: impl Into<String>, name: impl Into<String>) -> Self {
+        Self::new_typed(client, RepoType::Dataset, owner, name)
+    }
+}
+
+impl HFRepository<SpaceRepo> {
+    pub(crate) fn new_space(client: HFClient, owner: impl Into<String>, name: impl Into<String>) -> Self {
+        Self::new_typed(client, RepoType::Space, owner, name)
+    }
+}
+
+impl<K> HFRepository<K> {
+    fn new_typed(client: HFClient, repo_type: RepoType, owner: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            hf_client: client,
+            owner: owner.into(),
+            name: name.into(),
+            repo_type,
+            _kind: PhantomData,
         }
     }
 
@@ -1225,14 +1353,12 @@ impl HFRepository {
 }
 
 #[bon]
-impl HFRepository {
-    /// Fetch repository metadata, returning the appropriate [`RepoInfo`] variant.
+impl<K: RepoKind> HFRepository<K> {
+    /// Fetch repository metadata for this handle.
     ///
-    /// When the caller statically knows the repo type — e.g. after `client.model(...)`,
-    /// `client.dataset(...)`, `client.space(...)`, or `client.repo(RepoType::Kernel, ...)` —
-    /// prefer the typed accessors [`RepoInfo::into_model`], [`RepoInfo::into_dataset`],
-    /// [`RepoInfo::into_space`], and [`RepoInfo::into_kernel`] over a manual `match` on the
-    /// returned enum.
+    /// Handles created with [`HFClient::model`] and [`HFClient::dataset`] return their concrete
+    /// info types directly. Runtime-selected handles created with [`HFClient::repo`] return
+    /// [`RepoInfo`].
     ///
     /// For [`RepoType::Kernel`], note that the Hub's `/api/kernels/{repo_id}` endpoint returns
     /// a slim shape (no `tags`, `cardData`, or `siblings`) and silently ignores `expand`. To get
@@ -1253,13 +1379,8 @@ impl HFRepository {
         /// List of properties to expand in the response (e.g. `"trendingScore"`, `"cardData"`). When set, only
         /// the listed properties (plus `_id` and `id`) are returned. Ignored for kernel repos.
         expand: Option<Vec<String>>,
-    ) -> HFResult<RepoInfo> {
-        match self.repo_type {
-            RepoType::Model => self.model_info(revision, expand).await.map(RepoInfo::Model),
-            RepoType::Dataset => self.dataset_info(revision, expand).await.map(RepoInfo::Dataset),
-            RepoType::Space => self.space_info(revision, expand).await.map(RepoInfo::Space),
-            RepoType::Kernel => self.kernel_info(revision, expand).await.map(RepoInfo::Kernel),
-        }
+    ) -> HFResult<K::Info> {
+        K::fetch_info(self, revision, expand).await
     }
 
     /// Return `true` if the repository exists.
@@ -1684,7 +1805,7 @@ impl crate::blocking::HFClientSync {
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
+impl<K: RepoKind> crate::blocking::HFRepositorySync<K> {
     /// Blocking counterpart of [`HFRepository::info`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
@@ -1696,7 +1817,7 @@ impl crate::blocking::HFRepositorySync {
         /// List of properties to expand in the response (e.g. `"trendingScore"`, `"cardData"`). When set, only
         /// the listed properties (plus `_id` and `id`) are returned.
         expand: Option<Vec<String>>,
-    ) -> HFResult<RepoInfo> {
+    ) -> HFResult<K::Info> {
         self.runtime
             .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
     }

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -81,7 +81,7 @@ struct DeleteFolderParams {
     create_pr: bool,
 }
 
-impl HFRepository {
+impl<K: 'static> HFRepository<K> {
     async fn create_commit_impl(&self, params: CreateCommitParams) -> HFResult<CommitInfo> {
         let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
         let url = format!("{}/commit/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), revision);
@@ -679,7 +679,7 @@ fn collect_files_recursive(
 }
 
 #[bon]
-impl HFRepository {
+impl<K: 'static> HFRepository<K> {
     /// Create a commit with multiple operations.
     ///
     /// This is the lowest-level public mutation API in the files module. Use it when you need an
@@ -936,7 +936,7 @@ impl HFRepository {
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
+impl<K: 'static> crate::blocking::HFRepositorySync<K> {
     /// Blocking counterpart of [`HFRepository::create_commit`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]

--- a/hf-hub/src/spaces.rs
+++ b/hf-hub/src/spaces.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::HFClient;
 use crate::error::{HFError, HFResult};
-use crate::repository::{HFRepository, RepoType, RepoUrl};
+use crate::repository::{HFRepository, RepoType, RepoUrl, SpaceRepo};
 use crate::retry;
 
 /// Runtime state of a Space: stage, hardware, storage, and mounted volumes.
@@ -133,7 +133,7 @@ pub struct SpaceVariable {
 /// ```
 #[derive(Clone)]
 pub struct HFSpace {
-    pub(crate) repo: Arc<HFRepository>,
+    pub(crate) repo: Arc<HFRepository<SpaceRepo>>,
 }
 
 impl std::fmt::Debug for HFSpace {
@@ -153,7 +153,7 @@ impl HFSpace {
     /// Construct a new Space handle. Prefer [`HFClient::space`] in most cases.
     pub fn new(client: HFClient, owner: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
-            repo: Arc::new(HFRepository::new(client, RepoType::Space, owner, name)),
+            repo: Arc::new(HFRepository::new_space(client, owner, name)),
         }
     }
 
@@ -161,7 +161,7 @@ impl HFSpace {
     ///
     /// `HFSpace` already derefs to `HFRepository`, so this is mainly useful when you need an
     /// explicit reference (e.g. to clone or to disambiguate trait resolution).
-    pub fn repo(&self) -> &HFRepository {
+    pub fn repo(&self) -> &HFRepository<SpaceRepo> {
         &self.repo
     }
 }
@@ -572,18 +572,24 @@ impl TryFrom<HFRepository> for HFSpace {
                 actual: repo.repo_type(),
             });
         }
-        Ok(Self { repo: Arc::new(repo) })
+        Ok(Self {
+            repo: Arc::new(HFRepository::new_space(
+                repo.client().clone(),
+                repo.owner().to_string(),
+                repo.name().to_string(),
+            )),
+        })
     }
 }
 
-impl From<HFSpace> for Arc<HFRepository> {
+impl From<HFSpace> for Arc<HFRepository<SpaceRepo>> {
     fn from(space: HFSpace) -> Self {
         space.repo.clone()
     }
 }
 
 impl Deref for HFSpace {
-    type Target = HFRepository;
+    type Target = HFRepository<SpaceRepo>;
 
     fn deref(&self) -> &Self::Target {
         &self.repo
@@ -765,13 +771,15 @@ impl crate::blocking::HFSpaceSync {
 #[cfg(test)]
 mod tests {
     use super::{HFSpace, SpaceRuntime, SpaceVariable};
-    use crate::repository::{HFRepository, RepoType};
+    use crate::repository::{DatasetRepo, HFRepository, ModelRepo, RepoType, SpaceRepo};
 
     #[test]
     fn test_hfspace_constructor_and_deref() {
         let client = crate::HFClient::builder().build().unwrap();
         let space = HFSpace::new(client, "huggingface-projects", "diffusers-gallery");
+        fn assert_space_repo(_: &HFRepository<SpaceRepo>) {}
 
+        assert_space_repo(space.repo());
         assert_eq!(space.repo_type(), RepoType::Space);
         assert_eq!(space.repo_path(), "huggingface-projects/diffusers-gallery");
     }
@@ -791,6 +799,17 @@ mod tests {
             },
             _ => panic!("expected invalid repo type error"),
         }
+    }
+
+    #[test]
+    fn test_typed_repo_constructors() {
+        let client = crate::HFClient::builder().build().unwrap();
+
+        fn assert_model_repo(_: &HFRepository<ModelRepo>) {}
+        fn assert_dataset_repo(_: &HFRepository<DatasetRepo>) {}
+
+        assert_model_repo(&client.model("owner", "model"));
+        assert_dataset_repo(&client.dataset("owner", "dataset"));
     }
 
     #[test]

--- a/hf-hub/src/xet.rs
+++ b/hf-hub/src/xet.rs
@@ -350,7 +350,7 @@ async fn xet_upload_inner(
     Ok(xet_file_infos)
 }
 
-impl HFRepository {
+impl<K: 'static> HFRepository<K> {
     pub(crate) async fn xet_download_to_local_dir(
         &self,
         revision: &str,
@@ -587,7 +587,7 @@ impl HFRepository {
         file_hash: &str,
         file_size: u64,
         range: Option<std::ops::Range<u64>>,
-    ) -> HFResult<impl futures::Stream<Item = HFResult<bytes::Bytes>> + use<>> {
+    ) -> HFResult<impl futures::Stream<Item = HFResult<bytes::Bytes>> + use<K>> {
         let repo_path = self.repo_path();
         let repo_type = Some(self.repo_type);
         let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, repo_type, revision);

--- a/hfrs/src/commands/datasets/info.rs
+++ b/hfrs/src/commands/datasets/info.rs
@@ -24,7 +24,7 @@ pub struct Args {
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let (owner, name) = crate::util::split_repo_id(&args.dataset_id);
     let repo = client.dataset(owner, name);
-    let info = repo.info().maybe_revision(args.revision).send().await?.into_dataset_info()?;
+    let info = repo.info().maybe_revision(args.revision).send().await?;
     let json_value = json!({
         "id": info.id,
         "author": info.author,

--- a/hfrs/src/commands/models/info.rs
+++ b/hfrs/src/commands/models/info.rs
@@ -24,7 +24,7 @@ pub struct Args {
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let (owner, name) = crate::util::split_repo_id(&args.model_id);
     let repo = client.model(owner, name);
-    let info = repo.info().maybe_revision(args.revision).send().await?.into_model_info()?;
+    let info = repo.info().maybe_revision(args.revision).send().await?;
     let json_value = json!({
         "id": info.id,
         "author": info.author,

--- a/hfrs/src/commands/spaces/info.rs
+++ b/hfrs/src/commands/spaces/info.rs
@@ -24,7 +24,7 @@ pub struct Args {
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let (owner, name) = crate::util::split_repo_id(&args.space_id);
     let repo = client.space(owner, name);
-    let info = repo.info().maybe_revision(args.revision).send().await?.into_space_info()?;
+    let info = repo.info().maybe_revision(args.revision).send().await?;
     let json_value = json!({
         "id": info.id,
         "author": info.author,

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -49,18 +49,20 @@ const TEST_USER: &str = "julien-c";
 const TEST_MODEL_AUTHOR: &str = "openai-community";
 const TEST_MODEL_REPO: &str = "hf-internal-testing/tiny-gemma3";
 const TEST_DATASET_REPO: &str = "hf-internal-testing/cats_vs_dogs_sample";
+const TEST_MODEL_PARTS: (&str, &str) = ("hf-internal-testing", "tiny-gemma3");
+const TEST_DATASET_PARTS: (&str, &str) = ("hf-internal-testing", "cats_vs_dogs_sample");
 
 /// Split a `"owner/name"` string into an `HFRepositorySync` handle.
 fn repo_handle(client: &HFClientSync, repo_id: &str) -> hf_hub::HFRepositorySync {
     let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
     if parts.len() == 2 {
-        client.model(parts[0], parts[1])
+        client.repo(RepoType::Model, parts[0], parts[1])
     } else {
-        client.model("", repo_id)
+        client.repo(RepoType::Model, "", repo_id)
     }
 }
 
-fn collect_file_paths(test_repo: &hf_hub::HFRepositorySync) -> std::collections::HashSet<String> {
+fn collect_file_paths<K: 'static>(test_repo: &hf_hub::HFRepositorySync<K>) -> std::collections::HashSet<String> {
     test_repo
         .list_tree()
         .recursive(true)
@@ -74,39 +76,24 @@ fn collect_file_paths(test_repo: &hf_hub::HFRepositorySync) -> std::collections:
         .collect()
 }
 
-fn dataset_handle(client: &HFClientSync, repo_id: &str) -> hf_hub::HFRepositorySync {
-    let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
-    if parts.len() == 2 {
-        client.dataset(parts[0], parts[1])
-    } else {
-        client.dataset("", repo_id)
-    }
-}
-
 // --- Repo info ---
 
 #[test]
 fn test_sync_model_info() {
     let Some(client) = prod_sync_api() else { return };
-    let model_repo = TEST_MODEL_REPO;
-    let repo = repo_handle(&client, model_repo);
-    let info = repo.info().send().unwrap();
-    match info {
-        RepoInfo::Model(model) => assert!(model.id.contains("tiny-gemma3")),
-        _ => panic!("expected model info"),
-    }
+    let info = client.model(TEST_MODEL_PARTS.0, TEST_MODEL_PARTS.1).info().send().unwrap();
+    assert!(info.id.contains("tiny-gemma3"));
 }
 
 #[test]
 fn test_sync_dataset_info() {
     let Some(client) = prod_sync_api() else { return };
-    let dataset_repo = TEST_DATASET_REPO;
-    let repo = dataset_handle(&client, dataset_repo);
-    let info = repo.info().send().unwrap();
-    match info {
-        RepoInfo::Dataset(ds) => assert_eq!(ds.id, dataset_repo),
-        _ => panic!("expected dataset info"),
-    }
+    let info = client
+        .dataset(TEST_DATASET_PARTS.0, TEST_DATASET_PARTS.1)
+        .info()
+        .send()
+        .unwrap();
+    assert_eq!(info.id, TEST_DATASET_REPO);
 }
 
 #[test]

--- a/integration-tests/tests/download_test.rs
+++ b/integration-tests/tests/download_test.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use futures::StreamExt;
 use hf_hub::progress::{DownloadEvent, FileStatus, ProgressEvent, ProgressHandler, UploadEvent};
 use hf_hub::repository::{AddSource, CommitOperation};
-use hf_hub::{HFClient, HFClientBuilder, HFRepository};
+use hf_hub::{HFClient, HFClientBuilder, HFRepository, RepoType};
 use integration_tests::test_utils::*;
 use sha2::{Digest, Sha256};
 
@@ -80,11 +80,11 @@ const TEST_MODEL_PARTS: (&str, &str) = ("hf-internal-testing", "tiny-gemma3");
 const TEST_DATASET_PARTS: (&str, &str) = ("hf-internal-testing", "cats_vs_dogs_sample");
 
 fn model(client: &HFClient, owner: &str, name: &str) -> HFRepository {
-    client.model(owner, name)
+    client.repo(RepoType::Model, owner, name)
 }
 
 fn dataset(client: &HFClient, owner: &str, name: &str) -> HFRepository {
-    client.dataset(owner, name)
+    client.repo(RepoType::Dataset, owner, name)
 }
 
 #[tokio::test]
@@ -584,7 +584,7 @@ async fn test_download_with_no_progress_handler() {
 
 fn repo_from_id(client: &HFClient, repo_id: &str) -> HFRepository {
     let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
-    client.model(parts[0], parts[1])
+    client.repo(RepoType::Model, parts[0], parts[1])
 }
 
 #[tokio::test]

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -60,6 +60,8 @@ const TEST_MODEL_REPO: &str = "hf-internal-testing/tiny-gemma3";
 const TEST_SPACE_REPO: (&str, &str) = ("huggingface-projects", "diffusers-gallery");
 const TEST_SPACE_INFO_REPO: &str = "HuggingFaceFW/blogpost-fineweb-v1";
 const TEST_DATASET_REPO: &str = "hf-internal-testing/cats_vs_dogs_sample";
+const TEST_MODEL_PARTS: (&str, &str) = ("hf-internal-testing", "tiny-gemma3");
+const TEST_DATASET_PARTS: (&str, &str) = ("hf-internal-testing", "cats_vs_dogs_sample");
 
 /// Cached whoami username, fetched once and reused across write tests.
 async fn cached_username() -> &'static str {
@@ -76,13 +78,13 @@ async fn cached_username() -> &'static str {
 fn repo(client: &HFClient, repo_id: &str) -> HFRepository {
     let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
     if parts.len() == 2 {
-        client.model(parts[0], parts[1])
+        client.repo(RepoType::Model, parts[0], parts[1])
     } else {
-        client.model("", repo_id)
+        client.repo(RepoType::Model, "", repo_id)
     }
 }
 
-async fn collect_file_paths(test_repo: &HFRepository) -> std::collections::HashSet<String> {
+async fn collect_file_paths<K: 'static>(test_repo: &HFRepository<K>) -> std::collections::HashSet<String> {
     let stream = test_repo.list_tree().recursive(true).send().unwrap();
     futures::pin_mut!(stream);
     let mut files = std::collections::HashSet::new();
@@ -108,12 +110,13 @@ fn repo_typed(client: &HFClient, repo_id: &str, repo_type: RepoType) -> HFReposi
 #[tokio::test]
 async fn test_model_info() {
     let Some(client) = prod_api() else { return };
-    let model_repo = TEST_MODEL_REPO;
-    let info = repo(&client, model_repo).info().send().await.unwrap();
-    match info {
-        RepoInfo::Model(model) => assert!(model.id.contains("tiny-gemma3")),
-        _ => panic!("expected model info"),
-    }
+    let info = client
+        .model(TEST_MODEL_PARTS.0, TEST_MODEL_PARTS.1)
+        .info()
+        .send()
+        .await
+        .unwrap();
+    assert!(info.id.contains("tiny-gemma3"));
 }
 
 #[tokio::test]
@@ -135,16 +138,13 @@ async fn test_repo_handle_info_and_file_exists() {
 #[tokio::test]
 async fn test_dataset_info() {
     let Some(client) = prod_api() else { return };
-    let dataset_repo = TEST_DATASET_REPO;
-    let info = repo_typed(&client, dataset_repo, RepoType::Dataset)
+    let info = client
+        .dataset(TEST_DATASET_PARTS.0, TEST_DATASET_PARTS.1)
         .info()
         .send()
         .await
         .unwrap();
-    match info {
-        RepoInfo::Dataset(ds) => assert_eq!(ds.id, dataset_repo),
-        _ => panic!("expected dataset info"),
-    }
+    assert_eq!(info.id, TEST_DATASET_REPO);
 }
 
 #[tokio::test]

--- a/integration-tests/tests/xet_transfer_test.rs
+++ b/integration-tests/tests/xet_transfer_test.rs
@@ -17,7 +17,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures::StreamExt;
 use hf_hub::repository::AddSource;
-use hf_hub::{HFClient, HFClientBuilder, HFRepository};
+use hf_hub::{HFClient, HFClientBuilder, HFRepository, RepoType};
 use integration_tests::test_utils::*;
 use rand::RngExt;
 use tokio::sync::OnceCell;
@@ -68,7 +68,7 @@ fn unique_suffix() -> String {
 
 /// Split an `"owner/name"` repo_id into an [`HFRepository`] handle.
 fn repo_handle(client: &HFClient, owner: &str, name: &str) -> HFRepository {
-    client.model(owner, name)
+    client.repo(RepoType::Model, owner, name)
 }
 
 async fn create_test_repo(client: &HFClient, suffix: &str) -> (String, String) {


### PR DESCRIPTION
simplifes 

```rust
    let model = client.model("openai-community", "gpt2");
    let info = model.info().send().await?.into_model_info()?;
    println!("Model: {} (downloads: {:?})", info.id, info.downloads);

    let dataset = client.dataset("rajpurkar", "squad");
    let info = dataset.info().send().await?.into_dataset_info()?;
    println!("Dataset: {} (downloads: {:?})", info.id, info.downloads);

    let space = client.space("huggingface", "transformers-benchmarks");
    let info = space.info().send().await?.into_space_info()?;
    println!("Space: {} (sdk: {:?})", info.id, info.sdk);
```

to

```rust
    let model = client.model("openai-community", "gpt2");
    let info = model.info().send().await?;
    println!("Model: {} (downloads: {:?})", info.id, info.downloads);

    let dataset = client.dataset("rajpurkar", "squad");
    let info = dataset.info().send().await?;
    println!("Dataset: {} (downloads: {:?})", info.id, info.downloads);

    let space = client.space("huggingface", "transformers-benchmarks");
    let info = space.info().send().await?;
    println!("Space: {} (sdk: {:?})", info.id, info.sdk);
```

small test

```bash
cargo run -p examples --example repository
```
```
Model: openai-community/gpt2 (downloads: Some(15304081))
Dataset: rajpurkar/squad (downloads: Some(141750))
Space: huggingface-projects/diffusers-gallery (sdk: Some("static"))
gpt2 exists: true
gpt2@main exists: true
gpt2/config.json exists: true

Models by openai:
  - openai/privacy-filter
  - openai/gpt-oss-120b
  - openai/whisper-large-v3

Datasets matching 'squad':
  - rajpurkar/squad_v2
  - iapp/iapp_wiki_qa_squad
  - rajpurkar/squad

Spaces by huggingface:
  - huggingface/ai-deadlines
  - huggingface/InferenceSupport
  - huggingface/openapi

Created repo: https://huggingface.co/drbh/example-repo-80383
Updated repo description
Moved repo to: https://huggingface.co/drbh/example-repo-renamed-80383
Deleted repo
```

note this make the `info` call return concrete types ie:
<img width="673" height="212" alt="genericrepotypes" src="https://github.com/user-attachments/assets/46474719-cb41-468c-9115-51fdb6b6e147" />
