### PR TITLE
refactor(hf-hub): make RepoType a trait, HFRepository<T> generic, drop HFSpace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,12 +28,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        features:
-          - ""
-          - "--all-features"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -45,8 +39,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
 
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets ${{ matrix.features }} -- -D warnings
+      - name: Clippy (default features)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Clippy (all features)
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   build-and-test:
     name: Build & Test

--- a/examples/blocking_read.rs
+++ b/examples/blocking_read.rs
@@ -18,13 +18,13 @@ fn main() -> hf_hub::HFResult<()> {
     let dataset = client.dataset("rajpurkar", "squad");
     let space = client.space("huggingface", "transformers-benchmarks");
 
-    let info = model.info().send()?.into_model_info()?;
+    let info = model.info().send()?;
     println!("Model: {} (downloads: {:?})", info.id, info.downloads);
 
-    let info = dataset.info().send()?.into_dataset_info()?;
+    let info = dataset.info().send()?;
     println!("Dataset: {} (downloads: {:?})", info.id, info.downloads);
 
-    let info = space.info().send()?.into_space_info()?;
+    let info = space.info().send()?;
     println!("Space: {} (sdk: {:?})", info.id, info.sdk);
 
     let exists = model.exists().send()?;

--- a/examples/blocking_repository_handles.rs
+++ b/examples/blocking_repository_handles.rs
@@ -1,12 +1,11 @@
 //! Synchronous repository handle ergonomics using HFClientSync.
 //!
-//! Demonstrates typed repo constructors, revision pinning, tagged repo info,
-//! and converting a generic repo handle into HFSpaceSync.
+//! Demonstrates typed repo constructors, revision pinning, and per-repo-kind info responses.
 //!
 //! Read-only operations require no auth.
-//! Run: cargo run -p examples --features blocking --example blocking_repo_handles
+//! Run: cargo run -p examples --features blocking --example blocking_repository_handles
 
-use hf_hub::{HFClientSync, HFSpaceSync, RepoType};
+use hf_hub::HFClientSync;
 
 fn main() -> hf_hub::HFResult<()> {
     let client = HFClientSync::new()?;
@@ -14,24 +13,19 @@ fn main() -> hf_hub::HFResult<()> {
     let model = client.model("openai-community", "gpt2");
     println!("Model handle: owner={}, name={}", model.owner(), model.name());
 
-    let info = model.info().send()?.into_model_info()?;
+    let info = model.info().send()?;
     println!("Model info: {} (sha: {:?})", info.id, info.sha);
 
     let config_exists = model.file_exists().filename("config.json").send()?;
     println!("config.json exists on {}: {config_exists}", model.repo_path());
 
-    let dataset = client.repo(RepoType::Dataset, "rajpurkar", "squad");
-    let info = dataset.info().send()?.into_dataset_info()?;
+    let dataset = client.dataset("rajpurkar", "squad");
+    let info = dataset.info().send()?;
     println!("Dataset info: {}", info.id);
 
-    let generic_space = client.repo(RepoType::Space, "huggingface", "transformers-benchmarks");
-    let space = HFSpaceSync::try_from(generic_space)?;
-
-    let info = space.info().send()?.into_space_info()?;
+    let space = client.space("huggingface", "transformers-benchmarks");
+    let info = space.info().send()?;
     println!("Space info: {} (sdk: {:?})", info.id, info.sdk);
-
-    let direct_space = client.space("huggingface", "transformers-benchmarks");
-    println!("Direct space handle matches converted handle: {}", direct_space.repo_path() == space.repo_path());
 
     Ok(())
 }

--- a/examples/blocking_spaces.rs
+++ b/examples/blocking_spaces.rs
@@ -24,7 +24,7 @@ fn main() -> hf_hub::HFResult<()> {
     let space = client.space(&user.username, format!("blocking-example-space-{unique}"));
 
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .private(true)
@@ -52,7 +52,7 @@ fn main() -> hf_hub::HFResult<()> {
     println!("Restarted space: {restarted:?}");
 
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .missing_ok(true)

--- a/examples/blocking_spaces.rs
+++ b/examples/blocking_spaces.rs
@@ -24,7 +24,8 @@ fn main() -> hf_hub::HFResult<()> {
     let space = client.space(&user.username, format!("blocking-example-space-{unique}"));
 
     client
-        .create_repo::<RepoTypeSpace>()
+        .create_repo()
+        .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .private(true)
         .space_sdk("static")
@@ -51,7 +52,8 @@ fn main() -> hf_hub::HFResult<()> {
     println!("Restarted space: {restarted:?}");
 
     client
-        .delete_repo::<RepoTypeSpace>()
+        .delete_repo()
+        .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .missing_ok(true)
         .send()?;

--- a/examples/blocking_spaces.rs
+++ b/examples/blocking_spaces.rs
@@ -1,11 +1,12 @@
-//! Synchronous Space operations using HFClientSync and HFSpaceSync.
+//! Synchronous Space operations using HFClientSync.
 //!
-//! Demonstrates runtime info, secrets, variables, and lifecycle management.
+//! Demonstrates runtime info, secrets, variables, and lifecycle management on a
+//! blocking `HFRepositorySync<RepoTypeSpace>`.
 //!
-//! Requires HF_TOKEN and the "blocking" + "spaces" features.
+//! Requires HF_TOKEN and the "blocking" feature.
 //! Run: cargo run -p examples --features blocking --example blocking_spaces
 
-use hf_hub::{HFClientSync, RepoType};
+use hf_hub::{HFClientSync, RepoTypeSpace};
 
 fn main() -> hf_hub::HFResult<()> {
     let client = HFClientSync::new()?;
@@ -23,9 +24,8 @@ fn main() -> hf_hub::HFResult<()> {
     let space = client.space(&user.username, format!("blocking-example-space-{unique}"));
 
     client
-        .create_repo()
+        .create_repo::<RepoTypeSpace>()
         .repo_id(space.repo_path())
-        .repo_type(RepoType::Space)
         .private(true)
         .space_sdk("static")
         .exist_ok(true)
@@ -51,9 +51,8 @@ fn main() -> hf_hub::HFResult<()> {
     println!("Restarted space: {restarted:?}");
 
     client
-        .delete_repo()
+        .delete_repo::<RepoTypeSpace>()
         .repo_id(space.repo_path())
-        .repo_type(RepoType::Space)
         .missing_ok(true)
         .send()?;
     println!("Cleaned up test space");

--- a/examples/blocking_write.rs
+++ b/examples/blocking_write.rs
@@ -17,7 +17,7 @@ fn main() -> hf_hub::HFResult<()> {
     // --- Create repo ---
 
     let repo_url = client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
@@ -108,7 +108,7 @@ fn main() -> hf_hub::HFResult<()> {
     // --- Clean up ---
 
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)

--- a/examples/blocking_write.rs
+++ b/examples/blocking_write.rs
@@ -5,8 +5,8 @@
 //! Requires HF_TOKEN environment variable.
 //! Run: cargo run -p examples --features blocking --example blocking_write
 
-use hf_hub::HFClientSync;
 use hf_hub::repository::{AddSource, CommitOperation, RepoTreeEntry};
+use hf_hub::{HFClientSync, RepoTypeModel};
 
 fn main() -> hf_hub::HFResult<()> {
     let client = HFClientSync::new()?;
@@ -17,7 +17,7 @@ fn main() -> hf_hub::HFResult<()> {
     // --- Create repo ---
 
     let repo_url = client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -106,7 +106,11 @@ fn main() -> hf_hub::HFResult<()> {
 
     // --- Clean up ---
 
-    client.delete_repo().repo_id(repo.repo_path()).missing_ok(true).send()?;
+    client
+        .delete_repo::<RepoTypeModel>()
+        .repo_id(repo.repo_path())
+        .missing_ok(true)
+        .send()?;
     println!("Deleted repo");
 
     Ok(())

--- a/examples/blocking_write.rs
+++ b/examples/blocking_write.rs
@@ -17,7 +17,8 @@ fn main() -> hf_hub::HFResult<()> {
     // --- Create repo ---
 
     let repo_url = client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -107,7 +108,8 @@ fn main() -> hf_hub::HFResult<()> {
     // --- Clean up ---
 
     client
-        .delete_repo::<RepoTypeModel>()
+        .delete_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)
         .send()?;

--- a/examples/commits.rs
+++ b/examples/commits.rs
@@ -4,7 +4,7 @@
 //! Run: cargo run -p examples --example commits
 
 use futures::StreamExt;
-use hf_hub::HFClient;
+use hf_hub::{HFClient, RepoTypeModel};
 
 #[tokio::main]
 async fn main() -> hf_hub::HFResult<()> {
@@ -56,7 +56,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-commits-{unique}"));
 
     client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -76,7 +76,12 @@ async fn main() -> hf_hub::HFResult<()> {
     repo.delete_tag().tag("v0.1.0").send().await?;
     println!("Deleted tag: v0.1.0");
 
-    client.delete_repo().repo_id(repo.repo_path()).missing_ok(true).send().await?;
+    client
+        .delete_repo::<RepoTypeModel>()
+        .repo_id(repo.repo_path())
+        .missing_ok(true)
+        .send()
+        .await?;
     println!("Cleaned up test repo");
 
     Ok(())

--- a/examples/commits.rs
+++ b/examples/commits.rs
@@ -56,7 +56,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-commits-{unique}"));
 
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
@@ -78,7 +78,7 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Deleted tag: v0.1.0");
 
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)

--- a/examples/commits.rs
+++ b/examples/commits.rs
@@ -56,7 +56,8 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-commits-{unique}"));
 
     client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -77,7 +78,8 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Deleted tag: v0.1.0");
 
     client
-        .delete_repo::<RepoTypeModel>()
+        .delete_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)
         .send()

--- a/examples/download_upload.rs
+++ b/examples/download_upload.rs
@@ -107,7 +107,8 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-download-upload-{}", std::process::id()));
 
     client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -155,7 +156,8 @@ async fn main() -> hf_hub::HFResult<()> {
 
     // Cleanup
     client
-        .delete_repo::<RepoTypeModel>()
+        .delete_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)
         .send()

--- a/examples/download_upload.rs
+++ b/examples/download_upload.rs
@@ -107,7 +107,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-download-upload-{}", std::process::id()));
 
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
@@ -156,7 +156,7 @@ async fn main() -> hf_hub::HFResult<()> {
 
     // Cleanup
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)

--- a/examples/download_upload.rs
+++ b/examples/download_upload.rs
@@ -13,8 +13,8 @@
 use std::io::Write;
 
 use futures::StreamExt;
-use hf_hub::HFClient;
 use hf_hub::repository::AddSource;
+use hf_hub::{HFClient, RepoTypeModel};
 
 #[tokio::main]
 async fn main() -> hf_hub::HFResult<()> {
@@ -107,7 +107,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-download-upload-{}", std::process::id()));
 
     client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -154,7 +154,12 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Uploaded folder: {:?}", commit.commit_url);
 
     // Cleanup
-    client.delete_repo().repo_id(repo.repo_path()).missing_ok(true).send().await?;
+    client
+        .delete_repo::<RepoTypeModel>()
+        .repo_id(repo.repo_path())
+        .missing_ok(true)
+        .send()
+        .await?;
     println!("Cleaned up repo: {}", repo.repo_path());
 
     Ok(())

--- a/examples/files.rs
+++ b/examples/files.rs
@@ -60,7 +60,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-files-{unique}"));
 
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
@@ -110,7 +110,7 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Deleted data/ folder");
 
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)

--- a/examples/files.rs
+++ b/examples/files.rs
@@ -4,8 +4,8 @@
 //! Run: cargo run -p examples --example files
 
 use futures::StreamExt;
-use hf_hub::HFClient;
 use hf_hub::repository::{AddSource, CommitOperation, RepoTreeEntry};
+use hf_hub::{HFClient, RepoTypeModel};
 #[tokio::main]
 async fn main() -> hf_hub::HFResult<()> {
     let client = HFClient::new()?;
@@ -60,7 +60,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-files-{unique}"));
 
     client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -108,7 +108,12 @@ async fn main() -> hf_hub::HFResult<()> {
     repo.delete_folder().path_in_repo("data").send().await?;
     println!("Deleted data/ folder");
 
-    client.delete_repo().repo_id(repo.repo_path()).missing_ok(true).send().await?;
+    client
+        .delete_repo::<RepoTypeModel>()
+        .repo_id(repo.repo_path())
+        .missing_ok(true)
+        .send()
+        .await?;
     println!("Cleaned up test repo");
 
     Ok(())

--- a/examples/files.rs
+++ b/examples/files.rs
@@ -60,7 +60,8 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-files-{unique}"));
 
     client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -109,7 +110,8 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Deleted data/ folder");
 
     client
-        .delete_repo::<RepoTypeModel>()
+        .delete_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)
         .send()

--- a/examples/progress_logger.rs
+++ b/examples/progress_logger.rs
@@ -14,9 +14,9 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
-use hf_hub::HFClient;
 use hf_hub::progress::{ProgressEvent, ProgressHandler};
 use hf_hub::repository::AddSource;
+use hf_hub::{HFClient, RepoTypeModel};
 
 /// Logs each `ProgressEvent` to stderr with a millisecond offset from when
 /// the handler was constructed, plus an event counter. Thread-safe — uses
@@ -90,7 +90,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let user = client.whoami().send().await?;
     let repo = client.model(&user.username, format!("example-progress-logger-{}", std::process::id()));
     client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -108,7 +108,12 @@ async fn main() -> hf_hub::HFResult<()> {
         .await?;
     println!("Committed: {:?}", commit.commit_url);
 
-    client.delete_repo().repo_id(repo.repo_path()).missing_ok(true).send().await?;
+    client
+        .delete_repo::<RepoTypeModel>()
+        .repo_id(repo.repo_path())
+        .missing_ok(true)
+        .send()
+        .await?;
 
     Ok(())
 }

--- a/examples/progress_logger.rs
+++ b/examples/progress_logger.rs
@@ -90,7 +90,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let user = client.whoami().send().await?;
     let repo = client.model(&user.username, format!("example-progress-logger-{}", std::process::id()));
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
@@ -110,7 +110,7 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Committed: {:?}", commit.commit_url);
 
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)

--- a/examples/progress_logger.rs
+++ b/examples/progress_logger.rs
@@ -90,7 +90,8 @@ async fn main() -> hf_hub::HFResult<()> {
     let user = client.whoami().send().await?;
     let repo = client.model(&user.username, format!("example-progress-logger-{}", std::process::id()));
     client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -109,7 +110,8 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Committed: {:?}", commit.commit_url);
 
     client
-        .delete_repo::<RepoTypeModel>()
+        .delete_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .missing_ok(true)
         .send()

--- a/examples/repository.rs
+++ b/examples/repository.rs
@@ -76,7 +76,8 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-repo-{unique}"));
 
     let repo_url = client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -89,7 +90,8 @@ async fn main() -> hf_hub::HFResult<()> {
 
     let new_name = format!("{}/example-repo-renamed-{unique}", user.username);
     let moved = client
-        .move_repo::<RepoTypeModel>()
+        .move_repo()
+        .repo_type(RepoTypeModel)
         .from_id(repo.repo_path())
         .to_id(&new_name)
         .send()
@@ -97,7 +99,8 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Moved repo to: {}", moved.url);
 
     client
-        .delete_repo::<RepoTypeModel>()
+        .delete_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(&new_name)
         .missing_ok(true)
         .send()

--- a/examples/repository.rs
+++ b/examples/repository.rs
@@ -4,7 +4,7 @@
 //! Run: cargo run -p examples --example repo
 
 use futures::StreamExt;
-use hf_hub::HFClient;
+use hf_hub::{HFClient, RepoTypeModel};
 
 #[tokio::main]
 async fn main() -> hf_hub::HFResult<()> {
@@ -13,15 +13,15 @@ async fn main() -> hf_hub::HFResult<()> {
     // --- Read operations ---
 
     let model = client.model("openai-community", "gpt2");
-    let info = model.info().send().await?.into_model_info()?;
+    let info = model.info().send().await?;
     println!("Model: {} (downloads: {:?})", info.id, info.downloads);
 
     let dataset = client.dataset("rajpurkar", "squad");
-    let info = dataset.info().send().await?.into_dataset_info()?;
+    let info = dataset.info().send().await?;
     println!("Dataset: {} (downloads: {:?})", info.id, info.downloads);
 
     let space = client.space("huggingface", "transformers-benchmarks");
-    let info = space.info().send().await?.into_space_info()?;
+    let info = space.info().send().await?;
     println!("Space: {} (sdk: {:?})", info.id, info.sdk);
 
     let exists = model.exists().send().await?;
@@ -76,7 +76,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-repo-{unique}"));
 
     let repo_url = client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(repo.repo_path())
         .private(true)
         .exist_ok(true)
@@ -88,10 +88,20 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Updated repo description");
 
     let new_name = format!("{}/example-repo-renamed-{unique}", user.username);
-    let moved = client.move_repo().from_id(repo.repo_path()).to_id(&new_name).send().await?;
+    let moved = client
+        .move_repo::<RepoTypeModel>()
+        .from_id(repo.repo_path())
+        .to_id(&new_name)
+        .send()
+        .await?;
     println!("Moved repo to: {}", moved.url);
 
-    client.delete_repo().repo_id(&new_name).missing_ok(true).send().await?;
+    client
+        .delete_repo::<RepoTypeModel>()
+        .repo_id(&new_name)
+        .missing_ok(true)
+        .send()
+        .await?;
     println!("Deleted repo");
 
     Ok(())

--- a/examples/repository.rs
+++ b/examples/repository.rs
@@ -76,7 +76,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo = client.model(&user.username, format!("example-repo-{unique}"));
 
     let repo_url = client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(repo.repo_path())
         .private(true)
@@ -90,7 +90,7 @@ async fn main() -> hf_hub::HFResult<()> {
 
     let new_name = format!("{}/example-repo-renamed-{unique}", user.username);
     let moved = client
-        .move_repo()
+        .move_repository()
         .repo_type(RepoTypeModel)
         .from_id(repo.repo_path())
         .to_id(&new_name)
@@ -99,7 +99,7 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Moved repo to: {}", moved.url);
 
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&new_name)
         .missing_ok(true)

--- a/examples/repository_handles.rs
+++ b/examples/repository_handles.rs
@@ -1,10 +1,10 @@
 //! Repository handle ergonomics: typed repo constructors, revision pinning,
-//! tagged repo info, and converting a generic repo handle into HFSpace.
+//! and per-repo-kind info responses.
 //!
 //! Read-only operations require no auth.
-//! Run: cargo run -p examples --example repo_handles
+//! Run: cargo run -p examples --example repository_handles
 
-use hf_hub::{HFClient, HFSpace, RepoType};
+use hf_hub::HFClient;
 
 #[tokio::main]
 async fn main() -> hf_hub::HFResult<()> {
@@ -13,24 +13,19 @@ async fn main() -> hf_hub::HFResult<()> {
     let model = client.model("openai-community", "gpt2");
     println!("Model handle: owner={}, name={}", model.owner(), model.name());
 
-    let info = model.info().send().await?.into_model_info()?;
+    let info = model.info().send().await?;
     println!("Model info: {} (sha: {:?})", info.id, info.sha);
 
     let config_exists = model.file_exists().filename("config.json").send().await?;
     println!("config.json exists on {}: {config_exists}", model.repo_path());
 
-    let dataset = client.repo(RepoType::Dataset, "rajpurkar", "squad");
-    let info = dataset.info().send().await?.into_dataset_info()?;
+    let dataset = client.dataset("rajpurkar", "squad");
+    let info = dataset.info().send().await?;
     println!("Dataset info: {}", info.id);
 
-    let generic_space = client.repo(RepoType::Space, "huggingface", "transformers-benchmarks");
-    let space = HFSpace::try_from(generic_space)?;
-
-    let info = space.info().send().await?.into_space_info()?;
+    let space = client.space("huggingface", "transformers-benchmarks");
+    let info = space.info().send().await?;
     println!("Space info: {} (sdk: {:?})", info.id, info.sdk);
-
-    let direct_space = client.space("huggingface", "transformers-benchmarks");
-    println!("Direct space handle matches converted handle: {}", direct_space.repo_path() == space.repo_path());
 
     Ok(())
 }

--- a/examples/spaces.rs
+++ b/examples/spaces.rs
@@ -22,7 +22,8 @@ async fn main() -> hf_hub::HFResult<()> {
     let space = client.space(&user.username, format!("example-space-{unique}"));
 
     client
-        .create_repo::<RepoTypeSpace>()
+        .create_repo()
+        .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .private(true)
         .space_sdk("static")
@@ -50,7 +51,8 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Restarted space: {restarted:?}");
 
     client
-        .delete_repo::<RepoTypeSpace>()
+        .delete_repo()
+        .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .missing_ok(true)
         .send()

--- a/examples/spaces.rs
+++ b/examples/spaces.rs
@@ -22,7 +22,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let space = client.space(&user.username, format!("example-space-{unique}"));
 
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .private(true)
@@ -51,7 +51,7 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Restarted space: {restarted:?}");
 
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .missing_ok(true)

--- a/examples/spaces.rs
+++ b/examples/spaces.rs
@@ -1,9 +1,9 @@
 //! Space operations: runtime info, secrets, variables, and lifecycle management.
 //!
-//! Requires HF_TOKEN and the "spaces" feature.
+//! Requires HF_TOKEN.
 //! Run: cargo run -p examples --example spaces
 
-use hf_hub::{HFClient, RepoType};
+use hf_hub::{HFClient, RepoTypeSpace};
 
 #[tokio::main]
 async fn main() -> hf_hub::HFResult<()> {
@@ -22,9 +22,8 @@ async fn main() -> hf_hub::HFResult<()> {
     let space = client.space(&user.username, format!("example-space-{unique}"));
 
     client
-        .create_repo()
+        .create_repo::<RepoTypeSpace>()
         .repo_id(space.repo_path())
-        .repo_type(RepoType::Space)
         .private(true)
         .space_sdk("static")
         .exist_ok(true)
@@ -51,9 +50,8 @@ async fn main() -> hf_hub::HFResult<()> {
     println!("Restarted space: {restarted:?}");
 
     client
-        .delete_repo()
+        .delete_repo::<RepoTypeSpace>()
         .repo_id(space.repo_path())
-        .repo_type(RepoType::Space)
         .missing_ok(true)
         .send()
         .await?;

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -185,9 +185,11 @@ impl<T: RepoType> HFRepositorySync<T> {
         self.inner.repo_path()
     }
 
-    /// Lowercase singular name of this repo's kind, equivalent to `T::default().singular()`.
-    pub fn repo_type(&self) -> &'static str {
-        T::default().singular()
+    /// The marker for this handle's repo kind, equivalent to `T::default()`. Call
+    /// [`RepoType::singular`] / [`RepoType::plural`] / [`RepoType::url_prefix`] on it
+    /// to get the corresponding string.
+    pub fn repo_type(&self) -> impl RepoType {
+        T::default()
     }
 }
 
@@ -228,7 +230,7 @@ mod tests {
 
         assert_eq!(repo.owner(), "openai-community");
         assert_eq!(repo.name(), "gpt2");
-        assert_eq!(repo.repo_type(), "model");
-        assert_eq!(space.repo_type(), "space");
+        assert_eq!(repo.repo_type().singular(), "model");
+        assert_eq!(space.repo_type().singular(), "space");
     }
 }

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -1,9 +1,9 @@
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::client::HFClient;
 use crate::error::{HFError, HFResult};
-use crate::repository::{HFRepository, RepoType};
-use crate::spaces::HFSpace;
+use crate::repository::{HFRepository, RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};
 
 fn build_runtime() -> HFResult<Arc<tokio::runtime::Runtime>> {
     tokio::runtime::Builder::new_current_thread()
@@ -33,37 +33,25 @@ pub struct HFClientSync {
     pub(crate) runtime: Arc<tokio::runtime::Runtime>,
 }
 
-/// Synchronous/blocking counterpart to [`HFRepository`].
+/// Synchronous/blocking counterpart to [`HFRepository`], parameterised by the repo kind via `T`.
 ///
-/// Wraps an [`HFRepository`] and blocks on the corresponding async methods.
-/// Derefs to [`HFRepository`], so repo accessors are available directly.
+/// Wraps an [`HFRepository<T>`] and blocks on the corresponding async methods.
 ///
 /// See [`HFRepository`] for method semantics.
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
-#[derive(Clone)]
-pub struct HFRepositorySync {
-    pub(crate) inner: Arc<HFRepository>,
+pub struct HFRepositorySync<T: RepoType> {
+    pub(crate) inner: Arc<HFRepository<T>>,
     pub(crate) runtime: Arc<tokio::runtime::Runtime>,
+    _ty: PhantomData<fn() -> T>,
 }
 
-/// Synchronous/blocking counterpart to [`HFSpace`].
-///
-/// Derefs to [`HFRepositorySync`], so blocking repository methods are
-/// available directly.
-///
-/// See [`HFSpace`] for Space-specific behavior.
-#[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
-#[derive(Clone)]
-pub struct HFSpaceSync {
-    pub(crate) repo_sync: Arc<HFRepositorySync>,
-    pub(crate) inner: Arc<HFSpace>,
-}
-
-impl std::ops::Deref for HFSpaceSync {
-    type Target = HFRepositorySync;
-
-    fn deref(&self) -> &Self::Target {
-        &self.repo_sync
+impl<T: RepoType> Clone for HFRepositorySync<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            runtime: Arc::clone(&self.runtime),
+            _ty: PhantomData,
+        }
     }
 }
 
@@ -86,18 +74,9 @@ impl std::fmt::Debug for HFClientSync {
     }
 }
 
-impl std::fmt::Debug for HFRepositorySync {
+impl<T: RepoType> std::fmt::Debug for HFRepositorySync<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HFRepositorySync").field("inner", &self.inner).finish()
-    }
-}
-
-impl std::fmt::Debug for HFSpaceSync {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HFSpaceSync")
-            .field("inner", &self.inner)
-            .field("repo_sync", &self.repo_sync)
-            .finish()
     }
 }
 
@@ -134,32 +113,39 @@ impl HFClientSync {
         })
     }
 
-    /// Creates a blocking repository handle.
+    /// Creates a blocking handle for any repo kind via a turbofished generic.
     ///
-    /// See [`HFClient::repo`] for details.
-    pub fn repo(&self, repo_type: RepoType, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync {
-        HFRepositorySync::new(self.clone(), repo_type, owner, name)
+    /// See [`HFClient::repository`].
+    pub fn repository<T: RepoType>(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync<T> {
+        HFRepositorySync::new(self.clone(), owner, name)
     }
 
     /// Creates a blocking handle for a model repository.
     ///
     /// See [`HFClient::model`].
-    pub fn model(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync {
-        self.repo(RepoType::Model, owner, name)
+    pub fn model(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync<RepoTypeModel> {
+        self.repository::<RepoTypeModel>(owner, name)
     }
 
     /// Creates a blocking handle for a dataset repository.
     ///
     /// See [`HFClient::dataset`].
-    pub fn dataset(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync {
-        self.repo(RepoType::Dataset, owner, name)
+    pub fn dataset(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync<RepoTypeDataset> {
+        self.repository::<RepoTypeDataset>(owner, name)
     }
 
     /// Creates a blocking handle for a Space repository.
     ///
     /// See [`HFClient::space`].
-    pub fn space(&self, owner: impl Into<String>, name: impl Into<String>) -> HFSpaceSync {
-        HFSpaceSync::new(self.clone(), owner, name)
+    pub fn space(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync<RepoTypeSpace> {
+        self.repository::<RepoTypeSpace>(owner, name)
+    }
+
+    /// Creates a blocking handle for a kernel repository.
+    ///
+    /// See [`HFClient::kernel`].
+    pub fn kernel(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepositorySync<RepoTypeKernel> {
+        self.repository::<RepoTypeKernel>(owner, name)
     }
 
     /// Creates a blocking handle for a bucket.
@@ -170,14 +156,15 @@ impl HFClientSync {
     }
 }
 
-impl HFRepositorySync {
+impl<T: RepoType> HFRepositorySync<T> {
     /// Creates a blocking repository handle.
     ///
     /// See [`HFRepository::new`].
-    pub fn new(client: HFClientSync, repo_type: RepoType, owner: impl Into<String>, name: impl Into<String>) -> Self {
+    pub fn new(client: HFClientSync, owner: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
-            inner: Arc::new(HFRepository::new(client.inner.clone(), repo_type, owner, name)),
+            inner: Arc::new(HFRepository::new(client.inner.clone(), owner, name)),
             runtime: client.runtime.clone(),
+            _ty: PhantomData,
         }
     }
 
@@ -198,29 +185,9 @@ impl HFRepositorySync {
         self.inner.repo_path()
     }
 
-    /// The type of this repository (model, dataset, or space).
-    pub fn repo_type(&self) -> RepoType {
-        self.inner.repo_type()
-    }
-}
-
-impl HFSpaceSync {
-    /// Creates a blocking Space handle.
-    ///
-    /// See [`HFSpace::new`].
-    pub fn new(client: HFClientSync, owner: impl Into<String>, name: impl Into<String>) -> Self {
-        let repo_sync = Arc::new(HFRepositorySync::new(client, RepoType::Space, owner, name));
-        let inner = Arc::new(HFSpace {
-            repo: repo_sync.inner.clone(),
-        });
-        Self { repo_sync, inner }
-    }
-
-    /// Returns the underlying blocking repository handle.
-    ///
-    /// See [`HFSpace::repo`].
-    pub fn repo(&self) -> &HFRepositorySync {
-        &self.repo_sync
+    /// Lowercase singular name of this repo's kind, equivalent to `T::singular()`.
+    pub fn repo_type(&self) -> &'static str {
+        T::singular()
     }
 }
 
@@ -233,32 +200,6 @@ impl HFBucketSync {
             inner: Arc::new(crate::buckets::HFBucket::new(client.inner.clone(), owner, name)),
             runtime: client.runtime.clone(),
         }
-    }
-}
-
-impl TryFrom<HFRepositorySync> for HFSpaceSync {
-    type Error = HFError;
-
-    fn try_from(repo: HFRepositorySync) -> HFResult<Self> {
-        if repo.inner.repo_type() != RepoType::Space {
-            return Err(HFError::InvalidRepoType {
-                expected: RepoType::Space,
-                actual: repo.inner.repo_type(),
-            });
-        }
-        let inner = Arc::new(HFSpace {
-            repo: repo.inner.clone(),
-        });
-        Ok(Self {
-            repo_sync: Arc::new(repo),
-            inner,
-        })
-    }
-}
-
-impl From<HFSpaceSync> for Arc<HFRepositorySync> {
-    fn from(space: HFSpaceSync) -> Self {
-        space.repo_sync
     }
 }
 
@@ -287,24 +228,7 @@ mod tests {
 
         assert_eq!(repo.owner(), "openai-community");
         assert_eq!(repo.name(), "gpt2");
-        assert_eq!(repo.repo_type(), RepoType::Model);
-        assert_eq!(space.repo_type(), RepoType::Space);
-    }
-
-    #[test]
-    fn test_sync_space_try_from_repo() {
-        let client = HFClientSync::from_inner(HFClient::builder().build().unwrap()).unwrap();
-        let space_repo = client.repo(RepoType::Space, "owner", "space");
-        assert!(HFSpaceSync::try_from(space_repo).is_ok());
-
-        let model_repo = client.repo(RepoType::Model, "owner", "model");
-        let error = HFSpaceSync::try_from(model_repo).unwrap_err();
-        match error {
-            HFError::InvalidRepoType { expected, actual } => {
-                assert_eq!(expected, RepoType::Space);
-                assert_eq!(actual, RepoType::Model);
-            },
-            _ => panic!("expected invalid repo type error"),
-        }
+        assert_eq!(repo.repo_type(), "model");
+        assert_eq!(space.repo_type(), "space");
     }
 }

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -185,9 +185,9 @@ impl<T: RepoType> HFRepositorySync<T> {
         self.inner.repo_path()
     }
 
-    /// Lowercase singular name of this repo's kind, equivalent to `T::singular()`.
+    /// Lowercase singular name of this repo's kind, equivalent to `T::default().singular()`.
     pub fn repo_type(&self) -> &'static str {
-        T::singular()
+        T::default().singular()
     }
 }
 

--- a/hf-hub/src/cache/mod.rs
+++ b/hf-hub/src/cache/mod.rs
@@ -19,7 +19,6 @@ use bon::bon;
 
 use crate::client::HFClient;
 use crate::error::HFResult;
-use crate::repository::RepoType;
 
 pub(crate) mod storage;
 
@@ -73,8 +72,9 @@ pub struct CachedRevisionInfo {
 pub struct CachedRepoInfo {
     /// Hub repo identifier (e.g. `gpt2`, `google/bert-base-uncased`).
     pub repo_id: String,
-    /// Repository type (model, dataset, or space).
-    pub repo_type: RepoType,
+    /// Lowercase singular name of the repo kind (`"model"`, `"dataset"`, `"space"`, or `"kernel"`)
+    /// — see [`crate::repository::RepoType::singular`].
+    pub repo_type: &'static str,
     /// Absolute path of the repo's cache subfolder
     /// (`<cache>/<type>s--<owner>--<name>/`).
     pub repo_path: PathBuf,

--- a/hf-hub/src/cache/storage.rs
+++ b/hf-hub/src/cache/storage.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use super::{CachedFileInfo, CachedRepoInfo, CachedRevisionInfo, HFCacheInfo};
-use crate::repository::RepoType;
 
 pub(crate) struct CacheLock {
     _file: File,
@@ -101,10 +100,12 @@ pub(crate) fn is_commit_hash(revision: &str) -> bool {
     revision.len() == 40 && revision.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-pub(crate) fn repo_folder_name(repo_id: &str, repo_type: Option<RepoType>) -> String {
-    let repo_type = repo_type.unwrap_or(RepoType::Model);
-    let type_plural = format!("{}s", repo_type);
-    std::iter::once(type_plural.as_str())
+/// Build the folder name for the cache layout: `<plural>--<owner>--<name>`.
+///
+/// `type_plural` is the API segment of the repo type — `"models"`, `"datasets"`, `"spaces"`,
+/// or `"kernels"` — i.e. the value returned by [`crate::repository::RepoType::plural`].
+pub(crate) fn repo_folder_name(repo_id: &str, type_plural: &str) -> String {
+    std::iter::once(type_plural)
         .chain(repo_id.split('/'))
         .collect::<Vec<_>>()
         .join("--")
@@ -130,12 +131,17 @@ pub(crate) fn no_exist_path(cache_dir: &Path, repo_folder: &str, commit_hash: &s
     cache_dir.join(repo_folder).join(".no_exist").join(commit_hash).join(filename)
 }
 
-fn parse_repo_folder_name(name: &str) -> Option<(RepoType, String)> {
+fn parse_repo_folder_name(name: &str) -> Option<(&'static str, String)> {
     let (type_plural, rest) = name.split_once("--")?;
-    let type_singular = type_plural.strip_suffix('s')?;
-    let repo_type: RepoType = type_singular.parse().ok()?;
+    let singular = match type_plural {
+        "models" => "model",
+        "datasets" => "dataset",
+        "spaces" => "space",
+        "kernels" => "kernel",
+        _ => return None,
+    };
     let repo_id = rest.replace("--", "/");
-    Some((repo_type, repo_id))
+    Some((singular, repo_id))
 }
 
 fn read_commit_refs(repo_path: &Path) -> HashMap<String, Vec<String>> {
@@ -335,34 +341,25 @@ mod tests {
         parse_repo_folder_name, read_commit_refs, read_ref, ref_path, repo_folder_name, scan_cache_dir, snapshot_path,
         write_ref,
     };
-    use crate::repository::RepoType;
 
     #[test]
     fn test_repo_folder_name_model_with_org() {
-        assert_eq!(
-            repo_folder_name("google/bert-base-uncased", Some(RepoType::Model)),
-            "models--google--bert-base-uncased"
-        );
+        assert_eq!(repo_folder_name("google/bert-base-uncased", "models"), "models--google--bert-base-uncased");
     }
 
     #[test]
     fn test_repo_folder_name_model_no_org() {
-        assert_eq!(repo_folder_name("gpt2", Some(RepoType::Model)), "models--gpt2");
-    }
-
-    #[test]
-    fn test_repo_folder_name_model_none_type() {
-        assert_eq!(repo_folder_name("gpt2", None), "models--gpt2");
+        assert_eq!(repo_folder_name("gpt2", "models"), "models--gpt2");
     }
 
     #[test]
     fn test_repo_folder_name_dataset() {
-        assert_eq!(repo_folder_name("rajpurkar/squad", Some(RepoType::Dataset)), "datasets--rajpurkar--squad");
+        assert_eq!(repo_folder_name("rajpurkar/squad", "datasets"), "datasets--rajpurkar--squad");
     }
 
     #[test]
     fn test_repo_folder_name_space() {
-        assert_eq!(repo_folder_name("dalle-mini/dalle-mini", Some(RepoType::Space)), "spaces--dalle-mini--dalle-mini");
+        assert_eq!(repo_folder_name("dalle-mini/dalle-mini", "spaces"), "spaces--dalle-mini--dalle-mini");
     }
 
     #[test]
@@ -496,17 +493,17 @@ mod tests {
 
     #[test]
     fn test_parse_repo_folder_name_model() {
-        assert_eq!(parse_repo_folder_name("models--gpt2"), Some((RepoType::Model, "gpt2".to_string())));
+        assert_eq!(parse_repo_folder_name("models--gpt2"), Some(("model", "gpt2".to_string())));
     }
 
     #[test]
     fn test_parse_repo_folder_name_model_with_org() {
-        assert_eq!(parse_repo_folder_name("models--google--bert"), Some((RepoType::Model, "google/bert".to_string())));
+        assert_eq!(parse_repo_folder_name("models--google--bert"), Some(("model", "google/bert".to_string())));
     }
 
     #[test]
     fn test_parse_repo_folder_name_dataset() {
-        assert_eq!(parse_repo_folder_name("datasets--squad"), Some((RepoType::Dataset, "squad".to_string())));
+        assert_eq!(parse_repo_folder_name("datasets--squad"), Some(("dataset", "squad".to_string())));
     }
 
     #[test]
@@ -552,7 +549,7 @@ mod tests {
         let result = scan_cache_dir(cache).await.unwrap();
         assert_eq!(result.repos.len(), 1);
         assert_eq!(result.repos[0].repo_id, "gpt2");
-        assert_eq!(result.repos[0].repo_type, RepoType::Model);
+        assert_eq!(result.repos[0].repo_type, "model");
         assert_eq!(result.repos[0].revisions.len(), 1);
         assert_eq!(result.repos[0].revisions[0].refs, vec!["main"]);
         assert_eq!(result.repos[0].revisions[0].files.len(), 1);

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -303,22 +303,22 @@ impl HFClient {
         headers
     }
 
-    /// Build a URL for the API: {endpoint}/api/{segment}/{repo_id}
-    pub(crate) fn api_url(&self, repo_type: Option<crate::repository::RepoType>, repo_id: &str) -> String {
-        let segment = constants::repo_type_api_segment(repo_type);
-        format!("{}/api/{}/{}", self.endpoint(), segment, repo_id)
+    /// Build a URL for the API: {endpoint}/api/{api_segment}/{repo_id}.
+    ///
+    /// `api_segment` is the plural form of the repo type — `"models"`, `"datasets"`,
+    /// `"spaces"`, or `"kernels"`. Pass [`crate::repository::RepoType::plural`] for the
+    /// concrete repo type at the call site.
+    pub(crate) fn api_url(&self, api_segment: &str, repo_id: &str) -> String {
+        format!("{}/api/{}/{}", self.endpoint(), api_segment, repo_id)
     }
 
-    /// Build a download URL: {endpoint}/{prefix}{repo_id}/resolve/{revision}/{filename}
-    pub(crate) fn download_url(
-        &self,
-        repo_type: Option<crate::repository::RepoType>,
-        repo_id: &str,
-        revision: &str,
-        filename: &str,
-    ) -> String {
-        let prefix = constants::repo_type_url_prefix(repo_type);
-        format!("{}/{}{}/resolve/{}/{}", self.endpoint(), prefix, repo_id, revision, filename)
+    /// Build a download URL: {endpoint}/{url_prefix}{repo_id}/resolve/{revision}/{filename}.
+    ///
+    /// `url_prefix` is `""` for models or `"<plural>/"` for the other repo types. Pass
+    /// [`crate::repository::RepoType::url_prefix`] for the concrete repo type at the call
+    /// site.
+    pub(crate) fn download_url(&self, url_prefix: &str, repo_id: &str, revision: &str, filename: &str) -> String {
+        format!("{}/{}{}/resolve/{}/{}", self.endpoint(), url_prefix, repo_id, revision, filename)
     }
 
     /// Build a bucket API URL: `{endpoint}/api/buckets/{bucket_id}`

--- a/hf-hub/src/constants.rs
+++ b/hf-hub/src/constants.rs
@@ -24,27 +24,6 @@ pub(crate) const HEADER_X_REPO_COMMIT: &str = "x-repo-commit";
 pub(crate) const HEADER_X_LINKED_ETAG: &str = "x-linked-etag";
 pub(crate) const HEADER_X_LINKED_SIZE: &str = "x-linked-size";
 
-/// URL prefixes for different repo types
-/// Models have no prefix, datasets use "datasets/", spaces use "spaces/", kernels use "kernels/"
-pub fn repo_type_url_prefix(repo_type: Option<crate::repository::RepoType>) -> &'static str {
-    match repo_type {
-        None | Some(crate::repository::RepoType::Model) => "",
-        Some(crate::repository::RepoType::Dataset) => "datasets/",
-        Some(crate::repository::RepoType::Space) => "spaces/",
-        Some(crate::repository::RepoType::Kernel) => "kernels/",
-    }
-}
-
-/// API path segment for repo types: "models", "datasets", "spaces", "kernels"
-pub fn repo_type_api_segment(repo_type: Option<crate::repository::RepoType>) -> &'static str {
-    match repo_type {
-        None | Some(crate::repository::RepoType::Model) => "models",
-        Some(crate::repository::RepoType::Dataset) => "datasets",
-        Some(crate::repository::RepoType::Space) => "spaces",
-        Some(crate::repository::RepoType::Kernel) => "kernels",
-    }
-}
-
 pub(crate) fn dirs_or_home() -> String {
     std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string())
 }
@@ -74,28 +53,4 @@ pub fn resolve_cache_dir() -> std::path::PathBuf {
         return std::path::PathBuf::from(cache);
     }
     hf_home().join("hub")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{repo_type_api_segment, repo_type_url_prefix};
-    use crate::repository::RepoType;
-
-    #[test]
-    fn test_repo_type_url_prefix() {
-        assert_eq!(repo_type_url_prefix(None), "");
-        assert_eq!(repo_type_url_prefix(Some(RepoType::Model)), "");
-        assert_eq!(repo_type_url_prefix(Some(RepoType::Dataset)), "datasets/");
-        assert_eq!(repo_type_url_prefix(Some(RepoType::Space)), "spaces/");
-        assert_eq!(repo_type_url_prefix(Some(RepoType::Kernel)), "kernels/");
-    }
-
-    #[test]
-    fn test_repo_type_api_segment() {
-        assert_eq!(repo_type_api_segment(None), "models");
-        assert_eq!(repo_type_api_segment(Some(RepoType::Model)), "models");
-        assert_eq!(repo_type_api_segment(Some(RepoType::Dataset)), "datasets");
-        assert_eq!(repo_type_api_segment(Some(RepoType::Space)), "spaces");
-        assert_eq!(repo_type_api_segment(Some(RepoType::Kernel)), "kernels");
-    }
 }

--- a/hf-hub/src/error.rs
+++ b/hf-hub/src/error.rs
@@ -143,15 +143,6 @@ pub enum HFError {
         context: Option<Box<HttpErrorContext>>,
     },
 
-    /// A handle of the wrong repository type was used for an operation.
-    #[error("Invalid repository type: expected {expected}, got {actual}")]
-    InvalidRepoType {
-        /// Required repository type.
-        expected: crate::repository::RepoType,
-        /// Actual repository type on the handle.
-        actual: crate::repository::RepoType,
-    },
-
     /// Credentials are valid, but the caller is not allowed to perform the
     /// operation.
     #[error("Forbidden: {}{}", .context.url, format_http_suffix(.context))]

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -4,9 +4,12 @@
 //! the Rust counterpart to the Python [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library.
 //!
 //! The crate exposes a high-level, ergonomic API built around a single entry point,
-//! [`HFClient`], and a family of typed handles ([`HFRepository`], [`HFSpace`],
-//! [`HFBucket`]) that scope operations to a specific resource. All network I/O is
-//! async and driven by the [`reqwest`](https://docs.rs/reqwest) HTTP client with built-in retries on transient failures.
+//! [`HFClient`], and a family of typed handles ([`HFRepository<T>`](HFRepository),
+//! [`HFBucket`]) that scope operations to a specific resource. The repo kind lives in
+//! the type system via the [`RepoType`] trait and its four marker structs
+//! ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], [`RepoTypeKernel`]).
+//! All network I/O is async and driven by the [`reqwest`](https://docs.rs/reqwest)
+//! HTTP client with built-in retries on transient failures.
 //!
 //! ## Quick start
 //!
@@ -68,10 +71,11 @@
 //! ## Repository handles
 //!
 //! Rather than passing `(repo_type, owner, name)` to every method, bind them once
-//! with a typed handle:
+//! with a typed handle. The repo kind is encoded in the type via a marker
+//! ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], [`RepoTypeKernel`]):
 //!
 //! ```rust,no_run
-//! use hf_hub::{HFClient, RepoType};
+//! use hf_hub::HFClient;
 //!
 //! # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
 //! let client = HFClient::new()?;
@@ -79,17 +83,14 @@
 //! let model = client.model("openai-community", "gpt2");
 //! let dataset = client.dataset("HuggingFaceFW", "fineweb");
 //! let space = client.space("huggingface", "diffusers-gallery");
-//!
-//! // Or a generic repo when the type is only known at runtime:
-//! let repo = client.repo(RepoType::Model, "openai-community", "gpt2");
+//! let kernel = client.kernel("kernels-community", "cutlass-mla");
 //!
 //! let exists = model.exists().send().await?;
-//! # let _ = (dataset, space, repo, exists); Ok(()) }
+//! # let _ = (dataset, space, kernel, exists); Ok(()) }
 //! ```
 //!
-//! [`HFSpace`] dereferences to [`HFRepository`], so every generic repo method is
-//! available on Space handles in addition to Space-specific operations like
-//! hardware and secret management.
+//! Space-specific methods like `runtime`, `add_secret`, and `pause` live as `impl`
+//! blocks on `HFRepository<RepoTypeSpace>` — there is no separate `HFSpace` wrapper.
 //!
 //! ## File operations
 //!
@@ -160,8 +161,8 @@
 //! fn main() {}
 //! ```
 //!
-//! The blocking handles ([`HFClientSync`], [`HFRepositorySync`], [`HFSpaceSync`],
-//! [`HFBucketSync`]) mirror their async counterparts method-for-method.
+//! The blocking handles ([`HFClientSync`], [`HFRepositorySync`], [`HFBucketSync`])
+//! mirror their async counterparts method-for-method.
 //!
 //! ## Errors
 //!
@@ -215,7 +216,7 @@ pub(crate) mod xet;
 
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
-pub use blocking::{HFBucketSync, HFClientSync, HFRepositorySync, HFSpaceSync};
+pub use blocking::{HFBucketSync, HFClientSync, HFRepositorySync};
 #[doc(inline)]
 pub use buckets::HFBucket;
 pub use client::{HFClient, HFClientBuilder};
@@ -223,8 +224,4 @@ pub use client::{HFClient, HFClientBuilder};
 pub use constants::{hf_home, resolve_cache_dir};
 pub use error::{HFError, HFResult, XetOperation};
 #[doc(inline)]
-pub use repository::HFRepository;
-#[doc(inline)]
-pub use repository::RepoType;
-#[doc(inline)]
-pub use spaces::HFSpace;
+pub use repository::{HFRepository, RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};

--- a/hf-hub/src/repository/commits.rs
+++ b/hf-hub/src/repository/commits.rs
@@ -17,8 +17,8 @@ use futures::stream::{Stream, StreamExt};
 use serde::Deserialize;
 use url::Url;
 
-use super::HFRepository;
 use super::diff::{self, HFFileDiff};
+use super::{HFRepository, RepoType};
 use crate::error::HFResult;
 use crate::{constants, retry};
 
@@ -111,7 +111,7 @@ pub struct DiffEntry {
 }
 
 #[bon]
-impl HFRepository {
+impl<T: RepoType> HFRepository<T> {
     /// Stream commit history for the repository at a given revision.
     ///
     /// Returns `HFResult<impl Stream<Item = HFResult<GitCommitInfo>>>`. Pagination is automatic.
@@ -130,8 +130,7 @@ impl HFRepository {
         limit: Option<usize>,
     ) -> HFResult<impl Stream<Item = HFResult<GitCommitInfo>> + '_> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url_str =
-            format!("{}/commits/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), revision);
+        let url_str = format!("{}/commits/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
         let url = Url::parse(&url_str)?;
         Ok(self.hf_client.paginate(url, vec![], limit))
     }
@@ -150,7 +149,7 @@ impl HFRepository {
         #[builder(default)]
         include_pull_requests: bool,
     ) -> HFResult<GitRefs> {
-        let url = format!("{}/refs", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()));
+        let url = format!("{}/refs", self.hf_client.api_url(T::plural(), &self.repo_path()));
         let mut query: Vec<(&str, String)> = Vec::new();
         if include_pull_requests {
             query.push(("include_prs", "1".into()));
@@ -201,7 +200,7 @@ impl HFRepository {
         #[builder(into)]
         compare: String,
     ) -> HFResult<String> {
-        let url = format!("{}/compare/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), compare);
+        let url = format!("{}/compare/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), compare);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -242,7 +241,7 @@ impl HFRepository {
         #[builder(into)]
         compare: String,
     ) -> HFResult<String> {
-        let url = format!("{}/compare/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), compare);
+        let url = format!("{}/compare/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), compare);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -287,7 +286,7 @@ impl HFRepository {
         #[builder(into)]
         compare: String,
     ) -> HFResult<impl Stream<Item = HFResult<HFFileDiff>> + '_> {
-        let url = format!("{}/compare/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), compare);
+        let url = format!("{}/compare/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), compare);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -327,7 +326,7 @@ impl HFRepository {
         #[builder(into)]
         revision: Option<String>,
     ) -> HFResult<()> {
-        let url = format!("{}/branch/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), branch);
+        let url = format!("{}/branch/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), branch);
 
         let mut body = serde_json::Map::new();
         if let Some(ref rev) = revision {
@@ -366,7 +365,7 @@ impl HFRepository {
         #[builder(into)]
         branch: String,
     ) -> HFResult<()> {
-        let url = format!("{}/branch/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), branch);
+        let url = format!("{}/branch/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), branch);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -404,7 +403,7 @@ impl HFRepository {
         message: Option<String>,
     ) -> HFResult<()> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!("{}/tag/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), revision);
+        let url = format!("{}/tag/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
 
         let mut body = serde_json::json!({ "tag": tag });
         if let Some(ref m) = message {
@@ -443,7 +442,7 @@ impl HFRepository {
         #[builder(into)]
         tag: String,
     ) -> HFResult<()> {
-        let url = format!("{}/tag/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), tag);
+        let url = format!("{}/tag/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), tag);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -461,7 +460,7 @@ impl HFRepository {
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
+impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::list_commits`]. Collects the stream into a
     /// `Vec<GitCommitInfo>`.
     #[builder(finish_fn = send, derive(Debug, Clone))]

--- a/hf-hub/src/repository/commits.rs
+++ b/hf-hub/src/repository/commits.rs
@@ -130,7 +130,8 @@ impl<T: RepoType> HFRepository<T> {
         limit: Option<usize>,
     ) -> HFResult<impl Stream<Item = HFResult<GitCommitInfo>> + '_> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url_str = format!("{}/commits/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
+        let url_str =
+            format!("{}/commits/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), revision);
         let url = Url::parse(&url_str)?;
         Ok(self.hf_client.paginate(url, vec![], limit))
     }
@@ -149,7 +150,7 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(default)]
         include_pull_requests: bool,
     ) -> HFResult<GitRefs> {
-        let url = format!("{}/refs", self.hf_client.api_url(T::plural(), &self.repo_path()));
+        let url = format!("{}/refs", self.hf_client.api_url(T::default().plural(), &self.repo_path()));
         let mut query: Vec<(&str, String)> = Vec::new();
         if include_pull_requests {
             query.push(("include_prs", "1".into()));
@@ -200,7 +201,7 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         compare: String,
     ) -> HFResult<String> {
-        let url = format!("{}/compare/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), compare);
+        let url = format!("{}/compare/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), compare);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -241,7 +242,7 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         compare: String,
     ) -> HFResult<String> {
-        let url = format!("{}/compare/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), compare);
+        let url = format!("{}/compare/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), compare);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -286,7 +287,7 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         compare: String,
     ) -> HFResult<impl Stream<Item = HFResult<HFFileDiff>> + '_> {
-        let url = format!("{}/compare/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), compare);
+        let url = format!("{}/compare/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), compare);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -326,7 +327,7 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         revision: Option<String>,
     ) -> HFResult<()> {
-        let url = format!("{}/branch/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), branch);
+        let url = format!("{}/branch/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), branch);
 
         let mut body = serde_json::Map::new();
         if let Some(ref rev) = revision {
@@ -365,7 +366,7 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         branch: String,
     ) -> HFResult<()> {
-        let url = format!("{}/branch/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), branch);
+        let url = format!("{}/branch/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), branch);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -403,7 +404,7 @@ impl<T: RepoType> HFRepository<T> {
         message: Option<String>,
     ) -> HFResult<()> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!("{}/tag/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
+        let url = format!("{}/tag/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), revision);
 
         let mut body = serde_json::json!({ "tag": tag });
         if let Some(ref m) = message {
@@ -442,7 +443,7 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         tag: String,
     ) -> HFResult<()> {
-        let url = format!("{}/tag/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), tag);
+        let url = format!("{}/tag/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), tag);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -95,7 +95,7 @@ impl<T: RepoType> HFRepository<T> {
         let repo_path = self.repo_path();
         let url = self
             .hf_client
-            .download_url(T::url_prefix(), &repo_path, revision, &params.filename);
+            .download_url(T::default().url_prefix(), &repo_path, revision, &params.filename);
 
         let headers = self.hf_client.auth_headers();
         let head_response = retry::retry(self.hf_client.retry_config(), || {
@@ -187,7 +187,7 @@ impl<T: RepoType> HFRepository<T> {
         let repo_path = self.repo_path();
         let url = self
             .hf_client
-            .download_url(T::url_prefix(), &repo_path, revision, &params.filename);
+            .download_url(T::default().url_prefix(), &repo_path, revision, &params.filename);
 
         let headers = self.hf_client.auth_headers();
         let head_response = retry::retry(self.hf_client.retry_config(), || {
@@ -318,7 +318,7 @@ impl<T: RepoType> HFRepository<T> {
     async fn download_file_to_cache(&self, params: &DownloadFileParams) -> HFResult<PathBuf> {
         let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
         let cache_dir = self.hf_client.cache_dir();
-        let repo_folder = cache::repo_folder_name(&self.repo_path(), T::plural());
+        let repo_folder = cache::repo_folder_name(&self.repo_path(), T::default().plural());
         let force_download = params.force_download;
 
         if cache::is_commit_hash(revision) && !force_download {
@@ -355,7 +355,7 @@ impl<T: RepoType> HFRepository<T> {
         let repo_path = self.repo_path();
         let url = self
             .hf_client
-            .download_url(T::url_prefix(), &repo_path, revision, &params.filename);
+            .download_url(T::default().url_prefix(), &repo_path, revision, &params.filename);
 
         let cached_etag = if !force_download {
             self.find_cached_etag(repo_folder, revision, &params.filename)
@@ -548,7 +548,7 @@ impl<T: RepoType> HFRepository<T> {
         }
         let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
         let max_workers = params.max_workers.unwrap_or(8);
-        let repo_folder = cache::repo_folder_name(&self.repo_path(), T::plural());
+        let repo_folder = cache::repo_folder_name(&self.repo_path(), T::default().plural());
         let cache_dir = self.hf_client.cache_dir();
 
         if params.local_files_only {
@@ -595,7 +595,7 @@ impl<T: RepoType> HFRepository<T> {
         let commit_hash_ref = &commit_hash;
         let head_futs = filenames.iter().map(|filename| {
                 let url = self
-                    .hf_client.download_url(T::url_prefix(), &repo_path, commit_hash_ref, filename);
+                    .hf_client.download_url(T::default().url_prefix(), &repo_path, commit_hash_ref, filename);
                 let auth = self.hf_client.auth_headers();
                 let filename = filename.clone();
                 let repo_folder_ref = &repo_folder;

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -18,6 +18,7 @@ use bon::bon;
 use futures::TryStreamExt;
 use futures::stream::{Stream, StreamExt};
 use reqwest::header::IF_NONE_MATCH;
+use serde::Deserialize;
 
 use super::files::{extract_commit_hash, extract_etag, extract_file_size, extract_xet_hash, matches_any_glob};
 use super::{FileMetadataInfo, HFRepository, RepoTreeEntry, RepoType};
@@ -56,7 +57,7 @@ struct SnapshotDownloadParams {
     progress: Option<Progress>,
 }
 
-impl HFRepository {
+impl<T: RepoType> HFRepository<T> {
     async fn download_file_impl(&self, params: DownloadFileParams) -> HFResult<PathBuf> {
         let result = self.download_file_inner(&params).await;
         if result.is_ok() {
@@ -94,7 +95,7 @@ impl HFRepository {
         let repo_path = self.repo_path();
         let url = self
             .hf_client
-            .download_url(Some(self.repo_type), &repo_path, revision, &params.filename);
+            .download_url(T::url_prefix(), &repo_path, revision, &params.filename);
 
         let headers = self.hf_client.auth_headers();
         let head_response = retry::retry(self.hf_client.retry_config(), || {
@@ -186,7 +187,7 @@ impl HFRepository {
         let repo_path = self.repo_path();
         let url = self
             .hf_client
-            .download_url(Some(self.repo_type), &repo_path, revision, &params.filename);
+            .download_url(T::url_prefix(), &repo_path, revision, &params.filename);
 
         let headers = self.hf_client.auth_headers();
         let head_response = retry::retry(self.hf_client.retry_config(), || {
@@ -317,7 +318,7 @@ impl HFRepository {
     async fn download_file_to_cache(&self, params: &DownloadFileParams) -> HFResult<PathBuf> {
         let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
         let cache_dir = self.hf_client.cache_dir();
-        let repo_folder = cache::repo_folder_name(&self.repo_path(), Some(self.repo_type));
+        let repo_folder = cache::repo_folder_name(&self.repo_path(), T::plural());
         let force_download = params.force_download;
 
         if cache::is_commit_hash(revision) && !force_download {
@@ -354,7 +355,7 @@ impl HFRepository {
         let repo_path = self.repo_path();
         let url = self
             .hf_client
-            .download_url(Some(self.repo_type), &repo_path, revision, &params.filename);
+            .download_url(T::url_prefix(), &repo_path, revision, &params.filename);
 
         let cached_etag = if !force_download {
             self.find_cached_etag(repo_folder, revision, &params.filename)
@@ -503,13 +504,13 @@ impl HFRepository {
         if cache::is_commit_hash(revision) {
             return Ok(revision.to_string());
         }
+        #[derive(Deserialize)]
+        struct ShaOnly {
+            sha: Option<String>,
+        }
         let repo_path = self.repo_path();
-        let sha = match self.repo_type {
-            RepoType::Dataset => self.dataset_info(Some(revision.to_string()), None).await?.sha,
-            RepoType::Space => self.space_info(Some(revision.to_string()), None).await?.sha,
-            _ => self.model_info(Some(revision.to_string()), None).await?.sha,
-        };
-        sha.ok_or_else(|| {
+        let info: ShaOnly = self.fetch_repo_info(Some(revision.to_string()), None).await?;
+        info.sha.ok_or_else(|| {
             HFError::malformed_response(format!("repo info for {}@{} returned no commit sha", repo_path, revision))
         })
     }
@@ -547,7 +548,7 @@ impl HFRepository {
         }
         let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
         let max_workers = params.max_workers.unwrap_or(8);
-        let repo_folder = cache::repo_folder_name(&self.repo_path(), Some(self.repo_type));
+        let repo_folder = cache::repo_folder_name(&self.repo_path(), T::plural());
         let cache_dir = self.hf_client.cache_dir();
 
         if params.local_files_only {
@@ -594,7 +595,7 @@ impl HFRepository {
         let commit_hash_ref = &commit_hash;
         let head_futs = filenames.iter().map(|filename| {
                 let url = self
-                    .hf_client.download_url(Some(self.repo_type), &repo_path, commit_hash_ref, filename);
+                    .hf_client.download_url(T::url_prefix(), &repo_path, commit_hash_ref, filename);
                 let auth = self.hf_client.auth_headers();
                 let filename = filename.clone();
                 let repo_folder_ref = &repo_folder;
@@ -721,7 +722,6 @@ impl HFRepository {
             let non_xet_dl_params = build_download_params(
                 &repo_path,
                 &non_xet_filenames,
-                Some(self.repo_type),
                 &commit_hash,
                 params.force_download,
                 Some(local_dir.clone()),
@@ -790,7 +790,6 @@ impl HFRepository {
         let non_xet_dl_params = build_download_params(
             &repo_path,
             &non_xet_filenames,
-            Some(self.repo_type),
             &commit_hash,
             params.force_download,
             None,
@@ -855,7 +854,6 @@ async fn finalize_cached_file(
 fn build_download_params(
     _repo_id: &str,
     filenames: &[String],
-    _repo_type: Option<RepoType>,
     commit_hash: &str,
     force_download: bool,
     local_dir: Option<PathBuf>,
@@ -874,8 +872,8 @@ fn build_download_params(
         .collect()
 }
 
-async fn download_concurrently(
-    api: &HFRepository,
+async fn download_concurrently<T: RepoType>(
+    api: &HFRepository<T>,
     params: &[DownloadFileParams],
     max_workers: usize,
 ) -> HFResult<Vec<PathBuf>> {
@@ -968,7 +966,7 @@ fn wrap_stream_with_progress(
 }
 
 #[bon]
-impl HFRepository {
+impl<T: RepoType> HFRepository<T> {
     /// Download a single file from a repository.
     ///
     /// When `local_dir` is `Some`, the file is downloaded directly to that directory
@@ -1178,7 +1176,7 @@ impl HFRepository {
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
+impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::download_file`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]

--- a/hf-hub/src/repository/listing.rs
+++ b/hf-hub/src/repository/listing.rs
@@ -48,7 +48,7 @@ impl<T: RepoType> HFRepository<T> {
         limit: Option<usize>,
     ) -> HFResult<impl Stream<Item = HFResult<RepoTreeEntry>> + '_> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url_str = format!("{}/tree/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
+        let url_str = format!("{}/tree/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), revision);
         let url = Url::parse(&url_str)?;
 
         let mut query: Vec<(String, String)> = Vec::new();
@@ -83,7 +83,8 @@ impl<T: RepoType> HFRepository<T> {
         revision: Option<String>,
     ) -> HFResult<Vec<RepoTreeEntry>> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!("{}/paths-info/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
+        let url =
+            format!("{}/paths-info/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), revision);
 
         let body = serde_json::json!({ "paths": paths });
 
@@ -130,7 +131,9 @@ impl<T: RepoType> HFRepository<T> {
         let filename = filepath.clone();
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
         let repo_path = self.repo_path();
-        let url = self.hf_client.download_url(T::url_prefix(), &repo_path, revision, &filename);
+        let url = self
+            .hf_client
+            .download_url(T::default().url_prefix(), &repo_path, revision, &filename);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {

--- a/hf-hub/src/repository/listing.rs
+++ b/hf-hub/src/repository/listing.rs
@@ -13,12 +13,12 @@ use futures::stream::Stream;
 use reqwest::Url;
 
 use super::files::{extract_commit_hash, extract_etag, extract_file_size, extract_xet_hash};
-use super::{FileMetadataInfo, HFRepository, RepoTreeEntry};
+use super::{FileMetadataInfo, HFRepository, RepoTreeEntry, RepoType};
 use crate::error::{HFError, HFResult};
 use crate::{constants, retry};
 
 #[bon]
-impl HFRepository {
+impl<T: RepoType> HFRepository<T> {
     /// Stream file and directory entries in the repository tree.
     ///
     /// Returns `HFResult<impl Stream<Item = HFResult<RepoTreeEntry>>>`.
@@ -48,7 +48,7 @@ impl HFRepository {
         limit: Option<usize>,
     ) -> HFResult<impl Stream<Item = HFResult<RepoTreeEntry>> + '_> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url_str = format!("{}/tree/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), revision);
+        let url_str = format!("{}/tree/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
         let url = Url::parse(&url_str)?;
 
         let mut query: Vec<(String, String)> = Vec::new();
@@ -83,8 +83,7 @@ impl HFRepository {
         revision: Option<String>,
     ) -> HFResult<Vec<RepoTreeEntry>> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url =
-            format!("{}/paths-info/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), revision);
+        let url = format!("{}/paths-info/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
 
         let body = serde_json::json!({ "paths": paths });
 
@@ -131,9 +130,7 @@ impl HFRepository {
         let filename = filepath.clone();
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
         let repo_path = self.repo_path();
-        let url = self
-            .hf_client
-            .download_url(Some(self.repo_type), &repo_path, revision, &filename);
+        let url = self.hf_client.download_url(T::url_prefix(), &repo_path, revision, &filename);
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -177,7 +174,7 @@ use futures::stream::StreamExt as _;
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
+impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::list_tree`]. Returns the collected stream as a
     /// `Vec<RepoTreeEntry>`.
     #[builder(finish_fn = send, derive(Debug, Clone))]

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -1,9 +1,11 @@
 //! Repository handles, metadata types, and list/create/delete/move APIs.
 //!
 //! Start from [`crate::HFClient`] — [`crate::HFClient::model`], [`crate::HFClient::dataset`],
-//! [`crate::HFClient::space`], and [`crate::HFClient::repo`] return a repo handle ([`HFRepository`]
-//! or [`crate::HFSpace`], which derefs to [`HFRepository`]). All read/write file and revision APIs
-//! hang off that value.
+//! [`crate::HFClient::space`], and [`crate::HFClient::kernel`] return a typed
+//! [`HFRepository<T>`](HFRepository) for the corresponding repo kind. All read/write
+//! file and revision APIs hang off that value; methods that differ per repo kind (such
+//! as [`info`](HFRepository::info)) are resolved at compile time via the [`RepoType`]
+//! type parameter.
 //!
 //! Submodule pages group related builders and types:
 //!
@@ -22,9 +24,11 @@ pub mod diff;
 pub mod download;
 pub mod files;
 pub mod listing;
+pub mod repo_type;
 pub mod upload;
 
 use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::str::FromStr;
 
 use bon::bon;
@@ -36,6 +40,7 @@ pub use files::{
 };
 pub(crate) use files::{extract_file_size, extract_xet_hash};
 use futures::Stream;
+pub use repo_type::{RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize, Serializer};
 use url::Url;
@@ -43,20 +48,6 @@ use url::Url;
 use crate::client::HFClient;
 use crate::error::{HFError, HFResult};
 use crate::{constants, retry};
-
-/// The kind of repository on the Hugging Face Hub.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum RepoType {
-    /// A model repository.
-    Model,
-    /// A dataset repository.
-    Dataset,
-    /// A Space (interactive app) repository.
-    Space,
-    /// A kernel repository.
-    Kernel,
-}
 
 /// Access-gating mode for a repository.
 ///
@@ -108,23 +99,6 @@ impl GatedNotifications {
         self.email = Some(email.into());
         self
     }
-}
-
-/// Repo-type-tagged wrapper over [`ModelInfo`], [`DatasetInfo`], and [`SpaceInfo`].
-///
-/// Returned by [`HFRepository::info`]; the active variant
-/// matches the repository's [`RepoType`].
-#[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
-pub enum RepoInfo {
-    /// Info for a model repository.
-    Model(ModelInfo),
-    /// Info for a dataset repository.
-    Dataset(DatasetInfo),
-    /// Info for a Space repository.
-    Space(SpaceInfo),
-    /// Info for a kernel repository.
-    Kernel(KernelInfo),
 }
 
 /// A single file entry in a repository's flat "siblings" listing, as returned by the repo info endpoint.
@@ -479,7 +453,7 @@ pub struct SpaceInfo {
     /// Runtime state of the Space (stage, hardware, sleep time, volumes, etc.).
     ///
     /// Populated when the repo info request expands the `runtime` field. The same shape is also
-    /// returned by [`HFSpace::runtime`](crate::HFSpace::runtime).
+    /// returned by [`HFRepository::<RepoTypeSpace>::runtime`](HFRepository::runtime).
     pub runtime: Option<crate::spaces::SpaceRuntime>,
     /// Datasets used by the Space, declared in the Space card.
     pub datasets: Option<Vec<String>>,
@@ -540,11 +514,15 @@ pub struct RepoUrl {
     pub url: String,
 }
 
-/// A handle for a single repository on the Hugging Face Hub.
+/// A handle for a single repository on the Hugging Face Hub, parameterised by the
+/// repo kind via the type-level marker `T`.
 ///
-/// `HFRepository` is created via [`HFClient::repo`], [`HFClient::model`], or
-/// [`HFClient::dataset`] and binds together the client, owner, repo name, and repo type.
-/// All repo-scoped API operations are methods on this type.
+/// `HFRepository<T>` is created via the typed factories on [`HFClient`] —
+/// [`HFClient::model`], [`HFClient::dataset`], [`HFClient::space`], or
+/// [`HFClient::kernel`] — and binds together the client, owner, and repo name. The
+/// repo kind lives in the type system rather than in a runtime field, so methods
+/// that differ per repo kind (such as [`info`](HFRepository::info)) are dispatched
+/// at compile time and mismatches are impossible by construction.
 ///
 /// Cheap to clone — the inner [`HFClient`] is `Arc`-backed.
 ///
@@ -558,37 +536,20 @@ pub struct RepoUrl {
 /// let info = repo.info().send().await?;
 /// # Ok(()) }
 /// ```
-#[derive(Clone)]
-pub struct HFRepository {
+pub struct HFRepository<T: RepoType> {
     pub(crate) hf_client: HFClient,
     pub(super) owner: String,
     pub(super) name: String,
-    pub(crate) repo_type: RepoType,
+    _ty: PhantomData<fn() -> T>,
 }
 
-impl std::fmt::Display for RepoType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RepoType::Model => write!(f, "model"),
-            RepoType::Dataset => write!(f, "dataset"),
-            RepoType::Space => write!(f, "space"),
-            RepoType::Kernel => write!(f, "kernel"),
-        }
-    }
-}
-
-impl FromStr for RepoType {
-    type Err = HFError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "model" => Ok(RepoType::Model),
-            "dataset" => Ok(RepoType::Dataset),
-            "space" => Ok(RepoType::Space),
-            "kernel" => Ok(RepoType::Kernel),
-            _ => Err(HFError::InvalidParameter(format!(
-                "unknown repo type: {s:?}. Expected 'model', 'dataset', 'space', or 'kernel'"
-            ))),
+impl<T: RepoType> Clone for HFRepository<T> {
+    fn clone(&self) -> Self {
+        Self {
+            hf_client: self.hf_client.clone(),
+            owner: self.owner.clone(),
+            name: self.name.clone(),
+            _ty: PhantomData,
         }
     }
 }
@@ -635,97 +596,57 @@ impl FromStr for GatedNotificationsMode {
     }
 }
 
-impl RepoInfo {
-    /// The [`RepoType`] of the active variant.
-    pub fn repo_type(&self) -> RepoType {
-        match self {
-            RepoInfo::Model(_) => RepoType::Model,
-            RepoInfo::Dataset(_) => RepoType::Dataset,
-            RepoInfo::Space(_) => RepoType::Space,
-            RepoInfo::Kernel(_) => RepoType::Kernel,
-        }
-    }
-
-    /// Consume `self` and return the [`ModelInfo`] when this is a model repo.
-    ///
-    /// Useful when the caller already knows the repo type at compile time —
-    /// e.g. after `client.model(...)` — and wants to avoid a `match` on
-    /// [`RepoInfo`]. On a mismatch returns [`HFError::Other`] naming the
-    /// variant that was found instead.
-    pub fn into_model_info(self) -> HFResult<ModelInfo> {
-        match self {
-            RepoInfo::Model(info) => Ok(info),
-            other => Err(HFError::Other(format!("expected RepoInfo::Model, got RepoInfo::{:?}", other.repo_type()))),
-        }
-    }
-
-    /// Consume `self` and return the [`DatasetInfo`] when this is a dataset repo.
-    ///
-    /// Useful when the caller already knows the repo type at compile time —
-    /// e.g. after `client.dataset(...)` — and wants to avoid a `match` on
-    /// [`RepoInfo`]. On a mismatch returns [`HFError::Other`] naming the
-    /// variant that was found instead.
-    pub fn into_dataset_info(self) -> HFResult<DatasetInfo> {
-        match self {
-            RepoInfo::Dataset(info) => Ok(info),
-            other => Err(HFError::Other(format!("expected RepoInfo::Dataset, got RepoInfo::{:?}", other.repo_type()))),
-        }
-    }
-
-    /// Consume `self` and return the [`SpaceInfo`] when this is a Space repo.
-    ///
-    /// Useful when the caller already knows the repo type at compile time —
-    /// e.g. after `client.space(...)` — and wants to avoid a `match` on
-    /// [`RepoInfo`]. On a mismatch returns [`HFError::Other`] naming the
-    /// variant that was found instead.
-    pub fn into_space_info(self) -> HFResult<SpaceInfo> {
-        match self {
-            RepoInfo::Space(info) => Ok(info),
-            other => Err(HFError::Other(format!("expected RepoInfo::Space, got RepoInfo::{:?}", other.repo_type()))),
-        }
-    }
-
-    /// Consume `self` and return the [`KernelInfo`] when this is a kernel repo.
-    ///
-    /// Useful when the caller already knows the repo type at compile time —
-    /// e.g. after `client.repo(RepoType::Kernel, ...)` — and wants to avoid a
-    /// `match` on [`RepoInfo`]. On a mismatch returns [`HFError::Other`]
-    /// naming the variant that was found instead.
-    pub fn into_kernel_info(self) -> HFResult<KernelInfo> {
-        match self {
-            RepoInfo::Kernel(info) => Ok(info),
-            other => Err(HFError::Other(format!("expected RepoInfo::Kernel, got RepoInfo::{:?}", other.repo_type()))),
-        }
-    }
-}
-
-impl std::fmt::Debug for HFRepository {
+impl<T: RepoType> std::fmt::Debug for HFRepository<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HFRepository")
             .field("owner", &self.owner)
             .field("name", &self.name)
-            .field("repo_type", &self.repo_type)
+            .field("repo_type", &T::singular())
             .finish()
+    }
+}
+
+impl HFClient {
+    /// Create an [`HFRepository`] handle for any repo kind via a turbofished generic.
+    ///
+    /// Equivalent to the typed shortcuts ([`model`](Self::model), [`dataset`](Self::dataset),
+    /// [`space`](Self::space), [`kernel`](Self::kernel)) but useful when the kind is
+    /// expressed by an external type parameter or a `match` arm — for example, dispatching
+    /// from a CLI flag:
+    ///
+    /// ```rust,no_run
+    /// # use hf_hub::{HFClient, RepoTypeDataset};
+    /// # let client = HFClient::builder().build().unwrap();
+    /// let repo = client.repository::<RepoTypeDataset>("rajpurkar", "squad");
+    /// # let _ = repo;
+    /// ```
+    pub fn repository<T: RepoType>(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository<T> {
+        HFRepository::new(self.clone(), owner, name)
+    }
+
+    /// Create an [`HFRepository`] handle for a model repository.
+    pub fn model(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository<RepoTypeModel> {
+        self.repository::<RepoTypeModel>(owner, name)
+    }
+
+    /// Create an [`HFRepository`] handle for a dataset repository.
+    pub fn dataset(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository<RepoTypeDataset> {
+        self.repository::<RepoTypeDataset>(owner, name)
+    }
+
+    /// Create an [`HFRepository`] handle for a Space repository.
+    pub fn space(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository<RepoTypeSpace> {
+        self.repository::<RepoTypeSpace>(owner, name)
+    }
+
+    /// Create an [`HFRepository`] handle for a kernel repository.
+    pub fn kernel(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository<RepoTypeKernel> {
+        self.repository::<RepoTypeKernel>(owner, name)
     }
 }
 
 #[bon]
 impl HFClient {
-    /// Create an [`HFRepository`] handle for any repo type.
-    pub fn repo(&self, repo_type: RepoType, owner: impl Into<String>, name: impl Into<String>) -> HFRepository {
-        HFRepository::new(self.clone(), repo_type, owner, name)
-    }
-
-    /// Create an [`HFRepository`] handle for a model repository.
-    pub fn model(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository {
-        self.repo(RepoType::Model, owner, name)
-    }
-
-    /// Create an [`HFRepository`] handle for a dataset repository.
-    pub fn dataset(&self, owner: impl Into<String>, name: impl Into<String>) -> HFRepository {
-        self.repo(RepoType::Dataset, owner, name)
-    }
-
     /// List models on the Hub. Endpoint: `GET /api/models`.
     ///
     /// Returns a stream of [`ModelInfo`] entries. Pagination is automatic.
@@ -958,31 +879,32 @@ impl HFClient {
         Ok(self.paginate(url, query, limit))
     }
 
-    /// Create a new repository. Endpoint: `POST /api/repos/create`.
+    /// Create a new repository of kind `T`. Endpoint: `POST /api/repos/create`.
+    ///
+    /// `T` is the repo kind picked at the call site via turbofish — e.g.
+    /// `client.create_repo::<RepoTypeDataset>()...` to create a dataset. The body
+    /// always includes the `type` field, matching the Hub's per-kind defaults.
     ///
     /// # Parameters
     ///
     /// - `repo_id` (required): repository ID in `"owner/name"` or `"name"` format.
-    /// - `repo_type`: type of repository to create (model, dataset, space, kernel).
     /// - `private`: whether the repository should be private.
     /// - `exist_ok` (default `false`): if `true`, do not error when the repository already exists.
-    /// - `space_sdk`: SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `repo_type` is
-    ///   `Space`; ignored for other repo types.
+    /// - `space_sdk`: SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `T` is
+    ///   [`RepoTypeSpace`]; ignored for other repo kinds.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn create_repo(
+    pub async fn create_repo<T: RepoType>(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
-        /// Type of repository to create (model, dataset, space, kernel).
-        repo_type: Option<RepoType>,
         /// Whether the repository should be private.
         private: Option<bool>,
         /// If `true`, do not error when the repository already exists.
         #[builder(default)]
         exist_ok: bool,
-        /// SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `repo_type` is `Space`;
-        /// ignored for other repo types.
+        /// SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `T` is
+        /// [`RepoTypeSpace`]; ignored for other repo kinds.
         #[builder(into)]
         space_sdk: Option<String>,
     ) -> HFResult<RepoUrl> {
@@ -993,13 +915,11 @@ impl HFClient {
         let mut body = serde_json::json!({
             "name": name,
             "private": private.unwrap_or(false),
+            "type": T::singular(),
         });
 
         if let Some(ns) = namespace {
             body["organization"] = serde_json::Value::String(ns.to_string());
-        }
-        if let Some(ref rt) = repo_type {
-            body["type"] = serde_json::Value::String(rt.to_string());
         }
         if let Some(ref sdk) = space_sdk {
             body["sdk"] = serde_json::Value::String(sdk.clone());
@@ -1012,9 +932,8 @@ impl HFClient {
         .await?;
 
         if response.status().as_u16() == 409 && exist_ok {
-            let prefix = constants::repo_type_url_prefix(repo_type);
             return Ok(RepoUrl {
-                url: format!("{}/{}{}", self.endpoint(), prefix, repo_id),
+                url: format!("{}/{}{}", self.endpoint(), T::url_prefix(), repo_id),
             });
         }
 
@@ -1024,21 +943,22 @@ impl HFClient {
         Ok(response.json().await?)
     }
 
-    /// Delete a repository. Endpoint: `DELETE /api/repos/delete`.
+    /// Delete a repository of kind `T`. Endpoint: `DELETE /api/repos/delete`.
+    ///
+    /// `T` is the repo kind picked at the call site via turbofish — e.g.
+    /// `client.delete_repo::<RepoTypeSpace>()...`. The body always includes
+    /// the `type` field.
     ///
     /// # Parameters
     ///
     /// - `repo_id` (required): repository ID in `"owner/name"` or `"name"` format.
-    /// - `repo_type`: type of repository.
     /// - `missing_ok` (default `false`): if `true`, do not error when the repository does not exist.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn delete_repo(
+    pub async fn delete_repo<T: RepoType>(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
-        /// Type of repository.
-        repo_type: Option<RepoType>,
         /// If `true`, do not error when the repository does not exist.
         #[builder(default)]
         missing_ok: bool,
@@ -1047,12 +967,12 @@ impl HFClient {
 
         let (namespace, name) = split_repo_id(&repo_id);
 
-        let mut body = serde_json::json!({ "name": name });
+        let mut body = serde_json::json!({
+            "name": name,
+            "type": T::singular(),
+        });
         if let Some(ns) = namespace {
             body["organization"] = serde_json::Value::String(ns.to_string());
-        }
-        if let Some(ref rt) = repo_type {
-            body["type"] = serde_json::Value::String(rt.to_string());
         }
 
         let headers = self.auth_headers();
@@ -1070,15 +990,18 @@ impl HFClient {
         Ok(())
     }
 
-    /// Move (rename) a repository. Endpoint: `POST /api/repos/move`.
+    /// Move (rename) a repository of kind `T`. Endpoint: `POST /api/repos/move`.
+    ///
+    /// `T` is the repo kind picked at the call site via turbofish — e.g.
+    /// `client.move_repo::<RepoTypeModel>()...`. The body always includes
+    /// the `type` field.
     ///
     /// # Parameters
     ///
     /// - `from_id` (required): current repository ID in `"owner/name"` format.
     /// - `to_id` (required): new repository ID in `"owner/name"` format.
-    /// - `repo_type`: type of repository to move.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn move_repo(
+    pub async fn move_repo<T: RepoType>(
         &self,
         /// Current repository ID in `"owner/name"` format.
         #[builder(into)]
@@ -1086,17 +1009,13 @@ impl HFClient {
         /// New repository ID in `"owner/name"` format.
         #[builder(into)]
         to_id: String,
-        /// Type of repository to move.
-        repo_type: Option<RepoType>,
     ) -> HFResult<RepoUrl> {
         let url = format!("{}/api/repos/move", self.endpoint());
-        let mut body = serde_json::json!({
+        let body = serde_json::json!({
             "fromRepo": from_id,
             "toRepo": to_id,
+            "type": T::singular(),
         });
-        if let Some(ref rt) = repo_type {
-            body["type"] = serde_json::Value::String(rt.to_string());
-        }
 
         let headers = self.auth_headers();
         let response = retry::retry(self.retry_config(), || {
@@ -1106,21 +1025,20 @@ impl HFClient {
 
         self.check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
-        let prefix = constants::repo_type_url_prefix(repo_type);
         Ok(RepoUrl {
-            url: format!("{}/{}{}", self.endpoint(), prefix, to_id),
+            url: format!("{}/{}{}", self.endpoint(), T::url_prefix(), to_id),
         })
     }
 }
 
-impl HFRepository {
+impl<T: RepoType> HFRepository<T> {
     /// Construct a new repository handle. Prefer the factory methods on [`HFClient`] instead.
-    pub fn new(client: HFClient, repo_type: RepoType, owner: impl Into<String>, name: impl Into<String>) -> Self {
+    pub fn new(client: HFClient, owner: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             hf_client: client,
             owner: owner.into(),
             name: name.into(),
-            repo_type,
+            _ty: PhantomData,
         }
     }
 
@@ -1150,19 +1068,22 @@ impl HFRepository {
         }
     }
 
-    /// The type of this repository (model, dataset, space, or kernel).
-    pub fn repo_type(&self) -> RepoType {
-        self.repo_type
+    /// Lowercase singular name of this repo's kind (`"model"`, `"dataset"`, `"space"`, or `"kernel"`).
+    ///
+    /// Equivalent to `T::singular()` for the type parameter on this handle. Useful for
+    /// logs and error messages without naming `T` explicitly.
+    pub fn repo_type(&self) -> &'static str {
+        T::singular()
     }
 
-    /// Fetch repo info for this repository's `repo_type`, deserializing into `T`.
-    /// Endpoint: GET /api/{repo_type}s/{repo_id}[/revision/{revision}]
-    async fn fetch_repo_info<T: DeserializeOwned>(
+    /// Fetch repo info for this repository's kind, deserializing into `I`.
+    /// Endpoint: `GET /api/{plural}/{repo_id}[/revision/{revision}]`.
+    pub(crate) async fn fetch_repo_info<I: DeserializeOwned>(
         &self,
         revision: Option<String>,
         expand: Option<Vec<String>>,
-    ) -> HFResult<T> {
-        let mut url = self.hf_client.api_url(Some(self.repo_type), &self.repo_path());
+    ) -> HFResult<I> {
+        let mut url = self.hf_client.api_url(T::plural(), &self.repo_path());
         if let Some(ref revision) = revision {
             url = format!("{url}/revision/{revision}");
         }
@@ -1185,83 +1106,10 @@ impl HFRepository {
         let response = self.hf_client.check_response(response, Some(&repo_path), not_found_ctx).await?;
         Ok(response.json().await?)
     }
-
-    pub(crate) async fn model_info(
-        &self,
-        revision: Option<String>,
-        expand: Option<Vec<String>>,
-    ) -> HFResult<ModelInfo> {
-        self.fetch_repo_info(revision, expand).await
-    }
-
-    pub(crate) async fn dataset_info(
-        &self,
-        revision: Option<String>,
-        expand: Option<Vec<String>>,
-    ) -> HFResult<DatasetInfo> {
-        self.fetch_repo_info(revision, expand).await
-    }
-
-    pub(crate) async fn space_info(
-        &self,
-        revision: Option<String>,
-        expand: Option<Vec<String>>,
-    ) -> HFResult<SpaceInfo> {
-        self.fetch_repo_info(revision, expand).await
-    }
-
-    /// Fetch kernel-specific info from `/api/kernels/{repo_id}` (or
-    /// `/api/kernels/{repo_id}/revision/{revision}` when pinned).
-    ///
-    /// Note: the Hub silently ignores `expand` on this endpoint; the parameter
-    /// is plumbed through for symmetry but does not change the response shape.
-    pub(crate) async fn kernel_info(
-        &self,
-        revision: Option<String>,
-        expand: Option<Vec<String>>,
-    ) -> HFResult<KernelInfo> {
-        self.fetch_repo_info(revision, expand).await
-    }
 }
 
 #[bon]
-impl HFRepository {
-    /// Fetch repository metadata, returning the appropriate [`RepoInfo`] variant.
-    ///
-    /// When the caller statically knows the repo type — e.g. after `client.model(...)`,
-    /// `client.dataset(...)`, `client.space(...)`, or `client.repo(RepoType::Kernel, ...)` —
-    /// prefer the typed accessors [`RepoInfo::into_model`], [`RepoInfo::into_dataset`],
-    /// [`RepoInfo::into_space`], and [`RepoInfo::into_kernel`] over a manual `match` on the
-    /// returned enum.
-    ///
-    /// For [`RepoType::Kernel`], note that the Hub's `/api/kernels/{repo_id}` endpoint returns
-    /// a slim shape (no `tags`, `cardData`, or `siblings`) and silently ignores `expand`. To get
-    /// the full model-style metadata for a kernel, build a model handle for the same repo id
-    /// (`client.model(owner, name)`) and call `info()` on it.
-    ///
-    /// # Parameters
-    ///
-    /// - `revision`: Git revision (branch, tag, or commit SHA). Defaults to the main branch.
-    /// - `expand`: list of properties to expand in the response (e.g. `"trendingScore"`, `"cardData"`). When set, only
-    ///   the listed properties (plus `_id` and `id`) are returned. Ignored for kernel repos.
-    #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn info(
-        &self,
-        /// Git revision (branch, tag, or commit SHA). Defaults to the main branch.
-        #[builder(into)]
-        revision: Option<String>,
-        /// List of properties to expand in the response (e.g. `"trendingScore"`, `"cardData"`). When set, only
-        /// the listed properties (plus `_id` and `id`) are returned. Ignored for kernel repos.
-        expand: Option<Vec<String>>,
-    ) -> HFResult<RepoInfo> {
-        match self.repo_type {
-            RepoType::Model => self.model_info(revision, expand).await.map(RepoInfo::Model),
-            RepoType::Dataset => self.dataset_info(revision, expand).await.map(RepoInfo::Dataset),
-            RepoType::Space => self.space_info(revision, expand).await.map(RepoInfo::Space),
-            RepoType::Kernel => self.kernel_info(revision, expand).await.map(RepoInfo::Kernel),
-        }
-    }
-
+impl<T: RepoType> HFRepository<T> {
     /// Return `true` if the repository exists.
     ///
     /// Returns `Ok(false)` only when the Hub responds with 404. If the repo exists but the current
@@ -1269,7 +1117,7 @@ impl HFRepository {
     /// ([`HFError::AuthRequired`] or [`HFError::Forbidden`]), not `Ok(false)`.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub async fn exists(&self) -> HFResult<bool> {
-        let url = self.hf_client.api_url(Some(self.repo_type), &self.repo_path());
+        let url = self.hf_client.api_url(T::plural(), &self.repo_path());
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
             self.hf_client.http_client().get(&url).headers(headers.clone()).send()
@@ -1300,7 +1148,7 @@ impl HFRepository {
         #[builder(into)]
         revision: String,
     ) -> HFResult<bool> {
-        let url = format!("{}/revision/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), revision);
+        let url = format!("{}/revision/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
             self.hf_client.http_client().get(&url).headers(headers.clone()).send()
@@ -1334,7 +1182,7 @@ impl HFRepository {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
         let url = self
             .hf_client
-            .download_url(Some(self.repo_type), &self.repo_path(), revision, &filename);
+            .download_url(T::url_prefix(), &self.repo_path(), revision, &filename);
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
             self.hf_client.http_client().head(&url).headers(headers.clone()).send()
@@ -1359,7 +1207,7 @@ impl HFRepository {
     /// Update repository settings such as visibility, gating policy, description,
     /// discussion settings, and gated notification preferences.
     ///
-    /// Endpoint: `PUT /api/{repo_type}s/{repo_id}/settings`.
+    /// Endpoint: `PUT /api/{plural}/{repo_id}/settings`.
     ///
     /// # Parameters
     ///
@@ -1410,7 +1258,7 @@ impl HFRepository {
             gated_notifications_mode: gated_notifications.as_ref().map(|g| &g.mode),
         };
 
-        let url = format!("{}/settings", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()));
+        let url = format!("{}/settings", self.hf_client.api_url(T::plural(), &self.repo_path()));
         let headers = self.hf_client.auth_headers();
 
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -1428,6 +1276,110 @@ impl HFRepository {
             .check_response(response, Some(&repo_path), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(())
+    }
+}
+
+/// Documentation shared by the per-repo-kind `info` builders.
+macro_rules! info_method_doc {
+    () => {
+        "Fetch repository metadata for this repo kind, returning the concrete info struct.\n\n\
+        # Parameters\n\n\
+        - `revision`: Git revision (branch, tag, or commit SHA). Defaults to the main branch.\n\
+        - `expand`: list of properties to expand in the response (e.g. `\"trendingScore\"`, `\"cardData\"`).\n  \
+          When set, only the listed properties (plus `_id` and `id`) are returned. Kernel info ignores this."
+    };
+}
+
+#[bon]
+impl HFRepository<RepoTypeModel> {
+    /// Fetch [`ModelInfo`] for this model repository.
+    #[doc = info_method_doc!()]
+    #[builder(
+        finish_fn = send,
+        builder_type = HFModelInfoBuilder,
+        state_mod(name = hf_model_info_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub async fn info(
+        &self,
+        /// Git revision (branch, tag, or commit SHA). Defaults to the main branch.
+        #[builder(into)]
+        revision: Option<String>,
+        /// List of properties to expand in the response (e.g. `"trendingScore"`, `"cardData"`).
+        expand: Option<Vec<String>>,
+    ) -> HFResult<ModelInfo> {
+        self.fetch_repo_info(revision, expand).await
+    }
+}
+
+#[bon]
+impl HFRepository<RepoTypeDataset> {
+    /// Fetch [`DatasetInfo`] for this dataset repository.
+    #[doc = info_method_doc!()]
+    #[builder(
+        finish_fn = send,
+        builder_type = HFDatasetInfoBuilder,
+        state_mod(name = hf_dataset_info_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub async fn info(
+        &self,
+        /// Git revision (branch, tag, or commit SHA). Defaults to the main branch.
+        #[builder(into)]
+        revision: Option<String>,
+        /// List of properties to expand in the response (e.g. `"trendingScore"`, `"cardData"`).
+        expand: Option<Vec<String>>,
+    ) -> HFResult<DatasetInfo> {
+        self.fetch_repo_info(revision, expand).await
+    }
+}
+
+#[bon]
+impl HFRepository<RepoTypeSpace> {
+    /// Fetch [`SpaceInfo`] for this Space repository.
+    #[doc = info_method_doc!()]
+    #[builder(
+        finish_fn = send,
+        builder_type = HFSpaceInfoBuilder,
+        state_mod(name = hf_space_info_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub async fn info(
+        &self,
+        /// Git revision (branch, tag, or commit SHA). Defaults to the main branch.
+        #[builder(into)]
+        revision: Option<String>,
+        /// List of properties to expand in the response (e.g. `"trendingScore"`, `"cardData"`).
+        expand: Option<Vec<String>>,
+    ) -> HFResult<SpaceInfo> {
+        self.fetch_repo_info(revision, expand).await
+    }
+}
+
+#[bon]
+impl HFRepository<RepoTypeKernel> {
+    /// Fetch [`KernelInfo`] for this kernel repository.
+    ///
+    /// Note: the Hub's `/api/kernels/{repo_id}` endpoint returns a slim shape (no `tags`,
+    /// `cardData`, or `siblings`) and silently ignores `expand`. To get the full
+    /// model-style metadata for a kernel, build a model handle for the same repo id
+    /// (`client.model(owner, name)`) and call `info()` on it.
+    #[doc = info_method_doc!()]
+    #[builder(
+        finish_fn = send,
+        builder_type = HFKernelInfoBuilder,
+        state_mod(name = hf_kernel_info_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub async fn info(
+        &self,
+        /// Git revision (branch, tag, or commit SHA). Defaults to the main branch.
+        #[builder(into)]
+        revision: Option<String>,
+        /// List of properties to expand in the response. Kernel info ignores this parameter.
+        expand: Option<Vec<String>>,
+    ) -> HFResult<KernelInfo> {
+        self.fetch_repo_info(revision, expand).await
     }
 }
 
@@ -1604,28 +1556,25 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::create_repo`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn create_repo(
+    pub fn create_repo<T: RepoType>(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
-        /// Type of repository to create (model, dataset, space, kernel).
-        repo_type: Option<RepoType>,
         /// Whether the repository should be private.
         private: Option<bool>,
         /// If `true`, do not error when the repository already exists.
         #[builder(default)]
         exist_ok: bool,
-        /// SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `repo_type` is `Space`;
-        /// ignored for other repo types.
+        /// SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `T` is
+        /// [`RepoTypeSpace`]; ignored for other repo kinds.
         #[builder(into)]
         space_sdk: Option<String>,
     ) -> HFResult<RepoUrl> {
         self.runtime.block_on(
             self.inner
-                .create_repo()
+                .create_repo::<T>()
                 .repo_id(repo_id)
-                .maybe_repo_type(repo_type)
                 .maybe_private(private)
                 .exist_ok(exist_ok)
                 .maybe_space_sdk(space_sdk)
@@ -1636,31 +1585,23 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::delete_repo`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn delete_repo(
+    pub fn delete_repo<T: RepoType>(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
-        /// Type of repository.
-        repo_type: Option<RepoType>,
         /// If `true`, do not error when the repository does not exist.
         #[builder(default)]
         missing_ok: bool,
     ) -> HFResult<()> {
-        self.runtime.block_on(
-            self.inner
-                .delete_repo()
-                .repo_id(repo_id)
-                .maybe_repo_type(repo_type)
-                .missing_ok(missing_ok)
-                .send(),
-        )
+        self.runtime
+            .block_on(self.inner.delete_repo::<T>().repo_id(repo_id).missing_ok(missing_ok).send())
     }
 
     /// Blocking counterpart of [`HFClient::move_repo`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn move_repo(
+    pub fn move_repo<T: RepoType>(
         &self,
         /// Current repository ID in `"owner/name"` format.
         #[builder(into)]
@@ -1668,39 +1609,15 @@ impl crate::blocking::HFClientSync {
         /// New repository ID in `"owner/name"` format.
         #[builder(into)]
         to_id: String,
-        /// Type of repository to move.
-        repo_type: Option<RepoType>,
     ) -> HFResult<RepoUrl> {
-        self.runtime.block_on(
-            self.inner
-                .move_repo()
-                .from_id(from_id)
-                .to_id(to_id)
-                .maybe_repo_type(repo_type)
-                .send(),
-        )
+        self.runtime
+            .block_on(self.inner.move_repo::<T>().from_id(from_id).to_id(to_id).send())
     }
 }
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
-    /// Blocking counterpart of [`HFRepository::info`]. See the async method for parameters and
-    /// behavior.
-    #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn info(
-        &self,
-        /// Git revision (branch, tag, or commit SHA). Defaults to the main branch.
-        #[builder(into)]
-        revision: Option<String>,
-        /// List of properties to expand in the response (e.g. `"trendingScore"`, `"cardData"`). When set, only
-        /// the listed properties (plus `_id` and `id`) are returned.
-        expand: Option<Vec<String>>,
-    ) -> HFResult<RepoInfo> {
-        self.runtime
-            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
-    }
-
+impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::exists`].
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn exists(&self) -> HFResult<bool> {
@@ -1765,44 +1682,128 @@ impl crate::blocking::HFRepositorySync {
     }
 }
 
+/// Sync `info()` builders for each repo kind.
+///
+/// Each block mirrors the async per-kind `info()` impl in shape and forwards through the
+/// runtime. Builder type names are unique to keep the bon-generated state types from
+/// colliding across the four impl blocks.
+
+#[cfg(feature = "blocking")]
+#[bon]
+impl crate::blocking::HFRepositorySync<RepoTypeModel> {
+    /// Blocking counterpart of [`HFRepository::<RepoTypeModel>::info`].
+    #[builder(
+        finish_fn = send,
+        builder_type = HFModelInfoSyncBuilder,
+        state_mod(name = hf_model_info_sync_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub fn info(&self, #[builder(into)] revision: Option<String>, expand: Option<Vec<String>>) -> HFResult<ModelInfo> {
+        self.runtime
+            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
+    }
+}
+
+#[cfg(feature = "blocking")]
+#[bon]
+impl crate::blocking::HFRepositorySync<RepoTypeDataset> {
+    /// Blocking counterpart of [`HFRepository::<RepoTypeDataset>::info`].
+    #[builder(
+        finish_fn = send,
+        builder_type = HFDatasetInfoSyncBuilder,
+        state_mod(name = hf_dataset_info_sync_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub fn info(
+        &self,
+        #[builder(into)] revision: Option<String>,
+        expand: Option<Vec<String>>,
+    ) -> HFResult<DatasetInfo> {
+        self.runtime
+            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
+    }
+}
+
+#[cfg(feature = "blocking")]
+#[bon]
+impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
+    /// Blocking counterpart of [`HFRepository::<RepoTypeSpace>::info`].
+    #[builder(
+        finish_fn = send,
+        builder_type = HFSpaceInfoSyncBuilder,
+        state_mod(name = hf_space_info_sync_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub fn info(&self, #[builder(into)] revision: Option<String>, expand: Option<Vec<String>>) -> HFResult<SpaceInfo> {
+        self.runtime
+            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
+    }
+}
+
+#[cfg(feature = "blocking")]
+#[bon]
+impl crate::blocking::HFRepositorySync<RepoTypeKernel> {
+    /// Blocking counterpart of [`HFRepository::<RepoTypeKernel>::info`].
+    #[builder(
+        finish_fn = send,
+        builder_type = HFKernelInfoSyncBuilder,
+        state_mod(name = hf_kernel_info_sync_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub fn info(&self, #[builder(into)] revision: Option<String>, expand: Option<Vec<String>>) -> HFResult<KernelInfo> {
+        self.runtime
+            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use futures::StreamExt;
 
     use super::{
         DatasetInfo, EvalResultEntry, HFRepository, InferenceProviderMapping, KernelInfo, ModelInfo, RepoType,
-        SafeTensorsInfo, SpaceInfo, TransformersInfo, split_repo_id,
+        RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace, SafeTensorsInfo, SpaceInfo, TransformersInfo,
+        split_repo_id,
     };
     use crate::client::HFClient;
 
     #[test]
     fn test_repo_path_and_accessors() {
         let client = HFClient::builder().build().unwrap();
-        let repo = HFRepository::new(client, RepoType::Model, "openai-community", "gpt2");
+        let repo: HFRepository<RepoTypeModel> = HFRepository::new(client, "openai-community", "gpt2");
 
         assert_eq!(repo.owner(), "openai-community");
         assert_eq!(repo.name(), "gpt2");
         assert_eq!(repo.repo_path(), "openai-community/gpt2");
-        assert_eq!(repo.repo_type(), RepoType::Model);
+        assert_eq!(repo.repo_type(), "model");
     }
 
     #[test]
-    fn test_repo_type_from_str() {
-        assert_eq!("model".parse::<RepoType>().unwrap(), RepoType::Model);
-        assert_eq!("dataset".parse::<RepoType>().unwrap(), RepoType::Dataset);
-        assert_eq!("space".parse::<RepoType>().unwrap(), RepoType::Space);
-        assert_eq!("kernel".parse::<RepoType>().unwrap(), RepoType::Kernel);
-        assert_eq!("MODEL".parse::<RepoType>().unwrap(), RepoType::Model);
-        assert_eq!("KERNEL".parse::<RepoType>().unwrap(), RepoType::Kernel);
-        assert!("invalid".parse::<RepoType>().is_err());
+    fn test_marker_struct_singular_and_plural() {
+        assert_eq!(RepoTypeModel::singular(), "model");
+        assert_eq!(RepoTypeDataset::singular(), "dataset");
+        assert_eq!(RepoTypeSpace::singular(), "space");
+        assert_eq!(RepoTypeKernel::singular(), "kernel");
+        assert_eq!(RepoTypeModel::plural(), "models");
+        assert_eq!(RepoTypeDataset::plural(), "datasets");
+        assert_eq!(RepoTypeSpace::plural(), "spaces");
+        assert_eq!(RepoTypeKernel::plural(), "kernels");
     }
 
     #[test]
-    fn test_repo_type_display() {
-        assert_eq!(RepoType::Model.to_string(), "model");
-        assert_eq!(RepoType::Dataset.to_string(), "dataset");
-        assert_eq!(RepoType::Space.to_string(), "space");
-        assert_eq!(RepoType::Kernel.to_string(), "kernel");
+    fn test_marker_struct_url_prefix() {
+        assert_eq!(RepoTypeModel::url_prefix(), "");
+        assert_eq!(RepoTypeDataset::url_prefix(), "datasets/");
+        assert_eq!(RepoTypeSpace::url_prefix(), "spaces/");
+        assert_eq!(RepoTypeKernel::url_prefix(), "kernels/");
+    }
+
+    #[test]
+    fn test_marker_struct_display() {
+        assert_eq!(format!("{}", RepoTypeModel), "model");
+        assert_eq!(format!("{}", RepoTypeDataset), "dataset");
+        assert_eq!(format!("{}", RepoTypeSpace), "space");
+        assert_eq!(format!("{}", RepoTypeKernel), "kernel");
     }
 
     #[test]

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -607,7 +607,7 @@ impl<T: RepoType> std::fmt::Debug for HFRepository<T> {
         f.debug_struct("HFRepository")
             .field("owner", &self.owner)
             .field("name", &self.name)
-            .field("repo_type", &T::singular())
+            .field("repo_type", &T::default().singular())
             .finish()
     }
 }
@@ -885,18 +885,22 @@ impl HFClient {
         Ok(self.paginate(url, query, limit))
     }
 
-    /// Create a new repository of kind `T`. Endpoint: `POST /api/repos/create`.
+    /// Create a new repository. Endpoint: `POST /api/repos/create`.
     ///
-    /// `T` is the repo kind picked at the call site via turbofish — e.g.
-    /// `client.create_repo::<RepoTypeDataset>()...` to create a dataset. The body
-    /// always includes the `type` field, matching the Hub's per-kind defaults.
+    /// The repo kind is picked at the call site by passing one of the four marker
+    /// structs to [`repo_type`](HFClientCreateRepoBuilder::repo_type) — e.g.
+    /// `client.create_repo().repo_type(RepoTypeDataset)...` to create a dataset.
+    /// The body always includes the `type` field, matching the Hub's per-kind
+    /// defaults.
     ///
     /// # Parameters
     ///
     /// - `repo_id` (required): repository ID in `"owner/name"` or `"name"` format.
+    /// - `repo_type` (required): the repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], or
+    ///   [`RepoTypeKernel`]).
     /// - `private`: whether the repository should be private.
     /// - `exist_ok` (default `false`): if `true`, do not error when the repository already exists.
-    /// - `space_sdk`: SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `T` is
+    /// - `space_sdk`: SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `repo_type` is
     ///   [`RepoTypeSpace`]; ignored for other repo kinds.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub async fn create_repo<T: RepoType>(
@@ -904,12 +908,15 @@ impl HFClient {
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
+        /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
+        /// or [`RepoTypeKernel`]).
+        repo_type: T,
         /// Whether the repository should be private.
         private: Option<bool>,
         /// If `true`, do not error when the repository already exists.
         #[builder(default)]
         exist_ok: bool,
-        /// SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `T` is
+        /// SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `repo_type` is
         /// [`RepoTypeSpace`]; ignored for other repo kinds.
         #[builder(into)]
         space_sdk: Option<String>,
@@ -921,7 +928,7 @@ impl HFClient {
         let mut body = serde_json::json!({
             "name": name,
             "private": private.unwrap_or(false),
-            "type": T::singular(),
+            "type": repo_type.singular(),
         });
 
         if let Some(ns) = namespace {
@@ -939,7 +946,7 @@ impl HFClient {
 
         if response.status().as_u16() == 409 && exist_ok {
             return Ok(RepoUrl {
-                url: format!("{}/{}{}", self.endpoint(), T::url_prefix(), repo_id),
+                url: format!("{}/{}{}", self.endpoint(), repo_type.url_prefix(), repo_id),
             });
         }
 
@@ -949,15 +956,18 @@ impl HFClient {
         Ok(response.json().await?)
     }
 
-    /// Delete a repository of kind `T`. Endpoint: `DELETE /api/repos/delete`.
+    /// Delete a repository. Endpoint: `DELETE /api/repos/delete`.
     ///
-    /// `T` is the repo kind picked at the call site via turbofish — e.g.
-    /// `client.delete_repo::<RepoTypeSpace>()...`. The body always includes
+    /// The repo kind is picked at the call site by passing one of the four marker
+    /// structs to [`repo_type`](HFClientDeleteRepoBuilder::repo_type) — e.g.
+    /// `client.delete_repo().repo_type(RepoTypeSpace)...`. The body always includes
     /// the `type` field.
     ///
     /// # Parameters
     ///
     /// - `repo_id` (required): repository ID in `"owner/name"` or `"name"` format.
+    /// - `repo_type` (required): the repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], or
+    ///   [`RepoTypeKernel`]).
     /// - `missing_ok` (default `false`): if `true`, do not error when the repository does not exist.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub async fn delete_repo<T: RepoType>(
@@ -965,6 +975,9 @@ impl HFClient {
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
+        /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
+        /// or [`RepoTypeKernel`]).
+        repo_type: T,
         /// If `true`, do not error when the repository does not exist.
         #[builder(default)]
         missing_ok: bool,
@@ -975,7 +988,7 @@ impl HFClient {
 
         let mut body = serde_json::json!({
             "name": name,
-            "type": T::singular(),
+            "type": repo_type.singular(),
         });
         if let Some(ns) = namespace {
             body["organization"] = serde_json::Value::String(ns.to_string());
@@ -996,16 +1009,19 @@ impl HFClient {
         Ok(())
     }
 
-    /// Move (rename) a repository of kind `T`. Endpoint: `POST /api/repos/move`.
+    /// Move (rename) a repository. Endpoint: `POST /api/repos/move`.
     ///
-    /// `T` is the repo kind picked at the call site via turbofish — e.g.
-    /// `client.move_repo::<RepoTypeModel>()...`. The body always includes
+    /// The repo kind is picked at the call site by passing one of the four marker
+    /// structs to [`repo_type`](HFClientMoveRepoBuilder::repo_type) — e.g.
+    /// `client.move_repo().repo_type(RepoTypeModel)...`. The body always includes
     /// the `type` field.
     ///
     /// # Parameters
     ///
     /// - `from_id` (required): current repository ID in `"owner/name"` format.
     /// - `to_id` (required): new repository ID in `"owner/name"` format.
+    /// - `repo_type` (required): the repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], or
+    ///   [`RepoTypeKernel`]).
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub async fn move_repo<T: RepoType>(
         &self,
@@ -1015,12 +1031,15 @@ impl HFClient {
         /// New repository ID in `"owner/name"` format.
         #[builder(into)]
         to_id: String,
+        /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
+        /// or [`RepoTypeKernel`]).
+        repo_type: T,
     ) -> HFResult<RepoUrl> {
         let url = format!("{}/api/repos/move", self.endpoint());
         let body = serde_json::json!({
             "fromRepo": from_id,
             "toRepo": to_id,
-            "type": T::singular(),
+            "type": repo_type.singular(),
         });
 
         let headers = self.auth_headers();
@@ -1032,7 +1051,7 @@ impl HFClient {
         self.check_response(response, None, crate::error::NotFoundContext::Generic)
             .await?;
         Ok(RepoUrl {
-            url: format!("{}/{}{}", self.endpoint(), T::url_prefix(), to_id),
+            url: format!("{}/{}{}", self.endpoint(), repo_type.url_prefix(), to_id),
         })
     }
 }
@@ -1076,10 +1095,10 @@ impl<T: RepoType> HFRepository<T> {
 
     /// Lowercase singular name of this repo's kind (`"model"`, `"dataset"`, `"space"`, or `"kernel"`).
     ///
-    /// Equivalent to `T::singular()` for the type parameter on this handle. Useful for
+    /// Equivalent to `T::default().singular()` for the type parameter on this handle. Useful for
     /// logs and error messages without naming `T` explicitly.
     pub fn repo_type(&self) -> &'static str {
-        T::singular()
+        T::default().singular()
     }
 
     /// Fetch repo info for this repository's kind, deserializing into `I`.
@@ -1089,7 +1108,7 @@ impl<T: RepoType> HFRepository<T> {
         revision: Option<String>,
         expand: Option<Vec<String>>,
     ) -> HFResult<I> {
-        let mut url = self.hf_client.api_url(T::plural(), &self.repo_path());
+        let mut url = self.hf_client.api_url(T::default().plural(), &self.repo_path());
         if let Some(ref revision) = revision {
             url = format!("{url}/revision/{revision}");
         }
@@ -1123,7 +1142,7 @@ impl<T: RepoType> HFRepository<T> {
     /// ([`HFError::AuthRequired`] or [`HFError::Forbidden`]), not `Ok(false)`.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub async fn exists(&self) -> HFResult<bool> {
-        let url = self.hf_client.api_url(T::plural(), &self.repo_path());
+        let url = self.hf_client.api_url(T::default().plural(), &self.repo_path());
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
             self.hf_client.http_client().get(&url).headers(headers.clone()).send()
@@ -1154,7 +1173,7 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         revision: String,
     ) -> HFResult<bool> {
-        let url = format!("{}/revision/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
+        let url = format!("{}/revision/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), revision);
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
             self.hf_client.http_client().get(&url).headers(headers.clone()).send()
@@ -1188,7 +1207,7 @@ impl<T: RepoType> HFRepository<T> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
         let url = self
             .hf_client
-            .download_url(T::url_prefix(), &self.repo_path(), revision, &filename);
+            .download_url(T::default().url_prefix(), &self.repo_path(), revision, &filename);
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
             self.hf_client.http_client().head(&url).headers(headers.clone()).send()
@@ -1264,7 +1283,7 @@ impl<T: RepoType> HFRepository<T> {
             gated_notifications_mode: gated_notifications.as_ref().map(|g| &g.mode),
         };
 
-        let url = format!("{}/settings", self.hf_client.api_url(T::plural(), &self.repo_path()));
+        let url = format!("{}/settings", self.hf_client.api_url(T::default().plural(), &self.repo_path()));
         let headers = self.hf_client.auth_headers();
 
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -1567,20 +1586,24 @@ impl crate::blocking::HFClientSync {
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
+        /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
+        /// or [`RepoTypeKernel`]).
+        repo_type: T,
         /// Whether the repository should be private.
         private: Option<bool>,
         /// If `true`, do not error when the repository already exists.
         #[builder(default)]
         exist_ok: bool,
-        /// SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `T` is
+        /// SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `repo_type` is
         /// [`RepoTypeSpace`]; ignored for other repo kinds.
         #[builder(into)]
         space_sdk: Option<String>,
     ) -> HFResult<RepoUrl> {
         self.runtime.block_on(
             self.inner
-                .create_repo::<T>()
+                .create_repo()
                 .repo_id(repo_id)
+                .repo_type(repo_type)
                 .maybe_private(private)
                 .exist_ok(exist_ok)
                 .maybe_space_sdk(space_sdk)
@@ -1596,12 +1619,21 @@ impl crate::blocking::HFClientSync {
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
+        /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
+        /// or [`RepoTypeKernel`]).
+        repo_type: T,
         /// If `true`, do not error when the repository does not exist.
         #[builder(default)]
         missing_ok: bool,
     ) -> HFResult<()> {
-        self.runtime
-            .block_on(self.inner.delete_repo::<T>().repo_id(repo_id).missing_ok(missing_ok).send())
+        self.runtime.block_on(
+            self.inner
+                .delete_repo()
+                .repo_id(repo_id)
+                .repo_type(repo_type)
+                .missing_ok(missing_ok)
+                .send(),
+        )
     }
 
     /// Blocking counterpart of [`HFClient::move_repo`]. See the async method for parameters and
@@ -1615,9 +1647,12 @@ impl crate::blocking::HFClientSync {
         /// New repository ID in `"owner/name"` format.
         #[builder(into)]
         to_id: String,
+        /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
+        /// or [`RepoTypeKernel`]).
+        repo_type: T,
     ) -> HFResult<RepoUrl> {
         self.runtime
-            .block_on(self.inner.move_repo::<T>().from_id(from_id).to_id(to_id).send())
+            .block_on(self.inner.move_repo().from_id(from_id).to_id(to_id).repo_type(repo_type).send())
     }
 }
 
@@ -1786,22 +1821,22 @@ mod tests {
 
     #[test]
     fn test_marker_struct_singular_and_plural() {
-        assert_eq!(RepoTypeModel::singular(), "model");
-        assert_eq!(RepoTypeDataset::singular(), "dataset");
-        assert_eq!(RepoTypeSpace::singular(), "space");
-        assert_eq!(RepoTypeKernel::singular(), "kernel");
-        assert_eq!(RepoTypeModel::plural(), "models");
-        assert_eq!(RepoTypeDataset::plural(), "datasets");
-        assert_eq!(RepoTypeSpace::plural(), "spaces");
-        assert_eq!(RepoTypeKernel::plural(), "kernels");
+        assert_eq!(RepoTypeModel.singular(), "model");
+        assert_eq!(RepoTypeDataset.singular(), "dataset");
+        assert_eq!(RepoTypeSpace.singular(), "space");
+        assert_eq!(RepoTypeKernel.singular(), "kernel");
+        assert_eq!(RepoTypeModel.plural(), "models");
+        assert_eq!(RepoTypeDataset.plural(), "datasets");
+        assert_eq!(RepoTypeSpace.plural(), "spaces");
+        assert_eq!(RepoTypeKernel.plural(), "kernels");
     }
 
     #[test]
     fn test_marker_struct_url_prefix() {
-        assert_eq!(RepoTypeModel::url_prefix(), "");
-        assert_eq!(RepoTypeDataset::url_prefix(), "datasets/");
-        assert_eq!(RepoTypeSpace::url_prefix(), "spaces/");
-        assert_eq!(RepoTypeKernel::url_prefix(), "kernels/");
+        assert_eq!(RepoTypeModel.url_prefix(), "");
+        assert_eq!(RepoTypeDataset.url_prefix(), "datasets/");
+        assert_eq!(RepoTypeSpace.url_prefix(), "spaces/");
+        assert_eq!(RepoTypeKernel.url_prefix(), "kernels/");
     }
 
     #[test]

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -888,8 +888,8 @@ impl HFClient {
     /// Create a new repository. Endpoint: `POST /api/repos/create`.
     ///
     /// The repo kind is picked at the call site by passing one of the four marker
-    /// structs to [`repo_type`](HFClientCreateRepoBuilder::repo_type) — e.g.
-    /// `client.create_repo().repo_type(RepoTypeDataset)...` to create a dataset.
+    /// structs to [`repo_type`](HFClientCreateRepositoryBuilder::repo_type) — e.g.
+    /// `client.create_repository().repo_type(RepoTypeDataset)...` to create a dataset.
     /// The body always includes the `type` field, matching the Hub's per-kind
     /// defaults.
     ///
@@ -903,7 +903,7 @@ impl HFClient {
     /// - `space_sdk`: SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `repo_type` is
     ///   [`RepoTypeSpace`]; ignored for other repo kinds.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn create_repo<T: RepoType>(
+    pub async fn create_repository<T: RepoType>(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
@@ -959,8 +959,8 @@ impl HFClient {
     /// Delete a repository. Endpoint: `DELETE /api/repos/delete`.
     ///
     /// The repo kind is picked at the call site by passing one of the four marker
-    /// structs to [`repo_type`](HFClientDeleteRepoBuilder::repo_type) — e.g.
-    /// `client.delete_repo().repo_type(RepoTypeSpace)...`. The body always includes
+    /// structs to [`repo_type`](HFClientDeleteRepositoryBuilder::repo_type) — e.g.
+    /// `client.delete_repository().repo_type(RepoTypeSpace)...`. The body always includes
     /// the `type` field.
     ///
     /// # Parameters
@@ -970,7 +970,7 @@ impl HFClient {
     ///   [`RepoTypeKernel`]).
     /// - `missing_ok` (default `false`): if `true`, do not error when the repository does not exist.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn delete_repo<T: RepoType>(
+    pub async fn delete_repository<T: RepoType>(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
@@ -1012,8 +1012,8 @@ impl HFClient {
     /// Move (rename) a repository. Endpoint: `POST /api/repos/move`.
     ///
     /// The repo kind is picked at the call site by passing one of the four marker
-    /// structs to [`repo_type`](HFClientMoveRepoBuilder::repo_type) — e.g.
-    /// `client.move_repo().repo_type(RepoTypeModel)...`. The body always includes
+    /// structs to [`repo_type`](HFClientMoveRepositoryBuilder::repo_type) — e.g.
+    /// `client.move_repository().repo_type(RepoTypeModel)...`. The body always includes
     /// the `type` field.
     ///
     /// # Parameters
@@ -1023,7 +1023,7 @@ impl HFClient {
     /// - `repo_type` (required): the repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], or
     ///   [`RepoTypeKernel`]).
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn move_repo<T: RepoType>(
+    pub async fn move_repository<T: RepoType>(
         &self,
         /// Current repository ID in `"owner/name"` format.
         #[builder(into)]
@@ -1578,10 +1578,10 @@ impl crate::blocking::HFClientSync {
         })
     }
 
-    /// Blocking counterpart of [`HFClient::create_repo`]. See the async method for parameters and
+    /// Blocking counterpart of [`HFClient::create_repository`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn create_repo<T: RepoType>(
+    pub fn create_repository<T: RepoType>(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
@@ -1601,7 +1601,7 @@ impl crate::blocking::HFClientSync {
     ) -> HFResult<RepoUrl> {
         self.runtime.block_on(
             self.inner
-                .create_repo()
+                .create_repository()
                 .repo_id(repo_id)
                 .repo_type(repo_type)
                 .maybe_private(private)
@@ -1611,10 +1611,10 @@ impl crate::blocking::HFClientSync {
         )
     }
 
-    /// Blocking counterpart of [`HFClient::delete_repo`]. See the async method for parameters and
+    /// Blocking counterpart of [`HFClient::delete_repository`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn delete_repo<T: RepoType>(
+    pub fn delete_repository<T: RepoType>(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
@@ -1628,7 +1628,7 @@ impl crate::blocking::HFClientSync {
     ) -> HFResult<()> {
         self.runtime.block_on(
             self.inner
-                .delete_repo()
+                .delete_repository()
                 .repo_id(repo_id)
                 .repo_type(repo_type)
                 .missing_ok(missing_ok)
@@ -1636,10 +1636,10 @@ impl crate::blocking::HFClientSync {
         )
     }
 
-    /// Blocking counterpart of [`HFClient::move_repo`]. See the async method for parameters and
+    /// Blocking counterpart of [`HFClient::move_repository`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn move_repo<T: RepoType>(
+    pub fn move_repository<T: RepoType>(
         &self,
         /// Current repository ID in `"owner/name"` format.
         #[builder(into)]
@@ -1651,8 +1651,14 @@ impl crate::blocking::HFClientSync {
         /// or [`RepoTypeKernel`]).
         repo_type: T,
     ) -> HFResult<RepoUrl> {
-        self.runtime
-            .block_on(self.inner.move_repo().from_id(from_id).to_id(to_id).repo_type(repo_type).send())
+        self.runtime.block_on(
+            self.inner
+                .move_repository()
+                .from_id(from_id)
+                .to_id(to_id)
+                .repo_type(repo_type)
+                .send(),
+        )
     }
 }
 

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -903,14 +903,14 @@ impl HFClient {
     /// - `space_sdk`: SDK for a Space (e.g. `"gradio"`, `"streamlit"`, `"docker"`). Required when `repo_type` is
     ///   [`RepoTypeSpace`]; ignored for other repo kinds.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn create_repository<T: RepoType>(
+    pub async fn create_repository(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
         /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
         /// or [`RepoTypeKernel`]).
-        repo_type: T,
+        repo_type: impl RepoType,
         /// Whether the repository should be private.
         private: Option<bool>,
         /// If `true`, do not error when the repository already exists.
@@ -970,14 +970,14 @@ impl HFClient {
     ///   [`RepoTypeKernel`]).
     /// - `missing_ok` (default `false`): if `true`, do not error when the repository does not exist.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn delete_repository<T: RepoType>(
+    pub async fn delete_repository(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
         /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
         /// or [`RepoTypeKernel`]).
-        repo_type: T,
+        repo_type: impl RepoType,
         /// If `true`, do not error when the repository does not exist.
         #[builder(default)]
         missing_ok: bool,
@@ -1023,7 +1023,7 @@ impl HFClient {
     /// - `repo_type` (required): the repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], or
     ///   [`RepoTypeKernel`]).
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub async fn move_repository<T: RepoType>(
+    pub async fn move_repository(
         &self,
         /// Current repository ID in `"owner/name"` format.
         #[builder(into)]
@@ -1033,7 +1033,7 @@ impl HFClient {
         to_id: String,
         /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
         /// or [`RepoTypeKernel`]).
-        repo_type: T,
+        repo_type: impl RepoType,
     ) -> HFResult<RepoUrl> {
         let url = format!("{}/api/repos/move", self.endpoint());
         let body = serde_json::json!({
@@ -1584,14 +1584,14 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::create_repository`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn create_repository<T: RepoType>(
+    pub fn create_repository(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
         /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
         /// or [`RepoTypeKernel`]).
-        repo_type: T,
+        repo_type: impl RepoType,
         /// Whether the repository should be private.
         private: Option<bool>,
         /// If `true`, do not error when the repository already exists.
@@ -1617,14 +1617,14 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::delete_repository`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn delete_repository<T: RepoType>(
+    pub fn delete_repository(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
         #[builder(into)]
         repo_id: String,
         /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
         /// or [`RepoTypeKernel`]).
-        repo_type: T,
+        repo_type: impl RepoType,
         /// If `true`, do not error when the repository does not exist.
         #[builder(default)]
         missing_ok: bool,
@@ -1642,7 +1642,7 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::move_repository`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn move_repository<T: RepoType>(
+    pub fn move_repository(
         &self,
         /// Current repository ID in `"owner/name"` format.
         #[builder(into)]
@@ -1652,7 +1652,7 @@ impl crate::blocking::HFClientSync {
         to_id: String,
         /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
         /// or [`RepoTypeKernel`]).
-        repo_type: T,
+        repo_type: impl RepoType,
     ) -> HFResult<RepoUrl> {
         self.runtime.block_on(
             self.inner

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -168,6 +168,12 @@ pub struct InferenceProviderMapping {
     pub r#type: Option<String>,
 }
 
+// The Hub returns `inferenceProviderMapping` as an object keyed by provider name on
+// `GET /api/models/{id}` and as an array on `GET /api/models`. See:
+//   https://huggingface.co/docs/inference-providers/hub-api
+//   https://huggingface.co/docs/inference-providers/register-as-a-provider
+// The Python `huggingface_hub` library handles both shapes the same way and notes:
+// "a dict on model_info and a list on list_models. Let's harmonize to list."
 fn deserialize_inference_provider_mapping<'de, D>(
     deserializer: D,
 ) -> Result<Option<Vec<InferenceProviderMapping>>, D::Error>

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -1093,12 +1093,15 @@ impl<T: RepoType> HFRepository<T> {
         }
     }
 
-    /// Lowercase singular name of this repo's kind (`"model"`, `"dataset"`, `"space"`, or `"kernel"`).
+    /// The marker for this handle's repo kind.
     ///
-    /// Equivalent to `T::default().singular()` for the type parameter on this handle. Useful for
-    /// logs and error messages without naming `T` explicitly.
-    pub fn repo_type(&self) -> &'static str {
-        T::default().singular()
+    /// Equivalent to `T::default()` — useful when you want to read the kind off a
+    /// repository handle (e.g. for logging) without naming `T` explicitly. Call
+    /// [`singular`](RepoType::singular), [`plural`](RepoType::plural), or
+    /// [`url_prefix`](RepoType::url_prefix) on the returned value to get the
+    /// corresponding string.
+    pub fn repo_type(&self) -> impl RepoType {
+        T::default()
     }
 
     /// Fetch repo info for this repository's kind, deserializing into `I`.
@@ -1822,7 +1825,7 @@ mod tests {
         assert_eq!(repo.owner(), "openai-community");
         assert_eq!(repo.name(), "gpt2");
         assert_eq!(repo.repo_path(), "openai-community/gpt2");
-        assert_eq!(repo.repo_type(), "model");
+        assert_eq!(repo.repo_type().singular(), "model");
     }
 
     #[test]

--- a/hf-hub/src/repository/repo_type.rs
+++ b/hf-hub/src/repository/repo_type.rs
@@ -4,9 +4,14 @@
 //! [`RepoTypeDataset`], [`RepoTypeSpace`], [`RepoTypeKernel`]) parameterise
 //! [`HFRepository<T>`](super::HFRepository) and
 //! [`HFRepositorySync<T>`](crate::HFRepositorySync) so the repo kind is encoded in the
-//! type system. Methods that differ per repo kind (such as `info`) dispatch at compile time.
+//! type system. Methods that differ per repo kind (such as
+//! [`info`](super::HFRepository::info)) dispatch at compile time.
 //!
-//! All items here are re-exported flat at `hf_hub::repository::…` and at the crate root.
+//! See [`RepoType`] for the full overview, including the table of strings each marker
+//! returns and how to pass markers to client builders.
+//!
+//! All items here are re-exported flat at `hf_hub::repository::…` and at the crate root,
+//! so the canonical paths are `hf_hub::RepoType` and `hf_hub::RepoTypeModel` etc.
 
 mod sealed {
     pub trait Sealed {}
@@ -14,48 +19,195 @@ mod sealed {
 
 /// Type-level marker for a Hugging Face Hub repo kind (model, dataset, Space, or kernel).
 ///
-/// `RepoType` is a sealed trait — implemented only by the four marker structs in this
-/// module ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], [`RepoTypeKernel`]).
-/// Pick the marker as the `T` parameter on [`HFRepository<T>`](super::HFRepository) /
-/// [`HFRepositorySync<T>`](crate::HFRepositorySync) at construction time (e.g. via
-/// [`HFClient::model`](crate::HFClient::model) / [`HFClient::dataset`](crate::HFClient::dataset) /
-/// [`HFClient::space`](crate::HFClient::space) / [`HFClient::kernel`](crate::HFClient::kernel))
-/// to lock the repo type into the type system; methods that differ per repo kind (such
-/// as `info`) are then resolved at compile time.
+/// `RepoType` is sealed — only the four marker structs in this module implement it:
+/// [`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], [`RepoTypeKernel`]. Each is
+/// zero-sized and serves as the type parameter on [`HFRepository<T>`](super::HFRepository)
+/// and [`HFRepositorySync<T>`](crate::HFRepositorySync), so the repo kind is encoded in the
+/// type system and methods that differ per kind (such as
+/// [`info`](super::HFRepository::info)) dispatch at compile time.
 ///
-/// The trait exposes the fragments used to build Hub URLs and identify the repo kind in
-/// logs and error messages: [`singular`](Self::singular) (`"model"`, `"dataset"`, `"space"`,
-/// `"kernel"`), [`plural`](Self::plural) (the API segment — `"models"`, `"datasets"`,
-/// `"spaces"`, `"kernels"`), and [`url_prefix`](Self::url_prefix) (the path segment used by
-/// resolve URLs — `""` for models, `"<plural>/"` for everything else).
+/// # Picking a marker
 ///
-/// All methods return the same value regardless of the receiver — they're properties of
-/// the type itself. The marker structs are zero-sized and `Default`, so when only the
-/// type is in scope (inside an `impl<T: RepoType>` block, for example), use
-/// `T::default().singular()` to materialize an instance to call the method on.
+/// Two equivalent ways:
+///
+/// ```rust,no_run
+/// use hf_hub::{HFClient, RepoTypeDataset};
+/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+/// let client = HFClient::new()?;
+///
+/// // Typed shortcut — preferred when the kind is known at the call site:
+/// let repo = client.dataset("rajpurkar", "squad");
+///
+/// // Explicit marker — useful when the kind comes from a generic context:
+/// let repo = client.repository::<RepoTypeDataset>("rajpurkar", "squad");
+/// # let _ = repo; Ok(()) }
+/// ```
+///
+/// Methods like [`HFClient::create_repository`](crate::HFClient::create_repository) /
+/// [`delete_repository`](crate::HFClient::delete_repository) /
+/// [`move_repository`](crate::HFClient::move_repository) take the marker as a builder
+/// value:
+///
+/// ```rust,no_run
+/// use hf_hub::{HFClient, RepoTypeSpace};
+/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+/// # let client = HFClient::new()?;
+/// client
+///     .create_repository()
+///     .repo_id("acme/my-space")
+///     .repo_type(RepoTypeSpace)
+///     .space_sdk("static")
+///     .send()
+///     .await?;
+/// # Ok(()) }
+/// ```
+///
+/// # Trait methods
+///
+/// Each method returns the same value regardless of the receiver — they're properties
+/// of the type, not the instance. The receiver is `&self` so callers with a value
+/// in hand can write `marker.singular()`. Inside generic code where only the type
+/// is in scope (`impl<T: RepoType>`), materialise the marker on the fly with
+/// `T::default().singular()` — markers are zero-sized so it's a no-op:
+///
+/// | trait method     | `RepoTypeModel` | `RepoTypeDataset` | `RepoTypeSpace` | `RepoTypeKernel` |
+/// | ---------------- | --------------- | ----------------- | --------------- | ---------------- |
+/// | [`singular`]     | `"model"`       | `"dataset"`       | `"space"`       | `"kernel"`       |
+/// | [`plural`]       | `"models"`      | `"datasets"`      | `"spaces"`      | `"kernels"`      |
+/// | [`url_prefix`]   | `""`            | `"datasets/"`     | `"spaces/"`     | `"kernels/"`     |
+///
+/// The markers also implement [`Display`](std::fmt::Display) (writing the singular
+/// form), so `tracing` fields and `format!("{}", RepoTypeModel)` work directly.
+///
+/// [`singular`]: Self::singular
+/// [`plural`]: Self::plural
+/// [`url_prefix`]: Self::url_prefix
 pub trait RepoType: sealed::Sealed + Default + Copy + Clone + std::fmt::Debug + Send + Sync + 'static {
-    /// Lowercase singular name used in logs, error messages, and request bodies — e.g. `"model"`.
+    /// Lowercase singular form of the repo kind: `"model"`, `"dataset"`, `"space"`, or `"kernel"`.
+    /// Used in logs, error messages, and the `"type"` field of repo create/delete/move bodies.
     fn singular(&self) -> &'static str;
-    /// Lowercase plural form, used as the `/api/{plural}/...` segment — e.g. `"models"`.
+
+    /// Lowercase plural form, also the API segment in `/api/{plural}/{repo_id}` URLs:
+    /// `"models"`, `"datasets"`, `"spaces"`, or `"kernels"`.
     fn plural(&self) -> &'static str;
-    /// Path prefix used in `<endpoint>/{prefix}{repo_id}/resolve/...` URLs.
-    /// Empty for models; `"<plural>/"` for all other repo kinds.
+
+    /// Path prefix used in resolve URLs (`<endpoint>/{prefix}{repo_id}/resolve/...`):
+    /// `""` for [`RepoTypeModel`] (the model namespace is unprefixed) and `"<plural>/"`
+    /// for the other three kinds.
     fn url_prefix(&self) -> &'static str;
 }
 
-/// Marker for a model repository on the Hub. Implements [`RepoType`].
+/// Marker for a model repository on the Hub.
+///
+/// Implements [`RepoType`] returning `"model"` / `"models"` / `""` for
+/// [`singular`](RepoType::singular), [`plural`](RepoType::plural), and
+/// [`url_prefix`](RepoType::url_prefix). API URLs for models are
+/// `/api/models/{repo_id}`; resolve URLs are unprefixed (`<endpoint>/{repo_id}/...`).
+///
+/// Use [`HFClient::model`](crate::HFClient::model) for the typed shortcut, or pass this
+/// marker explicitly:
+///
+/// ```rust,no_run
+/// use hf_hub::{HFClient, RepoTypeModel};
+/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+/// let client = HFClient::new()?;
+/// let repo = client.repository::<RepoTypeModel>("openai-community", "gpt2");
+///
+/// client
+///     .create_repository()
+///     .repo_id("acme/my-model")
+///     .repo_type(RepoTypeModel)
+///     .send()
+///     .await?;
+/// # let _ = repo; Ok(()) }
+/// ```
 #[derive(Default, Copy, Clone, Debug)]
 pub struct RepoTypeModel;
 
-/// Marker for a dataset repository on the Hub. Implements [`RepoType`].
+/// Marker for a dataset repository on the Hub.
+///
+/// Implements [`RepoType`] returning `"dataset"` / `"datasets"` / `"datasets/"` for
+/// [`singular`](RepoType::singular), [`plural`](RepoType::plural), and
+/// [`url_prefix`](RepoType::url_prefix). API URLs are `/api/datasets/{repo_id}`;
+/// resolve URLs are `<endpoint>/datasets/{repo_id}/...`.
+///
+/// Use [`HFClient::dataset`](crate::HFClient::dataset) for the typed shortcut, or pass
+/// this marker explicitly:
+///
+/// ```rust,no_run
+/// use hf_hub::{HFClient, RepoTypeDataset};
+/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+/// let client = HFClient::new()?;
+/// let repo = client.repository::<RepoTypeDataset>("rajpurkar", "squad");
+///
+/// client
+///     .create_repository()
+///     .repo_id("acme/my-dataset")
+///     .repo_type(RepoTypeDataset)
+///     .send()
+///     .await?;
+/// # let _ = repo; Ok(()) }
+/// ```
 #[derive(Default, Copy, Clone, Debug)]
 pub struct RepoTypeDataset;
 
-/// Marker for a Space repository on the Hub. Implements [`RepoType`].
+/// Marker for a Space repository on the Hub.
+///
+/// Implements [`RepoType`] returning `"space"` / `"spaces"` / `"spaces/"` for
+/// [`singular`](RepoType::singular), [`plural`](RepoType::plural), and
+/// [`url_prefix`](RepoType::url_prefix). API URLs are `/api/spaces/{repo_id}`;
+/// resolve URLs are `<endpoint>/spaces/{repo_id}/...`.
+///
+/// Selects this marker to access Space-only methods on
+/// [`HFRepository`](super::HFRepository) such as
+/// [`runtime`](super::HFRepository::runtime),
+/// [`pause`](super::HFRepository::pause),
+/// [`add_secret`](super::HFRepository::add_secret), and
+/// [`duplicate`](super::HFRepository::duplicate). Use
+/// [`HFClient::space`](crate::HFClient::space) for the typed shortcut, or pass this
+/// marker explicitly:
+///
+/// ```rust,no_run
+/// use hf_hub::{HFClient, RepoTypeSpace};
+/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+/// let client = HFClient::new()?;
+/// let space = client.repository::<RepoTypeSpace>("acme", "demo");
+/// let runtime = space.runtime().send().await?;
+///
+/// // `space_sdk` is required when creating a Space repo.
+/// client
+///     .create_repository()
+///     .repo_id("acme/another")
+///     .repo_type(RepoTypeSpace)
+///     .space_sdk("static")
+///     .send()
+///     .await?;
+/// # let _ = runtime; Ok(()) }
+/// ```
 #[derive(Default, Copy, Clone, Debug)]
 pub struct RepoTypeSpace;
 
-/// Marker for a kernel repository on the Hub. Implements [`RepoType`].
+/// Marker for a kernel repository on the Hub.
+///
+/// Implements [`RepoType`] returning `"kernel"` / `"kernels"` / `"kernels/"` for
+/// [`singular`](RepoType::singular), [`plural`](RepoType::plural), and
+/// [`url_prefix`](RepoType::url_prefix). API URLs are `/api/kernels/{repo_id}`;
+/// resolve URLs are `<endpoint>/kernels/{repo_id}/...`.
+///
+/// Note that [`HFRepository::<RepoTypeKernel>::info`](super::HFRepository::info) hits
+/// `/api/kernels/{repo_id}` which returns a slim shape (no `tags`, `cardData`, or
+/// `siblings`). For full model-style metadata on a kernel repo, build a model handle
+/// for the same id and call `info()` on that. Use
+/// [`HFClient::kernel`](crate::HFClient::kernel) for the typed shortcut, or pass this
+/// marker explicitly:
+///
+/// ```rust,no_run
+/// use hf_hub::{HFClient, RepoTypeKernel};
+/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+/// let client = HFClient::new()?;
+/// let repo = client.repository::<RepoTypeKernel>("kernels-community", "cutlass-mla");
+/// # let _ = repo; Ok(()) }
+/// ```
 #[derive(Default, Copy, Clone, Debug)]
 pub struct RepoTypeKernel;
 

--- a/hf-hub/src/repository/repo_type.rs
+++ b/hf-hub/src/repository/repo_type.rs
@@ -1,0 +1,132 @@
+//! Type-level markers for the four Hugging Face Hub repo kinds.
+//!
+//! The [`RepoType`] sealed trait and its four marker structs ([`RepoTypeModel`],
+//! [`RepoTypeDataset`], [`RepoTypeSpace`], [`RepoTypeKernel`]) parameterise
+//! [`HFRepository<T>`](super::HFRepository) and
+//! [`HFRepositorySync<T>`](crate::HFRepositorySync) so the repo kind is encoded in the
+//! type system. Methods that differ per repo kind (such as `info`) dispatch at compile time.
+//!
+//! All items here are re-exported flat at `hf_hub::repository::…` and at the crate root.
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Type-level marker for a Hugging Face Hub repo kind (model, dataset, Space, or kernel).
+///
+/// `RepoType` is a sealed trait — implemented only by the four marker structs in this
+/// module ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`], [`RepoTypeKernel`]).
+/// Pick the marker as the `T` parameter on [`HFRepository<T>`](super::HFRepository) /
+/// [`HFRepositorySync<T>`](crate::HFRepositorySync) at construction time (e.g. via
+/// [`HFClient::model`](crate::HFClient::model) / [`HFClient::dataset`](crate::HFClient::dataset) /
+/// [`HFClient::space`](crate::HFClient::space) / [`HFClient::kernel`](crate::HFClient::kernel))
+/// to lock the repo type into the type system; methods that differ per repo kind (such
+/// as `info`) are then resolved at compile time.
+///
+/// The trait exposes the fragments used to build Hub URLs and identify the repo kind in
+/// logs and error messages: [`singular`](Self::singular) (`"model"`, `"dataset"`, `"space"`,
+/// `"kernel"`), [`plural`](Self::plural) (the API segment — `"models"`, `"datasets"`,
+/// `"spaces"`, `"kernels"`), and [`url_prefix`](Self::url_prefix) (the path segment used by
+/// resolve URLs — `""` for models, `"<plural>/"` for everything else).
+pub trait RepoType: sealed::Sealed + Default + Copy + Clone + std::fmt::Debug + Send + Sync + 'static {
+    /// Lowercase singular name used in logs, error messages, and request bodies — e.g. `"model"`.
+    fn singular() -> &'static str;
+    /// Lowercase plural form, used as the `/api/{plural}/...` segment — e.g. `"models"`.
+    fn plural() -> &'static str;
+    /// Path prefix used in `<endpoint>/{prefix}{repo_id}/resolve/...` URLs.
+    /// Empty for models; `"<plural>/"` for all other repo kinds.
+    fn url_prefix() -> &'static str;
+}
+
+/// Marker for a model repository on the Hub. Implements [`RepoType`].
+#[derive(Default, Copy, Clone, Debug)]
+pub struct RepoTypeModel;
+
+/// Marker for a dataset repository on the Hub. Implements [`RepoType`].
+#[derive(Default, Copy, Clone, Debug)]
+pub struct RepoTypeDataset;
+
+/// Marker for a Space repository on the Hub. Implements [`RepoType`].
+#[derive(Default, Copy, Clone, Debug)]
+pub struct RepoTypeSpace;
+
+/// Marker for a kernel repository on the Hub. Implements [`RepoType`].
+#[derive(Default, Copy, Clone, Debug)]
+pub struct RepoTypeKernel;
+
+impl sealed::Sealed for RepoTypeModel {}
+impl sealed::Sealed for RepoTypeDataset {}
+impl sealed::Sealed for RepoTypeSpace {}
+impl sealed::Sealed for RepoTypeKernel {}
+
+impl RepoType for RepoTypeModel {
+    fn singular() -> &'static str {
+        "model"
+    }
+    fn plural() -> &'static str {
+        "models"
+    }
+    fn url_prefix() -> &'static str {
+        ""
+    }
+}
+
+impl RepoType for RepoTypeDataset {
+    fn singular() -> &'static str {
+        "dataset"
+    }
+    fn plural() -> &'static str {
+        "datasets"
+    }
+    fn url_prefix() -> &'static str {
+        "datasets/"
+    }
+}
+
+impl RepoType for RepoTypeSpace {
+    fn singular() -> &'static str {
+        "space"
+    }
+    fn plural() -> &'static str {
+        "spaces"
+    }
+    fn url_prefix() -> &'static str {
+        "spaces/"
+    }
+}
+
+impl RepoType for RepoTypeKernel {
+    fn singular() -> &'static str {
+        "kernel"
+    }
+    fn plural() -> &'static str {
+        "kernels"
+    }
+    fn url_prefix() -> &'static str {
+        "kernels/"
+    }
+}
+
+impl std::fmt::Display for RepoTypeModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(Self::singular())
+    }
+}
+
+impl std::fmt::Display for RepoTypeDataset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(Self::singular())
+    }
+}
+
+impl std::fmt::Display for RepoTypeSpace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(Self::singular())
+    }
+}
+
+impl std::fmt::Display for RepoTypeKernel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(Self::singular())
+    }
+}

--- a/hf-hub/src/repository/repo_type.rs
+++ b/hf-hub/src/repository/repo_type.rs
@@ -28,14 +28,19 @@ mod sealed {
 /// `"kernel"`), [`plural`](Self::plural) (the API segment — `"models"`, `"datasets"`,
 /// `"spaces"`, `"kernels"`), and [`url_prefix`](Self::url_prefix) (the path segment used by
 /// resolve URLs — `""` for models, `"<plural>/"` for everything else).
+///
+/// All methods return the same value regardless of the receiver — they're properties of
+/// the type itself. The marker structs are zero-sized and `Default`, so when only the
+/// type is in scope (inside an `impl<T: RepoType>` block, for example), use
+/// `T::default().singular()` to materialize an instance to call the method on.
 pub trait RepoType: sealed::Sealed + Default + Copy + Clone + std::fmt::Debug + Send + Sync + 'static {
     /// Lowercase singular name used in logs, error messages, and request bodies — e.g. `"model"`.
-    fn singular() -> &'static str;
+    fn singular(&self) -> &'static str;
     /// Lowercase plural form, used as the `/api/{plural}/...` segment — e.g. `"models"`.
-    fn plural() -> &'static str;
+    fn plural(&self) -> &'static str;
     /// Path prefix used in `<endpoint>/{prefix}{repo_id}/resolve/...` URLs.
     /// Empty for models; `"<plural>/"` for all other repo kinds.
-    fn url_prefix() -> &'static str;
+    fn url_prefix(&self) -> &'static str;
 }
 
 /// Marker for a model repository on the Hub. Implements [`RepoType`].
@@ -60,73 +65,73 @@ impl sealed::Sealed for RepoTypeSpace {}
 impl sealed::Sealed for RepoTypeKernel {}
 
 impl RepoType for RepoTypeModel {
-    fn singular() -> &'static str {
+    fn singular(&self) -> &'static str {
         "model"
     }
-    fn plural() -> &'static str {
+    fn plural(&self) -> &'static str {
         "models"
     }
-    fn url_prefix() -> &'static str {
+    fn url_prefix(&self) -> &'static str {
         ""
     }
 }
 
 impl RepoType for RepoTypeDataset {
-    fn singular() -> &'static str {
+    fn singular(&self) -> &'static str {
         "dataset"
     }
-    fn plural() -> &'static str {
+    fn plural(&self) -> &'static str {
         "datasets"
     }
-    fn url_prefix() -> &'static str {
+    fn url_prefix(&self) -> &'static str {
         "datasets/"
     }
 }
 
 impl RepoType for RepoTypeSpace {
-    fn singular() -> &'static str {
+    fn singular(&self) -> &'static str {
         "space"
     }
-    fn plural() -> &'static str {
+    fn plural(&self) -> &'static str {
         "spaces"
     }
-    fn url_prefix() -> &'static str {
+    fn url_prefix(&self) -> &'static str {
         "spaces/"
     }
 }
 
 impl RepoType for RepoTypeKernel {
-    fn singular() -> &'static str {
+    fn singular(&self) -> &'static str {
         "kernel"
     }
-    fn plural() -> &'static str {
+    fn plural(&self) -> &'static str {
         "kernels"
     }
-    fn url_prefix() -> &'static str {
+    fn url_prefix(&self) -> &'static str {
         "kernels/"
     }
 }
 
 impl std::fmt::Display for RepoTypeModel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(Self::singular())
+        f.write_str(self.singular())
     }
 }
 
 impl std::fmt::Display for RepoTypeDataset {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(Self::singular())
+        f.write_str(self.singular())
     }
 }
 
 impl std::fmt::Display for RepoTypeSpace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(Self::singular())
+        f.write_str(self.singular())
     }
 }
 
 impl std::fmt::Display for RepoTypeKernel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(Self::singular())
+        f.write_str(self.singular())
     }
 }

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -81,10 +81,10 @@ struct DeleteFolderParams {
     create_pr: bool,
 }
 
-impl HFRepository {
+impl<T: RepoType> HFRepository<T> {
     async fn create_commit_impl(&self, params: CreateCommitParams) -> HFResult<CommitInfo> {
         let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!("{}/commit/{}", self.hf_client.api_url(Some(self.repo_type), &self.repo_path()), revision);
+        let url = format!("{}/commit/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
 
         let add_ops_count = params
             .operations
@@ -371,7 +371,7 @@ impl HFRepository {
         let upload_modes = self
             .fetch_upload_modes(
                 &self.repo_path(),
-                Some(self.repo_type),
+                T::plural(),
                 revision,
                 &file_infos
                     .iter()
@@ -407,11 +407,11 @@ impl HFRepository {
     async fn fetch_upload_modes(
         &self,
         repo_id: &str,
-        repo_type: Option<RepoType>,
+        api_segment: &str,
         revision: &str,
         files: &[(&str, u64, &[u8])],
     ) -> HFResult<HashMap<String, String>> {
-        let url = format!("{}/preupload/{}", self.hf_client.api_url(repo_type, repo_id), revision);
+        let url = format!("{}/preupload/{}", self.hf_client.api_url(api_segment, repo_id), revision);
 
         let files_payload: Vec<serde_json::Value> = files
             .iter()
@@ -469,7 +469,7 @@ impl HFRepository {
         let repo_path = self.repo_path();
         tracing::info!("calling LFS batch endpoint for transfer negotiation");
         let chosen_transfer = self
-            .post_lfs_batch_info(&repo_path, Some(self.repo_type), revision, &objects)
+            .post_lfs_batch_info(&repo_path, T::url_prefix(), revision, &objects)
             .await?;
         tracing::info!(?chosen_transfer, "LFS batch transfer negotiation complete");
 
@@ -502,12 +502,11 @@ impl HFRepository {
     async fn post_lfs_batch_info(
         &self,
         repo_id: &str,
-        repo_type: Option<RepoType>,
+        url_prefix: &str,
         revision: &str,
         objects: &[(&str, u64)],
     ) -> HFResult<Option<String>> {
-        let prefix = constants::repo_type_url_prefix(repo_type);
-        let url = format!("{}/{}{}.git/info/lfs/objects/batch", self.hf_client.endpoint(), prefix, repo_id);
+        let url = format!("{}/{}{}.git/info/lfs/objects/batch", self.hf_client.endpoint(), url_prefix, repo_id);
 
         let objects_payload: Vec<serde_json::Value> = objects
             .iter()
@@ -679,7 +678,7 @@ fn collect_files_recursive(
 }
 
 #[bon]
-impl HFRepository {
+impl<T: RepoType> HFRepository<T> {
     /// Create a commit with multiple operations.
     ///
     /// This is the lowest-level public mutation API in the files module. Use it when you need an
@@ -936,7 +935,7 @@ impl HFRepository {
 
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFRepositorySync {
+impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::create_commit`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -84,7 +84,7 @@ struct DeleteFolderParams {
 impl<T: RepoType> HFRepository<T> {
     async fn create_commit_impl(&self, params: CreateCommitParams) -> HFResult<CommitInfo> {
         let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!("{}/commit/{}", self.hf_client.api_url(T::plural(), &self.repo_path()), revision);
+        let url = format!("{}/commit/{}", self.hf_client.api_url(T::default().plural(), &self.repo_path()), revision);
 
         let add_ops_count = params
             .operations
@@ -371,7 +371,7 @@ impl<T: RepoType> HFRepository<T> {
         let upload_modes = self
             .fetch_upload_modes(
                 &self.repo_path(),
-                T::plural(),
+                T::default().plural(),
                 revision,
                 &file_infos
                     .iter()
@@ -469,7 +469,7 @@ impl<T: RepoType> HFRepository<T> {
         let repo_path = self.repo_path();
         tracing::info!("calling LFS batch endpoint for transfer negotiation");
         let chosen_transfer = self
-            .post_lfs_batch_info(&repo_path, T::url_prefix(), revision, &objects)
+            .post_lfs_batch_info(&repo_path, T::default().url_prefix(), revision, &objects)
             .await?;
         tracing::info!(?chosen_transfer, "LFS batch transfer negotiation complete");
 

--- a/hf-hub/src/spaces.rs
+++ b/hf-hub/src/spaces.rs
@@ -1,31 +1,25 @@
 //! Space handles, response types, and runtime/hardware/secrets APIs.
 //!
-//! Get a handle with [`HFClient::space`](HFClient::space). It is an [`HFSpace`], which
-//! wraps an [`HFRepository`] pinned to [`RepoType::Space`] and adds
-//! Space-only methods (runtime, hardware, secrets, variables, pause/restart, duplicate).
-//!
-//! [`HFSpace`] implements [`Deref`] to [`HFRepository`], so every repo method (`info`,
-//! `download_file`, `list_tree`, `create_commit`, …) is available on the same value without
-//! switching handles.
+//! Space-specific operations (runtime, hardware, secrets, variables, pause/restart, duplicate)
+//! live as methods on [`HFRepository<RepoTypeSpace>`](HFRepository). Get a handle with
+//! [`HFClient::space`](crate::HFClient::space) and call the methods directly — there is no separate
+//! `HFSpace` wrapper.
 //!
 //! Response structs such as [`SpaceRuntime`] and [`SpaceVariable`] live in this module; bon-generated
 //! `*Builder` types for each Space API appear here for rustdoc.
 
-use std::ops::Deref;
-use std::sync::Arc;
-
 use bon::bon;
 use serde::{Deserialize, Serialize};
 
-use crate::client::HFClient;
-use crate::error::{HFError, HFResult};
-use crate::repository::{HFRepository, RepoType, RepoUrl};
+use crate::error::HFResult;
+use crate::repository::{HFRepository, RepoTypeSpace, RepoUrl};
 use crate::retry;
 
 /// Runtime state of a Space: stage, hardware, storage, and mounted volumes.
 ///
 /// Returned by Space lifecycle methods such as
-/// [`HFSpace::runtime`], [`HFSpace::pause`], and [`HFSpace::restart`].
+/// [`runtime`](HFRepository::runtime), [`pause`](HFRepository::pause), and
+/// [`restart`](HFRepository::restart) on [`HFRepository<RepoTypeSpace>`](HFRepository).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SpaceRuntime {
@@ -112,62 +106,8 @@ pub struct SpaceVariable {
     pub updated_at: Option<String>,
 }
 
-/// A handle for a Space repository, providing Space-specific operations on top of [`HFRepository`].
-///
-/// `HFSpace` wraps an [`HFRepository`] fixed to [`RepoType::Space`] and exposes hardware,
-/// secret, and variable management. It derefs to [`HFRepository`], so all general repo
-/// methods (e.g. `exists`, `info`, `download_file`) are accessible directly.
-///
-/// Created via [`HFClient::space`] or [`TryFrom<HFRepository>`].
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use hf_hub::HFClient;
-/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
-/// let client = HFClient::builder().build()?;
-/// let space = client.space("huggingface", "diffusers-gallery");
-/// // General repo methods are available via Deref:
-/// let exists = space.exists().send().await?;
-/// # Ok(()) }
-/// ```
-#[derive(Clone)]
-pub struct HFSpace {
-    pub(crate) repo: Arc<HFRepository>,
-}
-
-impl std::fmt::Debug for HFSpace {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HFSpace").field("repo", &self.repo).finish()
-    }
-}
-
-impl HFClient {
-    /// Create an [`HFSpace`] handle for a Space repository.
-    pub fn space(&self, owner: impl Into<String>, name: impl Into<String>) -> HFSpace {
-        HFSpace::new(self.clone(), owner, name)
-    }
-}
-
-impl HFSpace {
-    /// Construct a new Space handle. Prefer [`HFClient::space`] in most cases.
-    pub fn new(client: HFClient, owner: impl Into<String>, name: impl Into<String>) -> Self {
-        Self {
-            repo: Arc::new(HFRepository::new(client, RepoType::Space, owner, name)),
-        }
-    }
-
-    /// Borrow the underlying [`HFRepository`].
-    ///
-    /// `HFSpace` already derefs to `HFRepository`, so this is mainly useful when you need an
-    /// explicit reference (e.g. to clone or to disambiguate trait resolution).
-    pub fn repo(&self) -> &HFRepository {
-        &self.repo
-    }
-}
-
 #[bon]
-impl HFSpace {
+impl HFRepository<RepoTypeSpace> {
     /// Fetch the current runtime state of the Space (hardware, stage, URL, etc.).
     ///
     /// Endpoint: `GET /api/spaces/{repo_id}/runtime`.
@@ -562,45 +502,17 @@ impl HFSpace {
     }
 }
 
-impl TryFrom<HFRepository> for HFSpace {
-    type Error = HFError;
-
-    fn try_from(repo: HFRepository) -> HFResult<Self> {
-        if repo.repo_type() != RepoType::Space {
-            return Err(HFError::InvalidRepoType {
-                expected: RepoType::Space,
-                actual: repo.repo_type(),
-            });
-        }
-        Ok(Self { repo: Arc::new(repo) })
-    }
-}
-
-impl From<HFSpace> for Arc<HFRepository> {
-    fn from(space: HFSpace) -> Self {
-        space.repo.clone()
-    }
-}
-
-impl Deref for HFSpace {
-    type Target = HFRepository;
-
-    fn deref(&self) -> &Self::Target {
-        &self.repo
-    }
-}
-
 #[cfg(feature = "blocking")]
 #[bon]
-impl crate::blocking::HFSpaceSync {
-    /// Blocking counterpart of [`HFSpace::runtime`]. See the async method for parameters and
+impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
+    /// Blocking counterpart of [`HFRepository::runtime`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn runtime(&self) -> HFResult<SpaceRuntime> {
-        self.repo_sync.runtime.block_on(self.inner.runtime().send())
+        self.runtime.block_on(self.inner.runtime().send())
     }
 
-    /// Blocking counterpart of [`HFSpace::request_hardware`]. See the async method for parameters
+    /// Blocking counterpart of [`HFRepository::request_hardware`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn request_hardware(
@@ -611,7 +523,7 @@ impl crate::blocking::HFSpaceSync {
         /// Seconds of inactivity before the Space is put to sleep. `0` means never sleep.
         sleep_time: Option<u64>,
     ) -> HFResult<SpaceRuntime> {
-        self.repo_sync.runtime.block_on(
+        self.runtime.block_on(
             self.inner
                 .request_hardware()
                 .hardware(hardware)
@@ -620,7 +532,7 @@ impl crate::blocking::HFSpaceSync {
         )
     }
 
-    /// Blocking counterpart of [`HFSpace::set_sleep_time`]. See the async method for parameters
+    /// Blocking counterpart of [`HFRepository::set_sleep_time`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn set_sleep_time(
@@ -628,26 +540,24 @@ impl crate::blocking::HFSpaceSync {
         /// Seconds of inactivity before the Space is put to sleep. `0` means never sleep.
         sleep_time: u64,
     ) -> HFResult<()> {
-        self.repo_sync
-            .runtime
-            .block_on(self.inner.set_sleep_time().sleep_time(sleep_time).send())
+        self.runtime.block_on(self.inner.set_sleep_time().sleep_time(sleep_time).send())
     }
 
-    /// Blocking counterpart of [`HFSpace::pause`]. See the async method for parameters and
+    /// Blocking counterpart of [`HFRepository::pause`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn pause(&self) -> HFResult<SpaceRuntime> {
-        self.repo_sync.runtime.block_on(self.inner.pause().send())
+        self.runtime.block_on(self.inner.pause().send())
     }
 
-    /// Blocking counterpart of [`HFSpace::restart`]. See the async method for parameters and
+    /// Blocking counterpart of [`HFRepository::restart`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn restart(&self) -> HFResult<SpaceRuntime> {
-        self.repo_sync.runtime.block_on(self.inner.restart().send())
+        self.runtime.block_on(self.inner.restart().send())
     }
 
-    /// Blocking counterpart of [`HFSpace::add_secret`]. See the async method for parameters and
+    /// Blocking counterpart of [`HFRepository::add_secret`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn add_secret(
@@ -662,7 +572,7 @@ impl crate::blocking::HFSpaceSync {
         #[builder(into)]
         description: Option<String>,
     ) -> HFResult<()> {
-        self.repo_sync.runtime.block_on(
+        self.runtime.block_on(
             self.inner
                 .add_secret()
                 .key(key)
@@ -672,7 +582,7 @@ impl crate::blocking::HFSpaceSync {
         )
     }
 
-    /// Blocking counterpart of [`HFSpace::delete_secret`]. See the async method for parameters and
+    /// Blocking counterpart of [`HFRepository::delete_secret`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn delete_secret(
@@ -681,10 +591,10 @@ impl crate::blocking::HFSpaceSync {
         #[builder(into)]
         key: String,
     ) -> HFResult<()> {
-        self.repo_sync.runtime.block_on(self.inner.delete_secret().key(key).send())
+        self.runtime.block_on(self.inner.delete_secret().key(key).send())
     }
 
-    /// Blocking counterpart of [`HFSpace::add_variable`]. See the async method for parameters and
+    /// Blocking counterpart of [`HFRepository::add_variable`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn add_variable(
@@ -699,7 +609,7 @@ impl crate::blocking::HFSpaceSync {
         #[builder(into)]
         description: Option<String>,
     ) -> HFResult<()> {
-        self.repo_sync.runtime.block_on(
+        self.runtime.block_on(
             self.inner
                 .add_variable()
                 .key(key)
@@ -709,7 +619,7 @@ impl crate::blocking::HFSpaceSync {
         )
     }
 
-    /// Blocking counterpart of [`HFSpace::delete_variable`]. See the async method for parameters
+    /// Blocking counterpart of [`HFRepository::delete_variable`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn delete_variable(
@@ -718,10 +628,10 @@ impl crate::blocking::HFSpaceSync {
         #[builder(into)]
         key: String,
     ) -> HFResult<()> {
-        self.repo_sync.runtime.block_on(self.inner.delete_variable().key(key).send())
+        self.runtime.block_on(self.inner.delete_variable().key(key).send())
     }
 
-    /// Blocking counterpart of [`HFSpace::duplicate`]. See the async method for parameters and
+    /// Blocking counterpart of [`HFRepository::duplicate`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn duplicate(
@@ -747,7 +657,7 @@ impl crate::blocking::HFSpaceSync {
         /// Public (non-secret) environment variables to set on the duplicated Space.
         variables: Option<Vec<serde_json::Value>>,
     ) -> HFResult<RepoUrl> {
-        self.repo_sync.runtime.block_on(
+        self.runtime.block_on(
             self.inner
                 .duplicate()
                 .maybe_to_id(to_id)
@@ -764,33 +674,15 @@ impl crate::blocking::HFSpaceSync {
 
 #[cfg(test)]
 mod tests {
-    use super::{HFSpace, SpaceRuntime, SpaceVariable};
-    use crate::repository::{HFRepository, RepoType};
+    use super::{SpaceRuntime, SpaceVariable};
 
     #[test]
-    fn test_hfspace_constructor_and_deref() {
+    fn test_space_handle_constructor() {
         let client = crate::HFClient::builder().build().unwrap();
-        let space = HFSpace::new(client, "huggingface-projects", "diffusers-gallery");
+        let space = client.space("huggingface-projects", "diffusers-gallery");
 
-        assert_eq!(space.repo_type(), RepoType::Space);
+        assert_eq!(space.repo_type(), "space");
         assert_eq!(space.repo_path(), "huggingface-projects/diffusers-gallery");
-    }
-
-    #[test]
-    fn test_hfspace_try_from_repo() {
-        let client = crate::HFClient::builder().build().unwrap();
-        let space_repo = HFRepository::new(client.clone(), RepoType::Space, "owner", "space");
-        assert!(HFSpace::try_from(space_repo).is_ok());
-
-        let model_repo = HFRepository::new(client, RepoType::Model, "owner", "model");
-        let error = HFSpace::try_from(model_repo).unwrap_err();
-        match error {
-            crate::HFError::InvalidRepoType { expected, actual } => {
-                assert_eq!(expected, RepoType::Space);
-                assert_eq!(actual, RepoType::Model);
-            },
-            _ => panic!("expected invalid repo type error"),
-        }
     }
 
     #[test]

--- a/hf-hub/src/spaces.rs
+++ b/hf-hub/src/spaces.rs
@@ -675,13 +675,14 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
 #[cfg(test)]
 mod tests {
     use super::{SpaceRuntime, SpaceVariable};
+    use crate::repository::RepoType;
 
     #[test]
     fn test_space_handle_constructor() {
         let client = crate::HFClient::builder().build().unwrap();
         let space = client.space("huggingface-projects", "diffusers-gallery");
 
-        assert_eq!(space.repo_type(), "space");
+        assert_eq!(space.repo_type().singular(), "space");
         assert_eq!(space.repo_path(), "huggingface-projects/diffusers-gallery");
     }
 

--- a/hf-hub/src/xet.rs
+++ b/hf-hub/src/xet.rs
@@ -353,7 +353,7 @@ impl<T: RepoType> HFRepository<T> {
         progress: &Option<Progress>,
     ) -> HFResult<PathBuf> {
         let repo_path = self.repo_path();
-        let api_segment = T::plural();
+        let api_segment = T::default().plural();
         let file_hash = crate::repository::extract_xet_hash(head_response)
             .ok_or_else(|| HFError::malformed_response("missing X-Xet-Hash header"))?;
 
@@ -428,7 +428,7 @@ impl<T: RepoType> HFRepository<T> {
         progress: &Option<Progress>,
     ) -> HFResult<()> {
         let repo_path = self.repo_path();
-        let api_segment = T::plural();
+        let api_segment = T::default().plural();
         let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, api_segment, revision);
         let conn = fetch_xet_connection_info(
             &self.hf_client,
@@ -500,7 +500,7 @@ impl<T: RepoType> HFRepository<T> {
         }
 
         let repo_path = self.repo_path();
-        let api_segment = T::plural();
+        let api_segment = T::default().plural();
         let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, api_segment, revision);
         let conn = fetch_xet_connection_info(
             &self.hf_client,
@@ -582,7 +582,7 @@ impl<T: RepoType> HFRepository<T> {
         range: Option<std::ops::Range<u64>>,
     ) -> HFResult<impl futures::Stream<Item = HFResult<bytes::Bytes>> + use<T>> {
         let repo_path = self.repo_path();
-        let api_segment = T::plural();
+        let api_segment = T::default().plural();
         let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, api_segment, revision);
         let conn = fetch_xet_connection_info(
             &self.hf_client,
@@ -639,7 +639,7 @@ impl<T: RepoType> HFRepository<T> {
         progress: &Option<Progress>,
     ) -> HFResult<Vec<XetFileInfo>> {
         let repo_path = self.repo_path();
-        let token_url = repo_xet_token_url(&self.hf_client, "write", &repo_path, T::plural(), revision);
+        let token_url = repo_xet_token_url(&self.hf_client, "write", &repo_path, T::default().plural(), revision);
         xet_upload_inner(
             &self.hf_client,
             files,

--- a/hf-hub/src/xet.rs
+++ b/hf-hub/src/xet.rs
@@ -16,7 +16,7 @@ use crate::client::HFClient;
 use crate::error::{HFError, HFResult, XetOperation};
 use crate::progress::{DownloadEvent, EmitEvent, FileProgress, FileStatus, Progress, UploadEvent};
 use crate::repository::{AddSource, HFRepository, RepoType};
-use crate::{constants, retry};
+use crate::retry;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -59,15 +59,8 @@ async fn fetch_xet_connection_info(
     })
 }
 
-fn repo_xet_token_url(
-    client: &HFClient,
-    token_type: &str,
-    repo_id: &str,
-    repo_type: Option<RepoType>,
-    revision: &str,
-) -> String {
-    let segment = constants::repo_type_api_segment(repo_type);
-    format!("{}/api/{}/{}/xet-{}-token/{}", client.endpoint(), segment, repo_id, token_type, revision)
+fn repo_xet_token_url(client: &HFClient, token_type: &str, repo_id: &str, api_segment: &str, revision: &str) -> String {
+    format!("{}/api/{}/{}/xet-{}-token/{}", client.endpoint(), api_segment, repo_id, token_type, revision)
 }
 
 pub(crate) fn bucket_xet_token_url(client: &HFClient, token_type: &str, bucket_id: &str) -> String {
@@ -350,7 +343,7 @@ async fn xet_upload_inner(
     Ok(xet_file_infos)
 }
 
-impl HFRepository {
+impl<T: RepoType> HFRepository<T> {
     pub(crate) async fn xet_download_to_local_dir(
         &self,
         revision: &str,
@@ -360,13 +353,13 @@ impl HFRepository {
         progress: &Option<Progress>,
     ) -> HFResult<PathBuf> {
         let repo_path = self.repo_path();
-        let repo_type = Some(self.repo_type);
+        let api_segment = T::plural();
         let file_hash = crate::repository::extract_xet_hash(head_response)
             .ok_or_else(|| HFError::malformed_response("missing X-Xet-Hash header"))?;
 
         let file_size: u64 = crate::repository::extract_file_size(head_response).unwrap_or(0);
 
-        let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, repo_type, revision);
+        let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, api_segment, revision);
         let conn = fetch_xet_connection_info(
             &self.hf_client,
             &token_url,
@@ -435,8 +428,8 @@ impl HFRepository {
         progress: &Option<Progress>,
     ) -> HFResult<()> {
         let repo_path = self.repo_path();
-        let repo_type = Some(self.repo_type);
-        let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, repo_type, revision);
+        let api_segment = T::plural();
+        let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, api_segment, revision);
         let conn = fetch_xet_connection_info(
             &self.hf_client,
             &token_url,
@@ -507,8 +500,8 @@ impl HFRepository {
         }
 
         let repo_path = self.repo_path();
-        let repo_type = Some(self.repo_type);
-        let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, repo_type, revision);
+        let api_segment = T::plural();
+        let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, api_segment, revision);
         let conn = fetch_xet_connection_info(
             &self.hf_client,
             &token_url,
@@ -587,10 +580,10 @@ impl HFRepository {
         file_hash: &str,
         file_size: u64,
         range: Option<std::ops::Range<u64>>,
-    ) -> HFResult<impl futures::Stream<Item = HFResult<bytes::Bytes>> + use<>> {
+    ) -> HFResult<impl futures::Stream<Item = HFResult<bytes::Bytes>> + use<T>> {
         let repo_path = self.repo_path();
-        let repo_type = Some(self.repo_type);
-        let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, repo_type, revision);
+        let api_segment = T::plural();
+        let token_url = repo_xet_token_url(&self.hf_client, "read", &repo_path, api_segment, revision);
         let conn = fetch_xet_connection_info(
             &self.hf_client,
             &token_url,
@@ -646,7 +639,7 @@ impl HFRepository {
         progress: &Option<Progress>,
     ) -> HFResult<Vec<XetFileInfo>> {
         let repo_path = self.repo_path();
-        let token_url = repo_xet_token_url(&self.hf_client, "write", &repo_path, Some(self.repo_type), revision);
+        let token_url = repo_xet_token_url(&self.hf_client, "write", &repo_path, T::plural(), revision);
         xet_upload_inner(
             &self.hf_client,
             files,

--- a/hfrs/src/cli.rs
+++ b/hfrs/src/cli.rs
@@ -66,8 +66,8 @@ pub enum OutputFormat {
 }
 
 /// User-facing CLI flag selecting the repo kind. Dispatched to the typed
-/// `HFClient::{model, dataset, space}` / `HFClient::create_repo::<T>()` etc. paths
-/// at the call site via a `match` (see [`crate::with_typed_repo`] /
+/// `HFClient::{model, dataset, space}` / `client.create_repo().repo_type(...)`
+/// paths at the call site via a `match` (see [`crate::with_typed_repo`] /
 /// [`crate::dispatch_repo_type`]).
 #[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum RepoTypeArg {

--- a/hfrs/src/cli.rs
+++ b/hfrs/src/cli.rs
@@ -66,7 +66,7 @@ pub enum OutputFormat {
 }
 
 /// User-facing CLI flag selecting the repo kind. Dispatched to the typed
-/// `HFClient::{model, dataset, space}` / `client.create_repo().repo_type(...)`
+/// `HFClient::{model, dataset, space}` / `client.create_repository().repo_type(...)`
 /// paths at the call site via a `match` (see [`crate::with_typed_repo`] /
 /// [`crate::dispatch_repo_type`]).
 #[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/hfrs/src/cli.rs
+++ b/hfrs/src/cli.rs
@@ -1,6 +1,5 @@
 use clap::builder::styling::{AnsiColor, Effects, Styles};
 use clap::{Parser, Subcommand, ValueEnum};
-use hf_hub::RepoType;
 
 const STYLES: Styles = Styles::styled()
     .header(AnsiColor::Yellow.on_default().effects(Effects::BOLD))
@@ -66,19 +65,13 @@ pub enum OutputFormat {
     Json,
 }
 
-#[derive(Clone, ValueEnum)]
+/// User-facing CLI flag selecting the repo kind. Dispatched to the typed
+/// `HFClient::{model, dataset, space}` / `HFClient::create_repo::<T>()` etc. paths
+/// at the call site via a `match` (see [`crate::with_typed_repo`] /
+/// [`crate::dispatch_repo_type`]).
+#[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum RepoTypeArg {
     Model,
     Dataset,
     Space,
-}
-
-impl From<RepoTypeArg> for RepoType {
-    fn from(arg: RepoTypeArg) -> Self {
-        match arg {
-            RepoTypeArg::Model => RepoType::Model,
-            RepoTypeArg::Dataset => RepoType::Dataset,
-            RepoTypeArg::Space => RepoType::Space,
-        }
-    }
 }

--- a/hfrs/src/commands/datasets/info.rs
+++ b/hfrs/src/commands/datasets/info.rs
@@ -24,7 +24,7 @@ pub struct Args {
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let (owner, name) = crate::util::split_repo_id(&args.dataset_id);
     let repo = client.dataset(owner, name);
-    let info = repo.info().maybe_revision(args.revision).send().await?.into_dataset_info()?;
+    let info = repo.info().maybe_revision(args.revision).send().await?;
     let json_value = json!({
         "id": info.id,
         "author": info.author,

--- a/hfrs/src/commands/download.rs
+++ b/hfrs/src/commands/download.rs
@@ -52,47 +52,46 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args, multi: Option<indicatif::MultiProgress>) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-
     let handler: Option<Progress> = if args.quiet {
         None
     } else {
         multi.map(|multi| CliProgressHandler::new(multi).into())
     };
 
-    let path = if args.filenames.len() == 1 && args.include.is_empty() && args.exclude.is_empty() {
-        repo.download_file()
-            .filename(args.filenames.into_iter().next().unwrap())
-            .maybe_local_dir(args.local_dir)
-            .maybe_revision(args.revision)
-            .force_download(args.force_download)
-            .maybe_progress(handler.clone())
-            .send()
-            .await?
-    } else {
-        let allow_patterns = if !args.filenames.is_empty() {
-            Some(args.filenames)
-        } else if !args.include.is_empty() {
-            Some(args.include)
+    let path = crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        if args.filenames.len() == 1 && args.include.is_empty() && args.exclude.is_empty() {
+            repo.download_file()
+                .filename(args.filenames.into_iter().next().unwrap())
+                .maybe_local_dir(args.local_dir)
+                .maybe_revision(args.revision)
+                .force_download(args.force_download)
+                .maybe_progress(handler.clone())
+                .send()
+                .await?
         } else {
-            None
-        };
-        let ignore_patterns = if !args.exclude.is_empty() {
-            Some(args.exclude)
-        } else {
-            None
-        };
-        repo.snapshot_download()
-            .maybe_revision(args.revision)
-            .maybe_allow_patterns(allow_patterns)
-            .maybe_ignore_patterns(ignore_patterns)
-            .maybe_local_dir(args.local_dir)
-            .force_download(args.force_download)
-            .maybe_progress(handler.clone())
-            .send()
-            .await?
-    };
+            let allow_patterns = if !args.filenames.is_empty() {
+                Some(args.filenames)
+            } else if !args.include.is_empty() {
+                Some(args.include)
+            } else {
+                None
+            };
+            let ignore_patterns = if !args.exclude.is_empty() {
+                Some(args.exclude)
+            } else {
+                None
+            };
+            repo.snapshot_download()
+                .maybe_revision(args.revision)
+                .maybe_allow_patterns(allow_patterns)
+                .maybe_ignore_patterns(ignore_patterns)
+                .maybe_local_dir(args.local_dir)
+                .force_download(args.force_download)
+                .maybe_progress(handler.clone())
+                .send()
+                .await?
+        }
+    });
 
     Ok(CommandResult::Raw(path.display().to_string()))
 }

--- a/hfrs/src/commands/models/info.rs
+++ b/hfrs/src/commands/models/info.rs
@@ -24,7 +24,7 @@ pub struct Args {
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let (owner, name) = crate::util::split_repo_id(&args.model_id);
     let repo = client.model(owner, name);
-    let info = repo.info().maybe_revision(args.revision).send().await?.into_model_info()?;
+    let info = repo.info().maybe_revision(args.revision).send().await?;
     let json_value = json!({
         "id": info.id,
         "author": info.author,

--- a/hfrs/src/commands/repos/branch.rs
+++ b/hfrs/src/commands/repos/branch.rs
@@ -61,19 +61,19 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
 }
 
 async fn create(client: &HFClient, args: BranchCreateArgs) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-    repo.create_branch()
-        .branch(args.branch)
-        .maybe_revision(args.revision)
-        .send()
-        .await?;
+    crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        repo.create_branch()
+            .branch(args.branch)
+            .maybe_revision(args.revision)
+            .send()
+            .await?
+    });
     Ok(CommandResult::Raw("Branch created.".to_string()))
 }
 
 async fn delete(client: &HFClient, args: BranchDeleteArgs) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-    repo.delete_branch().branch(args.branch).send().await?;
+    crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        repo.delete_branch().branch(args.branch).send().await?
+    });
     Ok(CommandResult::Silent)
 }

--- a/hfrs/src/commands/repos/create.rs
+++ b/hfrs/src/commands/repos/create.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Args as ClapArgs;
-use hf_hub::HFClient;
+use hf_hub::{HFClient, RepoTypeDataset, RepoTypeModel, RepoTypeSpace};
 
 use crate::cli::RepoTypeArg;
 use crate::output::CommandResult;
@@ -29,15 +29,37 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let result = client
-        .create_repo()
-        .repo_id(args.repo_id)
-        .repo_type(repo_type)
-        .maybe_private(if args.private { Some(true) } else { None })
-        .exist_ok(args.exist_ok)
-        .maybe_space_sdk(args.space_sdk)
-        .send()
-        .await?;
+    let result = match args.r#type {
+        RepoTypeArg::Model => {
+            client
+                .create_repo::<RepoTypeModel>()
+                .repo_id(args.repo_id)
+                .maybe_private(if args.private { Some(true) } else { None })
+                .exist_ok(args.exist_ok)
+                .maybe_space_sdk(args.space_sdk)
+                .send()
+                .await?
+        },
+        RepoTypeArg::Dataset => {
+            client
+                .create_repo::<RepoTypeDataset>()
+                .repo_id(args.repo_id)
+                .maybe_private(if args.private { Some(true) } else { None })
+                .exist_ok(args.exist_ok)
+                .maybe_space_sdk(args.space_sdk)
+                .send()
+                .await?
+        },
+        RepoTypeArg::Space => {
+            client
+                .create_repo::<RepoTypeSpace>()
+                .repo_id(args.repo_id)
+                .maybe_private(if args.private { Some(true) } else { None })
+                .exist_ok(args.exist_ok)
+                .maybe_space_sdk(args.space_sdk)
+                .send()
+                .await?
+        },
+    };
     Ok(CommandResult::Raw(result.url))
 }

--- a/hfrs/src/commands/repos/create.rs
+++ b/hfrs/src/commands/repos/create.rs
@@ -32,7 +32,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let result = match args.r#type {
         RepoTypeArg::Model => {
             client
-                .create_repo()
+                .create_repository()
                 .repo_type(RepoTypeModel)
                 .repo_id(args.repo_id)
                 .maybe_private(if args.private { Some(true) } else { None })
@@ -43,7 +43,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Dataset => {
             client
-                .create_repo()
+                .create_repository()
                 .repo_type(RepoTypeDataset)
                 .repo_id(args.repo_id)
                 .maybe_private(if args.private { Some(true) } else { None })
@@ -54,7 +54,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Space => {
             client
-                .create_repo()
+                .create_repository()
                 .repo_type(RepoTypeSpace)
                 .repo_id(args.repo_id)
                 .maybe_private(if args.private { Some(true) } else { None })

--- a/hfrs/src/commands/repos/create.rs
+++ b/hfrs/src/commands/repos/create.rs
@@ -32,7 +32,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let result = match args.r#type {
         RepoTypeArg::Model => {
             client
-                .create_repo::<RepoTypeModel>()
+                .create_repo()
+                .repo_type(RepoTypeModel)
                 .repo_id(args.repo_id)
                 .maybe_private(if args.private { Some(true) } else { None })
                 .exist_ok(args.exist_ok)
@@ -42,7 +43,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Dataset => {
             client
-                .create_repo::<RepoTypeDataset>()
+                .create_repo()
+                .repo_type(RepoTypeDataset)
                 .repo_id(args.repo_id)
                 .maybe_private(if args.private { Some(true) } else { None })
                 .exist_ok(args.exist_ok)
@@ -52,7 +54,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Space => {
             client
-                .create_repo::<RepoTypeSpace>()
+                .create_repo()
+                .repo_type(RepoTypeSpace)
                 .repo_id(args.repo_id)
                 .maybe_private(if args.private { Some(true) } else { None })
                 .exist_ok(args.exist_ok)

--- a/hfrs/src/commands/repos/delete.rs
+++ b/hfrs/src/commands/repos/delete.rs
@@ -24,7 +24,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     match args.r#type {
         RepoTypeArg::Model => {
             client
-                .delete_repo()
+                .delete_repository()
                 .repo_type(RepoTypeModel)
                 .repo_id(args.repo_id)
                 .missing_ok(args.missing_ok)
@@ -33,7 +33,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Dataset => {
             client
-                .delete_repo()
+                .delete_repository()
                 .repo_type(RepoTypeDataset)
                 .repo_id(args.repo_id)
                 .missing_ok(args.missing_ok)
@@ -42,7 +42,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Space => {
             client
-                .delete_repo()
+                .delete_repository()
                 .repo_type(RepoTypeSpace)
                 .repo_id(args.repo_id)
                 .missing_ok(args.missing_ok)

--- a/hfrs/src/commands/repos/delete.rs
+++ b/hfrs/src/commands/repos/delete.rs
@@ -24,7 +24,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     match args.r#type {
         RepoTypeArg::Model => {
             client
-                .delete_repo::<RepoTypeModel>()
+                .delete_repo()
+                .repo_type(RepoTypeModel)
                 .repo_id(args.repo_id)
                 .missing_ok(args.missing_ok)
                 .send()
@@ -32,7 +33,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Dataset => {
             client
-                .delete_repo::<RepoTypeDataset>()
+                .delete_repo()
+                .repo_type(RepoTypeDataset)
                 .repo_id(args.repo_id)
                 .missing_ok(args.missing_ok)
                 .send()
@@ -40,7 +42,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Space => {
             client
-                .delete_repo::<RepoTypeSpace>()
+                .delete_repo()
+                .repo_type(RepoTypeSpace)
                 .repo_id(args.repo_id)
                 .missing_ok(args.missing_ok)
                 .send()

--- a/hfrs/src/commands/repos/delete.rs
+++ b/hfrs/src/commands/repos/delete.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Args as ClapArgs;
-use hf_hub::HFClient;
+use hf_hub::{HFClient, RepoTypeDataset, RepoTypeModel, RepoTypeSpace};
 
 use crate::cli::RepoTypeArg;
 use crate::output::CommandResult;
@@ -21,13 +21,31 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    client
-        .delete_repo()
-        .repo_id(args.repo_id)
-        .repo_type(repo_type)
-        .missing_ok(args.missing_ok)
-        .send()
-        .await?;
+    match args.r#type {
+        RepoTypeArg::Model => {
+            client
+                .delete_repo::<RepoTypeModel>()
+                .repo_id(args.repo_id)
+                .missing_ok(args.missing_ok)
+                .send()
+                .await?;
+        },
+        RepoTypeArg::Dataset => {
+            client
+                .delete_repo::<RepoTypeDataset>()
+                .repo_id(args.repo_id)
+                .missing_ok(args.missing_ok)
+                .send()
+                .await?;
+        },
+        RepoTypeArg::Space => {
+            client
+                .delete_repo::<RepoTypeSpace>()
+                .repo_id(args.repo_id)
+                .missing_ok(args.missing_ok)
+                .send()
+                .await?;
+        },
+    }
     Ok(CommandResult::Silent)
 }

--- a/hfrs/src/commands/repos/delete_files.rs
+++ b/hfrs/src/commands/repos/delete_files.rs
@@ -40,41 +40,39 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-
     let matchers: Vec<_> = args
         .patterns
         .iter()
         .filter_map(|p| Glob::new(p).ok().map(|g| g.compile_matcher()))
         .collect();
 
-    let stream = repo.list_tree().maybe_revision(args.revision.clone()).recursive(true).send()?;
-    futures::pin_mut!(stream);
+    let result = crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        let stream = repo.list_tree().maybe_revision(args.revision.clone()).recursive(true).send()?;
+        futures::pin_mut!(stream);
 
-    let mut matched_files: Vec<String> = Vec::new();
-    while let Some(entry) = stream.next().await {
-        if let RepoTreeEntry::File { path, .. } = entry?
-            && matchers.iter().any(|m| m.is_match(&path))
-        {
-            matched_files.push(path);
+        let mut matched_files: Vec<String> = Vec::new();
+        while let Some(entry) = stream.next().await {
+            if let RepoTreeEntry::File { path, .. } = entry?
+                && matchers.iter().any(|m| m.is_match(&path))
+            {
+                matched_files.push(path);
+            }
         }
-    }
 
-    if matched_files.is_empty() {
-        anyhow::bail!("No files matched the given patterns");
-    }
+        if matched_files.is_empty() {
+            anyhow::bail!("No files matched the given patterns");
+        }
 
-    let operations: Vec<CommitOperation> = matched_files.into_iter().map(CommitOperation::delete).collect();
-    let result = repo
-        .create_commit()
-        .operations(operations)
-        .commit_message(args.commit_message)
-        .maybe_commit_description(args.commit_description)
-        .maybe_revision(args.revision)
-        .create_pr(args.create_pr)
-        .send()
-        .await?;
+        let operations: Vec<CommitOperation> = matched_files.into_iter().map(CommitOperation::delete).collect();
+        repo.create_commit()
+            .operations(operations)
+            .commit_message(args.commit_message)
+            .maybe_commit_description(args.commit_description)
+            .maybe_revision(args.revision)
+            .create_pr(args.create_pr)
+            .send()
+            .await?
+    });
     let url = result.commit_url.or(result.pr_url).unwrap_or_default();
     Ok(CommandResult::Raw(url))
 }

--- a/hfrs/src/commands/repos/file_metadata.rs
+++ b/hfrs/src/commands/repos/file_metadata.rs
@@ -29,15 +29,13 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-
-    let metadata = repo
-        .get_file_metadata()
-        .filepath(args.filepath)
-        .maybe_revision(args.revision)
-        .send()
-        .await?;
+    let metadata = crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        repo.get_file_metadata()
+            .filepath(args.filepath)
+            .maybe_revision(args.revision)
+            .send()
+            .await?
+    });
 
     let json_value = json!({
         "filename": metadata.filename,

--- a/hfrs/src/commands/repos/move_repo.rs
+++ b/hfrs/src/commands/repos/move_repo.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Args as ClapArgs;
-use hf_hub::HFClient;
+use hf_hub::{HFClient, RepoTypeDataset, RepoTypeModel, RepoTypeSpace};
 
 use crate::cli::RepoTypeArg;
 use crate::output::CommandResult;
@@ -20,13 +20,31 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let result = client
-        .move_repo()
-        .from_id(args.from_id)
-        .to_id(args.to_id)
-        .repo_type(repo_type)
-        .send()
-        .await?;
+    let result = match args.r#type {
+        RepoTypeArg::Model => {
+            client
+                .move_repo::<RepoTypeModel>()
+                .from_id(args.from_id)
+                .to_id(args.to_id)
+                .send()
+                .await?
+        },
+        RepoTypeArg::Dataset => {
+            client
+                .move_repo::<RepoTypeDataset>()
+                .from_id(args.from_id)
+                .to_id(args.to_id)
+                .send()
+                .await?
+        },
+        RepoTypeArg::Space => {
+            client
+                .move_repo::<RepoTypeSpace>()
+                .from_id(args.from_id)
+                .to_id(args.to_id)
+                .send()
+                .await?
+        },
+    };
     Ok(CommandResult::Raw(result.url))
 }

--- a/hfrs/src/commands/repos/move_repo.rs
+++ b/hfrs/src/commands/repos/move_repo.rs
@@ -23,7 +23,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let result = match args.r#type {
         RepoTypeArg::Model => {
             client
-                .move_repo()
+                .move_repository()
                 .repo_type(RepoTypeModel)
                 .from_id(args.from_id)
                 .to_id(args.to_id)
@@ -32,7 +32,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Dataset => {
             client
-                .move_repo()
+                .move_repository()
                 .repo_type(RepoTypeDataset)
                 .from_id(args.from_id)
                 .to_id(args.to_id)
@@ -41,7 +41,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Space => {
             client
-                .move_repo()
+                .move_repository()
                 .repo_type(RepoTypeSpace)
                 .from_id(args.from_id)
                 .to_id(args.to_id)

--- a/hfrs/src/commands/repos/move_repo.rs
+++ b/hfrs/src/commands/repos/move_repo.rs
@@ -23,7 +23,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let result = match args.r#type {
         RepoTypeArg::Model => {
             client
-                .move_repo::<RepoTypeModel>()
+                .move_repo()
+                .repo_type(RepoTypeModel)
                 .from_id(args.from_id)
                 .to_id(args.to_id)
                 .send()
@@ -31,7 +32,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Dataset => {
             client
-                .move_repo::<RepoTypeDataset>()
+                .move_repo()
+                .repo_type(RepoTypeDataset)
                 .from_id(args.from_id)
                 .to_id(args.to_id)
                 .send()
@@ -39,7 +41,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         },
         RepoTypeArg::Space => {
             client
-                .move_repo::<RepoTypeSpace>()
+                .move_repo()
+                .repo_type(RepoTypeSpace)
                 .from_id(args.from_id)
                 .to_id(args.to_id)
                 .send()

--- a/hfrs/src/commands/repos/settings.rs
+++ b/hfrs/src/commands/repos/settings.rs
@@ -42,9 +42,6 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-
     let gated: Option<GatedApprovalMode> = args.gated.map(|g| g.parse()).transpose()?;
     let gated_notifications_mode: Option<GatedNotificationsMode> =
         args.gated_notifications_mode.map(|m| m.parse()).transpose()?;
@@ -55,13 +52,15 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         (None, None) => None,
     };
 
-    repo.update_settings()
-        .maybe_private(args.private)
-        .maybe_gated(gated)
-        .maybe_description(args.description)
-        .maybe_discussions_disabled(args.discussions_disabled)
-        .maybe_gated_notifications(gated_notifications)
-        .send()
-        .await?;
+    crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        repo.update_settings()
+            .maybe_private(args.private)
+            .maybe_gated(gated)
+            .maybe_description(args.description)
+            .maybe_discussions_disabled(args.discussions_disabled)
+            .maybe_gated_notifications(gated_notifications)
+            .send()
+            .await?
+    });
     Ok(CommandResult::Silent)
 }

--- a/hfrs/src/commands/repos/tag.rs
+++ b/hfrs/src/commands/repos/tag.rs
@@ -84,28 +84,28 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
 }
 
 async fn create(client: &HFClient, args: TagCreateArgs) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-    repo.create_tag()
-        .tag(args.tag)
-        .maybe_revision(args.revision)
-        .maybe_message(args.message)
-        .send()
-        .await?;
+    crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        repo.create_tag()
+            .tag(args.tag)
+            .maybe_revision(args.revision)
+            .maybe_message(args.message)
+            .send()
+            .await?
+    });
     Ok(CommandResult::Raw("Tag created.".to_string()))
 }
 
 async fn delete(client: &HFClient, args: TagDeleteArgs) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-    repo.delete_tag().tag(args.tag).send().await?;
+    crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        repo.delete_tag().tag(args.tag).send().await?
+    });
     Ok(CommandResult::Silent)
 }
 
 async fn list(client: &HFClient, args: TagListArgs) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-    let refs = repo.list_refs().include_pull_requests(false).send().await?;
+    let refs = crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        repo.list_refs().include_pull_requests(false).send().await?
+    });
 
     if refs.tags.is_empty() && matches!(args.format, OutputFormat::Table) {
         return Ok(CommandResult::Raw("No tags found.".to_string()));

--- a/hfrs/src/commands/spaces/info.rs
+++ b/hfrs/src/commands/spaces/info.rs
@@ -24,7 +24,7 @@ pub struct Args {
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let (owner, name) = crate::util::split_repo_id(&args.space_id);
     let repo = client.space(owner, name);
-    let info = repo.info().maybe_revision(args.revision).send().await?.into_space_info()?;
+    let info = repo.info().maybe_revision(args.revision).send().await?;
     let json_value = json!({
         "id": info.id,
         "author": info.author,

--- a/hfrs/src/commands/upload.rs
+++ b/hfrs/src/commands/upload.rs
@@ -90,7 +90,7 @@ async fn do_upload<T: RepoType>(
     if !repo.exists().send().await? {
         info!(repo_id = args.repo_id.as_str(), private = args.private, "creating repository");
         client
-            .create_repo()
+            .create_repository()
             .repo_type(T::default())
             .repo_id(args.repo_id.clone())
             .maybe_private(if args.private { Some(true) } else { None })

--- a/hfrs/src/commands/upload.rs
+++ b/hfrs/src/commands/upload.rs
@@ -90,7 +90,8 @@ async fn do_upload<T: RepoType>(
     if !repo.exists().send().await? {
         info!(repo_id = args.repo_id.as_str(), private = args.private, "creating repository");
         client
-            .create_repo::<T>()
+            .create_repo()
+            .repo_type(T::default())
             .repo_id(args.repo_id.clone())
             .maybe_private(if args.private { Some(true) } else { None })
             .exist_ok(true)

--- a/hfrs/src/commands/upload.rs
+++ b/hfrs/src/commands/upload.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 
 use anyhow::{Result, bail};
 use clap::Args as ClapArgs;
-use hf_hub::HFClient;
 use hf_hub::progress::Progress;
 use hf_hub::repository::AddSource;
+use hf_hub::{HFClient, HFRepository, RepoType};
 use tracing::info;
 
 use crate::cli::RepoTypeArg;
@@ -65,28 +65,38 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args, multi: Option<indicatif::MultiProgress>) -> Result<CommandResult> {
-    let repo_type: hf_hub::RepoType = args.r#type.into();
-    let local_path = args.local_path.unwrap_or_else(|| PathBuf::from("."));
-    let repo = crate::util::make_repo(client, &args.repo_id, repo_type);
-
-    // Ensure the repo exists, creating it if necessary
-    if !repo.exists().send().await? {
-        info!(repo_id = args.repo_id.as_str(), private = args.private, "creating repository");
-        client
-            .create_repo()
-            .repo_id(args.repo_id.clone())
-            .repo_type(repo_type)
-            .maybe_private(if args.private { Some(true) } else { None })
-            .exist_ok(true)
-            .send()
-            .await?;
-    }
+    let local_path = args.local_path.clone().unwrap_or_else(|| PathBuf::from("."));
 
     let handler: Option<Progress> = if args.quiet {
         None
     } else {
         multi.map(|multi| CliProgressHandler::new(multi).into())
     };
+
+    let url = crate::with_typed_repo!(client, &args.repo_id, args.r#type, |repo| {
+        do_upload(client, repo, args, local_path, handler).await?
+    });
+
+    Ok(CommandResult::Raw(url))
+}
+
+async fn do_upload<T: RepoType>(
+    client: &HFClient,
+    repo: HFRepository<T>,
+    args: Args,
+    local_path: PathBuf,
+    handler: Option<Progress>,
+) -> Result<String> {
+    if !repo.exists().send().await? {
+        info!(repo_id = args.repo_id.as_str(), private = args.private, "creating repository");
+        client
+            .create_repo::<T>()
+            .repo_id(args.repo_id.clone())
+            .maybe_private(if args.private { Some(true) } else { None })
+            .exist_ok(true)
+            .send()
+            .await?;
+    }
 
     let commit_info = if local_path.is_file() {
         let path_in_repo = args.path_in_repo.unwrap_or_else(|| {
@@ -106,21 +116,9 @@ pub async fn execute(client: &HFClient, args: Args, multi: Option<indicatif::Mul
             .send()
             .await?
     } else if local_path.is_dir() {
-        let allow_patterns = if !args.include.is_empty() {
-            Some(args.include)
-        } else {
-            None
-        };
-        let ignore_patterns = if !args.exclude.is_empty() {
-            Some(args.exclude)
-        } else {
-            None
-        };
-        let delete_patterns = if !args.delete.is_empty() {
-            Some(args.delete)
-        } else {
-            None
-        };
+        let allow_patterns = (!args.include.is_empty()).then_some(args.include);
+        let ignore_patterns = (!args.exclude.is_empty()).then_some(args.exclude);
+        let delete_patterns = (!args.delete.is_empty()).then_some(args.delete);
         repo.upload_folder()
             .folder_path(local_path)
             .maybe_path_in_repo(args.path_in_repo)
@@ -138,6 +136,5 @@ pub async fn execute(client: &HFClient, args: Args, multi: Option<indicatif::Mul
         bail!("local path does not exist: {}", local_path.display());
     };
 
-    let url = commit_info.commit_url.or(commit_info.pr_url).unwrap_or_default();
-    Ok(CommandResult::Raw(url))
+    Ok(commit_info.commit_url.or(commit_info.pr_url).unwrap_or_default())
 }

--- a/hfrs/src/main.rs
+++ b/hfrs/src/main.rs
@@ -239,9 +239,6 @@ fn format_hf_error(err: &HFError) -> String {
         HFError::Url(e) => {
             format!("Invalid URL: {e}")
         },
-        HFError::InvalidRepoType { expected, actual } => {
-            format!("Invalid repository type: expected {expected:?}, got {actual:?}")
-        },
         HFError::InvalidParameter(msg) => msg.clone(),
         HFError::DiffParse(e) => {
             format!("Failed to parse diff: {e}")

--- a/hfrs/src/util/mod.rs
+++ b/hfrs/src/util/mod.rs
@@ -35,11 +35,10 @@ macro_rules! with_typed_repo {
     }};
 }
 
-/// Match on a [`crate::cli::RepoTypeArg`] and call a method that is generic over the repo
-/// kind via turbofish. Used for client-level methods like `create_repo::<T>()` and
-/// `delete_repo::<T>()` which don't take a typed repo handle.
+/// Match on a [`crate::cli::RepoTypeArg`] and call a generic helper function with the
+/// matching marker struct as the type parameter via turbofish.
 ///
-/// Expands to `match $arg { Model => $body::<RepoTypeModel>, ... }`.
+/// Expands to `match $arg { Model => $body::<RepoTypeModel>(), ... }`.
 #[macro_export]
 macro_rules! dispatch_repo_type {
     ($arg:expr, $body:ident) => {

--- a/hfrs/src/util/mod.rs
+++ b/hfrs/src/util/mod.rs
@@ -1,7 +1,5 @@
 pub mod token;
 
-use hf_hub::{HFClient, HFRepository, RepoType};
-
 /// Split a repo ID like "owner/name" into (owner, name).
 /// If no slash is present, treats the whole string as the name with an empty owner.
 pub fn split_repo_id(repo_id: &str) -> (&str, &str) {
@@ -11,8 +9,44 @@ pub fn split_repo_id(repo_id: &str) -> (&str, &str) {
     }
 }
 
-/// Create an HFRepository handle from an client client, repo_id string, and repo_type.
-pub fn make_repo(client: &HFClient, repo_id: &str, repo_type: RepoType) -> HFRepository {
-    let (owner, name) = split_repo_id(repo_id);
-    client.repo(repo_type, owner, name)
+/// Match on a [`crate::cli::RepoTypeArg`] and run `$body` with `$repo` bound to a typed
+/// `HFRepository<T>` for each arm. The body must compile generically over `T: RepoType`.
+///
+/// Used at CLI dispatch sites to convert the user-supplied `--type model|dataset|space`
+/// flag into a concrete typed repo handle without each command repeating the match.
+#[macro_export]
+macro_rules! with_typed_repo {
+    ($client:expr, $repo_id:expr, $arg:expr, |$repo:ident| $body:expr) => {{
+        let (owner, name) = $crate::util::split_repo_id($repo_id);
+        match $arg {
+            $crate::cli::RepoTypeArg::Model => {
+                let $repo = $client.repository::<hf_hub::RepoTypeModel>(owner, name);
+                $body
+            },
+            $crate::cli::RepoTypeArg::Dataset => {
+                let $repo = $client.repository::<hf_hub::RepoTypeDataset>(owner, name);
+                $body
+            },
+            $crate::cli::RepoTypeArg::Space => {
+                let $repo = $client.repository::<hf_hub::RepoTypeSpace>(owner, name);
+                $body
+            },
+        }
+    }};
+}
+
+/// Match on a [`crate::cli::RepoTypeArg`] and call a method that is generic over the repo
+/// kind via turbofish. Used for client-level methods like `create_repo::<T>()` and
+/// `delete_repo::<T>()` which don't take a typed repo handle.
+///
+/// Expands to `match $arg { Model => $body::<RepoTypeModel>, ... }`.
+#[macro_export]
+macro_rules! dispatch_repo_type {
+    ($arg:expr, $body:ident) => {
+        match $arg {
+            $crate::cli::RepoTypeArg::Model => $body::<hf_hub::RepoTypeModel>(),
+            $crate::cli::RepoTypeArg::Dataset => $body::<hf_hub::RepoTypeDataset>(),
+            $crate::cli::RepoTypeArg::Space => $body::<hf_hub::RepoTypeSpace>(),
+        }
+    };
 }

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -285,7 +285,7 @@ fn create_test_repo(client: &HFClientSync) -> String {
     let whoami = client.whoami().send().expect("whoami failed");
     let repo_id = format!("{}/hf-hub-sync-test-{}", whoami.username, uuid_v4_short());
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
@@ -307,7 +307,7 @@ fn create_test_repo(client: &HFClientSync) -> String {
 }
 
 fn delete_test_repo(client: &HFClientSync, repo_id: &str) {
-    let _ = client.delete_repo().repo_type(RepoTypeModel).repo_id(repo_id).send();
+    let _ = client.delete_repository().repo_type(RepoTypeModel).repo_id(repo_id).send();
 }
 
 #[test]
@@ -321,7 +321,7 @@ fn test_sync_create_and_delete_repo() {
     let repo_id = format!("{}/hf-hub-sync-test-{}", whoami.username, uuid_v4_short());
 
     let url = client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
@@ -344,7 +344,12 @@ fn test_sync_create_and_delete_repo() {
 
     assert!(test_repo.file_exists().filename("test.txt").send().unwrap());
 
-    client.delete_repo().repo_type(RepoTypeModel).repo_id(&repo_id).send().unwrap();
+    client
+        .delete_repository()
+        .repo_type(RepoTypeModel)
+        .repo_id(&repo_id)
+        .send()
+        .unwrap();
 }
 
 #[test]

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -7,7 +7,7 @@
 //! CI: The workflow sets HF_CI_TOKEN + HF_PROD_TOKEN.
 
 use hf_hub::repository::*;
-use hf_hub::{HFClientBuilder, HFClientSync};
+use hf_hub::{HFClientBuilder, HFClientSync, HFRepositorySync, RepoTypeDataset, RepoTypeModel};
 use integration_tests::test_utils::*;
 
 fn prod_sync_api() -> Option<HFClientSync> {
@@ -50,17 +50,27 @@ const TEST_MODEL_AUTHOR: &str = "openai-community";
 const TEST_MODEL_REPO: &str = "hf-internal-testing/tiny-gemma3";
 const TEST_DATASET_REPO: &str = "hf-internal-testing/cats_vs_dogs_sample";
 
-/// Split a `"owner/name"` string into an `HFRepositorySync` handle.
-fn repo_handle(client: &HFClientSync, repo_id: &str) -> hf_hub::HFRepositorySync {
+/// Split a `"owner/name"` string into an `HFRepositorySync<RepoTypeModel>` handle.
+fn repo_handle(client: &HFClientSync, repo_id: &str) -> HFRepositorySync<RepoTypeModel> {
+    let (owner, name) = split_id(repo_id);
+    client.model(owner, name)
+}
+
+fn dataset_handle(client: &HFClientSync, repo_id: &str) -> HFRepositorySync<RepoTypeDataset> {
+    let (owner, name) = split_id(repo_id);
+    client.dataset(owner, name)
+}
+
+fn split_id(repo_id: &str) -> (&str, &str) {
     let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
     if parts.len() == 2 {
-        client.model(parts[0], parts[1])
+        (parts[0], parts[1])
     } else {
-        client.model("", repo_id)
+        ("", repo_id)
     }
 }
 
-fn collect_file_paths(test_repo: &hf_hub::HFRepositorySync) -> std::collections::HashSet<String> {
+fn collect_file_paths<T: RepoType>(test_repo: &HFRepositorySync<T>) -> std::collections::HashSet<String> {
     test_repo
         .list_tree()
         .recursive(true)
@@ -74,15 +84,6 @@ fn collect_file_paths(test_repo: &hf_hub::HFRepositorySync) -> std::collections:
         .collect()
 }
 
-fn dataset_handle(client: &HFClientSync, repo_id: &str) -> hf_hub::HFRepositorySync {
-    let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
-    if parts.len() == 2 {
-        client.dataset(parts[0], parts[1])
-    } else {
-        client.dataset("", repo_id)
-    }
-}
-
 // --- Repo info ---
 
 #[test]
@@ -91,10 +92,7 @@ fn test_sync_model_info() {
     let model_repo = TEST_MODEL_REPO;
     let repo = repo_handle(&client, model_repo);
     let info = repo.info().send().unwrap();
-    match info {
-        RepoInfo::Model(model) => assert!(model.id.contains("tiny-gemma3")),
-        _ => panic!("expected model info"),
-    }
+    assert!(info.id.contains("tiny-gemma3"));
 }
 
 #[test]
@@ -103,10 +101,7 @@ fn test_sync_dataset_info() {
     let dataset_repo = TEST_DATASET_REPO;
     let repo = dataset_handle(&client, dataset_repo);
     let info = repo.info().send().unwrap();
-    match info {
-        RepoInfo::Dataset(ds) => assert_eq!(ds.id, dataset_repo),
-        _ => panic!("expected dataset info"),
-    }
+    assert_eq!(info.id, dataset_repo);
 }
 
 #[test]
@@ -116,10 +111,7 @@ fn test_sync_repo_handle_info_and_file_exists() {
     let repo = repo_handle(&client, model_repo);
 
     let info = repo.info().send().unwrap();
-    match info {
-        RepoInfo::Model(model) => assert_eq!(model.id, model_repo),
-        _ => panic!("expected model info"),
-    }
+    assert_eq!(info.id, model_repo);
 
     let exists = repo.file_exists().filename("config.json").send().unwrap();
     assert!(exists);
@@ -293,7 +285,7 @@ fn create_test_repo(client: &HFClientSync) -> String {
     let whoami = client.whoami().send().expect("whoami failed");
     let repo_id = format!("{}/hf-hub-sync-test-{}", whoami.username, uuid_v4_short());
     client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(false)
@@ -314,7 +306,7 @@ fn create_test_repo(client: &HFClientSync) -> String {
 }
 
 fn delete_test_repo(client: &HFClientSync, repo_id: &str) {
-    let _ = client.delete_repo().repo_id(repo_id).send();
+    let _ = client.delete_repo::<RepoTypeModel>().repo_id(repo_id).send();
 }
 
 #[test]
@@ -328,7 +320,7 @@ fn test_sync_create_and_delete_repo() {
     let repo_id = format!("{}/hf-hub-sync-test-{}", whoami.username, uuid_v4_short());
 
     let url = client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(true)
@@ -350,7 +342,7 @@ fn test_sync_create_and_delete_repo() {
 
     assert!(test_repo.file_exists().filename("test.txt").send().unwrap());
 
-    client.delete_repo().repo_id(&repo_id).send().unwrap();
+    client.delete_repo::<RepoTypeModel>().repo_id(&repo_id).send().unwrap();
 }
 
 #[test]

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -285,7 +285,8 @@ fn create_test_repo(client: &HFClientSync) -> String {
     let whoami = client.whoami().send().expect("whoami failed");
     let repo_id = format!("{}/hf-hub-sync-test-{}", whoami.username, uuid_v4_short());
     client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(false)
@@ -306,7 +307,7 @@ fn create_test_repo(client: &HFClientSync) -> String {
 }
 
 fn delete_test_repo(client: &HFClientSync, repo_id: &str) {
-    let _ = client.delete_repo::<RepoTypeModel>().repo_id(repo_id).send();
+    let _ = client.delete_repo().repo_type(RepoTypeModel).repo_id(repo_id).send();
 }
 
 #[test]
@@ -320,7 +321,8 @@ fn test_sync_create_and_delete_repo() {
     let repo_id = format!("{}/hf-hub-sync-test-{}", whoami.username, uuid_v4_short());
 
     let url = client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(true)
@@ -342,7 +344,7 @@ fn test_sync_create_and_delete_repo() {
 
     assert!(test_repo.file_exists().filename("test.txt").send().unwrap());
 
-    client.delete_repo::<RepoTypeModel>().repo_id(&repo_id).send().unwrap();
+    client.delete_repo().repo_type(RepoTypeModel).repo_id(&repo_id).send().unwrap();
 }
 
 #[test]

--- a/integration-tests/tests/download_test.rs
+++ b/integration-tests/tests/download_test.rs
@@ -62,7 +62,7 @@ async fn create_test_repo(client: &HFClient) -> String {
     let username = cached_username(client).await;
     let repo_id = format!("{}/hfrs-progress-test-{}", username, uuid_short());
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
@@ -74,7 +74,12 @@ async fn create_test_repo(client: &HFClient) -> String {
 }
 
 async fn delete_test_repo(client: &HFClient, repo_id: &str) {
-    let _ = client.delete_repo().repo_type(RepoTypeModel).repo_id(repo_id).send().await;
+    let _ = client
+        .delete_repository()
+        .repo_type(RepoTypeModel)
+        .repo_id(repo_id)
+        .send()
+        .await;
 }
 
 const TEST_MODEL_PARTS: (&str, &str) = ("hf-internal-testing", "tiny-gemma3");

--- a/integration-tests/tests/download_test.rs
+++ b/integration-tests/tests/download_test.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use futures::StreamExt;
 use hf_hub::progress::{DownloadEvent, FileStatus, ProgressEvent, ProgressHandler, UploadEvent};
 use hf_hub::repository::{AddSource, CommitOperation};
-use hf_hub::{HFClient, HFClientBuilder, HFRepository};
+use hf_hub::{HFClient, HFClientBuilder, HFRepository, RepoTypeDataset, RepoTypeModel};
 use integration_tests::test_utils::*;
 use sha2::{Digest, Sha256};
 
@@ -62,7 +62,7 @@ async fn create_test_repo(client: &HFClient) -> String {
     let username = cached_username(client).await;
     let repo_id = format!("{}/hfrs-progress-test-{}", username, uuid_short());
     client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(false)
@@ -73,17 +73,17 @@ async fn create_test_repo(client: &HFClient) -> String {
 }
 
 async fn delete_test_repo(client: &HFClient, repo_id: &str) {
-    let _ = client.delete_repo().repo_id(repo_id).send().await;
+    let _ = client.delete_repo::<RepoTypeModel>().repo_id(repo_id).send().await;
 }
 
 const TEST_MODEL_PARTS: (&str, &str) = ("hf-internal-testing", "tiny-gemma3");
 const TEST_DATASET_PARTS: (&str, &str) = ("hf-internal-testing", "cats_vs_dogs_sample");
 
-fn model(client: &HFClient, owner: &str, name: &str) -> HFRepository {
+fn model(client: &HFClient, owner: &str, name: &str) -> HFRepository<RepoTypeModel> {
     client.model(owner, name)
 }
 
-fn dataset(client: &HFClient, owner: &str, name: &str) -> HFRepository {
+fn dataset(client: &HFClient, owner: &str, name: &str) -> HFRepository<RepoTypeDataset> {
     client.dataset(owner, name)
 }
 
@@ -582,7 +582,7 @@ async fn test_download_with_no_progress_handler() {
 
 // --- Upload progress tests (write to hub-ci) ---
 
-fn repo_from_id(client: &HFClient, repo_id: &str) -> HFRepository {
+fn repo_from_id(client: &HFClient, repo_id: &str) -> HFRepository<RepoTypeModel> {
     let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
     client.model(parts[0], parts[1])
 }

--- a/integration-tests/tests/download_test.rs
+++ b/integration-tests/tests/download_test.rs
@@ -62,7 +62,8 @@ async fn create_test_repo(client: &HFClient) -> String {
     let username = cached_username(client).await;
     let repo_id = format!("{}/hfrs-progress-test-{}", username, uuid_short());
     client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(false)
@@ -73,7 +74,7 @@ async fn create_test_repo(client: &HFClient) -> String {
 }
 
 async fn delete_test_repo(client: &HFClient, repo_id: &str) {
-    let _ = client.delete_repo::<RepoTypeModel>().repo_id(repo_id).send().await;
+    let _ = client.delete_repo().repo_type(RepoTypeModel).repo_id(repo_id).send().await;
 }
 
 const TEST_MODEL_PARTS: (&str, &str) = ("hf-internal-testing", "tiny-gemma3");

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -784,7 +784,7 @@ async fn test_create_and_delete_repo() {
 
     // Create
     let url = client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
@@ -811,7 +811,7 @@ async fn test_create_and_delete_repo() {
 
     // Delete repo
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .send()
@@ -827,7 +827,7 @@ async fn create_test_repo(client: &HFClient) -> String {
     let username = cached_username().await;
     let repo_id = format!("{}/hf-hub-test-{}", username, uuid_v4_short());
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
@@ -850,7 +850,12 @@ async fn create_test_repo(client: &HFClient) -> String {
 }
 
 async fn delete_test_repo(client: &HFClient, repo_id: &str) {
-    let _ = client.delete_repo().repo_type(RepoTypeModel).repo_id(repo_id).send().await;
+    let _ = client
+        .delete_repository()
+        .repo_type(RepoTypeModel)
+        .repo_id(repo_id)
+        .send()
+        .await;
 }
 
 #[tokio::test]
@@ -1121,7 +1126,7 @@ async fn test_move_repo() {
     let new_name = format!("{}/hf-hub-move-dst-{}", username, uuid_v4_short());
 
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&original_name)
         .private(true)
@@ -1130,7 +1135,7 @@ async fn test_move_repo() {
         .unwrap();
 
     client
-        .move_repo()
+        .move_repository()
         .repo_type(RepoTypeModel)
         .from_id(&original_name)
         .to_id(&new_name)
@@ -1141,7 +1146,7 @@ async fn test_move_repo() {
     assert!(repo(&client, &new_name).exists().send().await.unwrap());
 
     client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&new_name)
         .send()
@@ -1173,7 +1178,7 @@ async fn test_duplicate_space() {
     // Create a minimal source space to duplicate.
     let source_id = format!("{}/hub-rust-test-dup-src-{}", username, uuid_v4_short());
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeSpace)
         .repo_id(&source_id)
         .private(true)
@@ -1196,8 +1201,13 @@ async fn test_duplicate_space() {
     assert!(result.url.contains(&to_id));
 
     // Clean up both spaces.
-    let _ = client.delete_repo().repo_type(RepoTypeSpace).repo_id(&to_id).send().await;
-    let _ = client.delete_repo().repo_type(RepoTypeSpace).repo_id(&source_id).send().await;
+    let _ = client.delete_repository().repo_type(RepoTypeSpace).repo_id(&to_id).send().await;
+    let _ = client
+        .delete_repository()
+        .repo_type(RepoTypeSpace)
+        .repo_id(&source_id)
+        .send()
+        .await;
 }
 
 #[tokio::test]
@@ -1209,7 +1219,7 @@ async fn test_space_secrets_and_variables() {
     let username = cached_username().await;
     let space = client.space(username, format!("hub-rust-test-space-{}", uuid_v4_short()));
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .private(true)
@@ -1233,7 +1243,7 @@ async fn test_space_secrets_and_variables() {
     space.delete_variable().key("TEST_VAR").send().await.unwrap();
 
     let _ = client
-        .delete_repo()
+        .delete_repository()
         .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .send()

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -18,7 +18,7 @@
 
 use futures::StreamExt;
 use hf_hub::repository::*;
-use hf_hub::{HFClient, HFClientBuilder, HFRepository, RepoType};
+use hf_hub::{HFClient, HFClientBuilder, HFRepository, RepoTypeDataset, RepoTypeModel, RepoTypeSpace};
 use integration_tests::test_utils::*;
 
 fn api() -> Option<HFClient> {
@@ -72,17 +72,34 @@ async fn cached_username() -> &'static str {
         .await
 }
 
-/// Create an HFRepository handle from a full `owner/name` repo_id string.
-fn repo(client: &HFClient, repo_id: &str) -> HFRepository {
+/// Create an HFRepository<RepoTypeModel> handle from a full `owner/name` repo_id string.
+fn repo(client: &HFClient, repo_id: &str) -> HFRepository<RepoTypeModel> {
+    let (owner, name) = split_id(repo_id);
+    client.model(owner, name)
+}
+
+/// Create an HFRepository<RepoTypeDataset> handle from a full `owner/name` repo_id string.
+fn dataset_repo(client: &HFClient, repo_id: &str) -> HFRepository<RepoTypeDataset> {
+    let (owner, name) = split_id(repo_id);
+    client.dataset(owner, name)
+}
+
+/// Create an HFRepository<RepoTypeSpace> handle from a full `owner/name` repo_id string.
+fn space_repo(client: &HFClient, repo_id: &str) -> HFRepository<RepoTypeSpace> {
+    let (owner, name) = split_id(repo_id);
+    client.space(owner, name)
+}
+
+fn split_id(repo_id: &str) -> (&str, &str) {
     let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
     if parts.len() == 2 {
-        client.model(parts[0], parts[1])
+        (parts[0], parts[1])
     } else {
-        client.model("", repo_id)
+        ("", repo_id)
     }
 }
 
-async fn collect_file_paths(test_repo: &HFRepository) -> std::collections::HashSet<String> {
+async fn collect_file_paths<T: RepoType>(test_repo: &HFRepository<T>) -> std::collections::HashSet<String> {
     let stream = test_repo.list_tree().recursive(true).send().unwrap();
     futures::pin_mut!(stream);
     let mut files = std::collections::HashSet::new();
@@ -94,26 +111,12 @@ async fn collect_file_paths(test_repo: &HFRepository) -> std::collections::HashS
     files
 }
 
-/// Create an HFRepository handle with a specific repo type.
-fn repo_typed(client: &HFClient, repo_id: &str, repo_type: RepoType) -> HFRepository {
-    let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
-    let (owner, name) = if parts.len() == 2 {
-        (parts[0], parts[1])
-    } else {
-        ("", repo_id)
-    };
-    client.repo(repo_type, owner, name)
-}
-
 #[tokio::test]
 async fn test_model_info() {
     let Some(client) = prod_api() else { return };
     let model_repo = TEST_MODEL_REPO;
     let info = repo(&client, model_repo).info().send().await.unwrap();
-    match info {
-        RepoInfo::Model(model) => assert!(model.id.contains("tiny-gemma3")),
-        _ => panic!("expected model info"),
-    }
+    assert!(info.id.contains("tiny-gemma3"));
 }
 
 #[tokio::test]
@@ -123,10 +126,7 @@ async fn test_repo_handle_info_and_file_exists() {
     let repo = repo(&client, model_repo);
 
     let info = repo.info().send().await.unwrap();
-    match info {
-        RepoInfo::Model(model) => assert_eq!(model.id, model_repo),
-        _ => panic!("expected model info"),
-    }
+    assert_eq!(info.id, model_repo);
 
     let exists = repo.file_exists().filename("config.json").send().await.unwrap();
     assert!(exists);
@@ -135,16 +135,9 @@ async fn test_repo_handle_info_and_file_exists() {
 #[tokio::test]
 async fn test_dataset_info() {
     let Some(client) = prod_api() else { return };
-    let dataset_repo = TEST_DATASET_REPO;
-    let info = repo_typed(&client, dataset_repo, RepoType::Dataset)
-        .info()
-        .send()
-        .await
-        .unwrap();
-    match info {
-        RepoInfo::Dataset(ds) => assert_eq!(ds.id, dataset_repo),
-        _ => panic!("expected dataset info"),
-    }
+    let id = TEST_DATASET_REPO;
+    let info = dataset_repo(&client, id).info().send().await.unwrap();
+    assert_eq!(info.id, id);
 }
 
 #[tokio::test]
@@ -463,12 +456,9 @@ async fn test_list_organization_members() {
 #[tokio::test]
 async fn test_space_info() {
     let Some(client) = prod_api() else { return };
-    let space_repo = TEST_SPACE_INFO_REPO;
-    let info = repo_typed(&client, space_repo, RepoType::Space).info().send().await.unwrap();
-    match info {
-        RepoInfo::Space(space) => assert_eq!(space.id, space_repo),
-        _ => panic!("expected space info"),
-    }
+    let id = TEST_SPACE_INFO_REPO;
+    let info = space_repo(&client, id).info().send().await.unwrap();
+    assert_eq!(info.id, id);
 }
 
 #[tokio::test]
@@ -744,7 +734,7 @@ async fn test_diff_against_empty_tree_all_additions() {
     ];
 
     for (repo_id, revision) in &test_cases {
-        let dataset = repo_typed(&client, repo_id, RepoType::Dataset);
+        let dataset = dataset_repo(&client, repo_id);
         let stream = dataset
             .get_raw_diff_stream()
             .compare(format!("{GIT_EMPTY_TREE_HASH}..{revision}"))
@@ -794,7 +784,7 @@ async fn test_create_and_delete_repo() {
 
     // Create
     let url = client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(true)
@@ -819,7 +809,7 @@ async fn test_create_and_delete_repo() {
     assert!(test_repo.file_exists().filename("test.txt").send().await.unwrap());
 
     // Delete repo
-    client.delete_repo().repo_id(&repo_id).send().await.unwrap();
+    client.delete_repo::<RepoTypeModel>().repo_id(&repo_id).send().await.unwrap();
 }
 
 fn uuid_v4_short() -> String {
@@ -830,7 +820,7 @@ async fn create_test_repo(client: &HFClient) -> String {
     let username = cached_username().await;
     let repo_id = format!("{}/hf-hub-test-{}", username, uuid_v4_short());
     client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(false)
@@ -852,7 +842,7 @@ async fn create_test_repo(client: &HFClient) -> String {
 }
 
 async fn delete_test_repo(client: &HFClient, repo_id: &str) {
-    let _ = client.delete_repo().repo_id(repo_id).send().await;
+    let _ = client.delete_repo::<RepoTypeModel>().repo_id(repo_id).send().await;
 }
 
 #[tokio::test]
@@ -1122,10 +1112,16 @@ async fn test_move_repo() {
     let original_name = format!("{}/hf-hub-move-src-{}", username, uuid_v4_short());
     let new_name = format!("{}/hf-hub-move-dst-{}", username, uuid_v4_short());
 
-    client.create_repo().repo_id(&original_name).private(true).send().await.unwrap();
+    client
+        .create_repo::<RepoTypeModel>()
+        .repo_id(&original_name)
+        .private(true)
+        .send()
+        .await
+        .unwrap();
 
     client
-        .move_repo()
+        .move_repo::<RepoTypeModel>()
         .from_id(&original_name)
         .to_id(&new_name)
         .send()
@@ -1134,7 +1130,7 @@ async fn test_move_repo() {
 
     assert!(repo(&client, &new_name).exists().send().await.unwrap());
 
-    client.delete_repo().repo_id(&new_name).send().await.unwrap();
+    client.delete_repo::<RepoTypeModel>().repo_id(&new_name).send().await.unwrap();
 }
 
 // =============================================================================
@@ -1161,9 +1157,8 @@ async fn test_duplicate_space() {
     // Create a minimal source space to duplicate.
     let source_id = format!("{}/hub-rust-test-dup-src-{}", username, uuid_v4_short());
     client
-        .create_repo()
+        .create_repo::<RepoTypeSpace>()
         .repo_id(&source_id)
-        .repo_type(RepoType::Space)
         .private(true)
         .space_sdk("static")
         .send()
@@ -1184,8 +1179,8 @@ async fn test_duplicate_space() {
     assert!(result.url.contains(&to_id));
 
     // Clean up both spaces.
-    let _ = client.delete_repo().repo_id(&to_id).repo_type(RepoType::Space).send().await;
-    let _ = client.delete_repo().repo_id(&source_id).repo_type(RepoType::Space).send().await;
+    let _ = client.delete_repo::<RepoTypeSpace>().repo_id(&to_id).send().await;
+    let _ = client.delete_repo::<RepoTypeSpace>().repo_id(&source_id).send().await;
 }
 
 #[tokio::test]
@@ -1197,9 +1192,8 @@ async fn test_space_secrets_and_variables() {
     let username = cached_username().await;
     let space = client.space(username, format!("hub-rust-test-space-{}", uuid_v4_short()));
     client
-        .create_repo()
+        .create_repo::<RepoTypeSpace>()
         .repo_id(space.repo_path())
-        .repo_type(RepoType::Space)
         .private(true)
         .space_sdk("static")
         .send()
@@ -1220,10 +1214,5 @@ async fn test_space_secrets_and_variables() {
 
     space.delete_variable().key("TEST_VAR").send().await.unwrap();
 
-    let _ = client
-        .delete_repo()
-        .repo_id(space.repo_path())
-        .repo_type(RepoType::Space)
-        .send()
-        .await;
+    let _ = client.delete_repo::<RepoTypeSpace>().repo_id(space.repo_path()).send().await;
 }

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -784,7 +784,8 @@ async fn test_create_and_delete_repo() {
 
     // Create
     let url = client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(true)
@@ -809,7 +810,13 @@ async fn test_create_and_delete_repo() {
     assert!(test_repo.file_exists().filename("test.txt").send().await.unwrap());
 
     // Delete repo
-    client.delete_repo::<RepoTypeModel>().repo_id(&repo_id).send().await.unwrap();
+    client
+        .delete_repo()
+        .repo_type(RepoTypeModel)
+        .repo_id(&repo_id)
+        .send()
+        .await
+        .unwrap();
 }
 
 fn uuid_v4_short() -> String {
@@ -820,7 +827,8 @@ async fn create_test_repo(client: &HFClient) -> String {
     let username = cached_username().await;
     let repo_id = format!("{}/hf-hub-test-{}", username, uuid_v4_short());
     client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(false)
@@ -842,7 +850,7 @@ async fn create_test_repo(client: &HFClient) -> String {
 }
 
 async fn delete_test_repo(client: &HFClient, repo_id: &str) {
-    let _ = client.delete_repo::<RepoTypeModel>().repo_id(repo_id).send().await;
+    let _ = client.delete_repo().repo_type(RepoTypeModel).repo_id(repo_id).send().await;
 }
 
 #[tokio::test]
@@ -1113,7 +1121,8 @@ async fn test_move_repo() {
     let new_name = format!("{}/hf-hub-move-dst-{}", username, uuid_v4_short());
 
     client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(&original_name)
         .private(true)
         .send()
@@ -1121,7 +1130,8 @@ async fn test_move_repo() {
         .unwrap();
 
     client
-        .move_repo::<RepoTypeModel>()
+        .move_repo()
+        .repo_type(RepoTypeModel)
         .from_id(&original_name)
         .to_id(&new_name)
         .send()
@@ -1130,7 +1140,13 @@ async fn test_move_repo() {
 
     assert!(repo(&client, &new_name).exists().send().await.unwrap());
 
-    client.delete_repo::<RepoTypeModel>().repo_id(&new_name).send().await.unwrap();
+    client
+        .delete_repo()
+        .repo_type(RepoTypeModel)
+        .repo_id(&new_name)
+        .send()
+        .await
+        .unwrap();
 }
 
 // =============================================================================
@@ -1157,7 +1173,8 @@ async fn test_duplicate_space() {
     // Create a minimal source space to duplicate.
     let source_id = format!("{}/hub-rust-test-dup-src-{}", username, uuid_v4_short());
     client
-        .create_repo::<RepoTypeSpace>()
+        .create_repo()
+        .repo_type(RepoTypeSpace)
         .repo_id(&source_id)
         .private(true)
         .space_sdk("static")
@@ -1179,8 +1196,8 @@ async fn test_duplicate_space() {
     assert!(result.url.contains(&to_id));
 
     // Clean up both spaces.
-    let _ = client.delete_repo::<RepoTypeSpace>().repo_id(&to_id).send().await;
-    let _ = client.delete_repo::<RepoTypeSpace>().repo_id(&source_id).send().await;
+    let _ = client.delete_repo().repo_type(RepoTypeSpace).repo_id(&to_id).send().await;
+    let _ = client.delete_repo().repo_type(RepoTypeSpace).repo_id(&source_id).send().await;
 }
 
 #[tokio::test]
@@ -1192,7 +1209,8 @@ async fn test_space_secrets_and_variables() {
     let username = cached_username().await;
     let space = client.space(username, format!("hub-rust-test-space-{}", uuid_v4_short()));
     client
-        .create_repo::<RepoTypeSpace>()
+        .create_repo()
+        .repo_type(RepoTypeSpace)
         .repo_id(space.repo_path())
         .private(true)
         .space_sdk("static")
@@ -1214,5 +1232,10 @@ async fn test_space_secrets_and_variables() {
 
     space.delete_variable().key("TEST_VAR").send().await.unwrap();
 
-    let _ = client.delete_repo::<RepoTypeSpace>().repo_id(space.repo_path()).send().await;
+    let _ = client
+        .delete_repo()
+        .repo_type(RepoTypeSpace)
+        .repo_id(space.repo_path())
+        .send()
+        .await;
 }

--- a/integration-tests/tests/xet_transfer_test.rs
+++ b/integration-tests/tests/xet_transfer_test.rs
@@ -17,7 +17,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures::StreamExt;
 use hf_hub::repository::AddSource;
-use hf_hub::{HFClient, HFClientBuilder, HFRepository};
+use hf_hub::{HFClient, HFClientBuilder, HFRepository, RepoTypeModel};
 use integration_tests::test_utils::*;
 use rand::RngExt;
 use tokio::sync::OnceCell;
@@ -67,7 +67,7 @@ fn unique_suffix() -> String {
 }
 
 /// Split an `"owner/name"` repo_id into an [`HFRepository`] handle.
-fn repo_handle(client: &HFClient, owner: &str, name: &str) -> HFRepository {
+fn repo_handle(client: &HFClient, owner: &str, name: &str) -> HFRepository<RepoTypeModel> {
     client.model(owner, name)
 }
 
@@ -78,7 +78,7 @@ async fn create_test_repo(client: &HFClient, suffix: &str) -> (String, String) {
     let name = format!("hf-hub-xet-test-{suffix}");
     let repo_id = format!("{username}/{name}");
     client
-        .create_repo()
+        .create_repo::<RepoTypeModel>()
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(true)
@@ -89,7 +89,7 @@ async fn create_test_repo(client: &HFClient, suffix: &str) -> (String, String) {
 }
 
 async fn delete_test_repo(client: &HFClient, repo_id: &str) {
-    let _ = client.delete_repo().repo_id(repo_id).send().await;
+    let _ = client.delete_repo::<RepoTypeModel>().repo_id(repo_id).send().await;
 }
 
 fn generate_random_bytes(size: usize) -> Vec<u8> {

--- a/integration-tests/tests/xet_transfer_test.rs
+++ b/integration-tests/tests/xet_transfer_test.rs
@@ -78,7 +78,7 @@ async fn create_test_repo(client: &HFClient, suffix: &str) -> (String, String) {
     let name = format!("hf-hub-xet-test-{suffix}");
     let repo_id = format!("{username}/{name}");
     client
-        .create_repo()
+        .create_repository()
         .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
@@ -90,7 +90,12 @@ async fn create_test_repo(client: &HFClient, suffix: &str) -> (String, String) {
 }
 
 async fn delete_test_repo(client: &HFClient, repo_id: &str) {
-    let _ = client.delete_repo().repo_type(RepoTypeModel).repo_id(repo_id).send().await;
+    let _ = client
+        .delete_repository()
+        .repo_type(RepoTypeModel)
+        .repo_id(repo_id)
+        .send()
+        .await;
 }
 
 fn generate_random_bytes(size: usize) -> Vec<u8> {

--- a/integration-tests/tests/xet_transfer_test.rs
+++ b/integration-tests/tests/xet_transfer_test.rs
@@ -78,7 +78,8 @@ async fn create_test_repo(client: &HFClient, suffix: &str) -> (String, String) {
     let name = format!("hf-hub-xet-test-{suffix}");
     let repo_id = format!("{username}/{name}");
     client
-        .create_repo::<RepoTypeModel>()
+        .create_repo()
+        .repo_type(RepoTypeModel)
         .repo_id(&repo_id)
         .private(true)
         .exist_ok(true)
@@ -89,7 +90,7 @@ async fn create_test_repo(client: &HFClient, suffix: &str) -> (String, String) {
 }
 
 async fn delete_test_repo(client: &HFClient, repo_id: &str) {
-    let _ = client.delete_repo::<RepoTypeModel>().repo_id(repo_id).send().await;
+    let _ = client.delete_repo().repo_type(RepoTypeModel).repo_id(repo_id).send().await;
 }
 
 fn generate_random_bytes(size: usize) -> Vec<u8> {


### PR DESCRIPTION
## Summary

Push repo-kind discrimination from a runtime enum into the type system. `RepoType` becomes a sealed trait, `HFRepository<T: RepoType>` is generic over four marker structs, and `HFSpace` / `RepoInfo` go away — Space-only methods move to ` impl HFRepository<RepoTypeSpace>`, and each repo kind has its own `info()` returning the concrete info struct.

- New: `repository::repo_type` submodule with `RepoType` trait + `RepoTypeModel` / `Dataset` / `Space` / `Kernel` markers (sealed). Re-exported flat at `hf_hub::repository::…` and at the crate root.
- New: `HFClient::repository::<T>(owner, name)` and `HFClientSync::repository::<T>(...)` generic constructors. `model` / `dataset` / `space` / `kernel` delegate to it; `kernel()` is new.
- Generic: every `impl HFRepository` / `impl HFRepositorySync` block becomes `impl<T: RepoType>`. `HFClient::create_repo` / `delete_repo` / `move_repo` are generic over `T` (callers turbofish).
- Per-T `info()` impls return `ModelInfo` / `DatasetInfo` / `SpaceInfo` / `KernelInfo`; the `RepoInfo` enum is removed. Bon builder type names are uniqued via `builder_type` / `state_mod` to avoid collisions.
- `HFSpace` / `HFSpaceSync` and their `TryFrom` / `Deref` / `Arc` plumbing are gone. All Space-only methods (runtime, hardware, secrets, variables, pause/restart, duplicate) move to `impl HFRepository<RepoTypeSpace>` blocks in `spaces.rs`.
- `HFError::InvalidRepoType` removed (compile-time enforcement now). `repo_type_url_prefix` / `repo_type_api_segment` helpers removed; `HFClient::api_url` / `download_url` take ` &str` directly. The download SHA dispatch is now a generic `fetch_repo_info::<ShaOnly>` call. Cache module uses `&'static str` for the repo type tag.
- CLI: keeps `RepoTypeArg` for user-input parsing; commands dispatch via a new `with_typed_repo!` macro that calls `client.repository::<T>(...)` per arm. `create_repo` / `delete_repo` / `move_repo` use a 3-arm `match` to call the generic methods.
- Examples and integration tests updated to the new typed API.

## Test plan

- [x] \`cargo +nightly fmt\` clean
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\` clean
- [x] \`cargo test -p hf-hub --all-features\` — 161 unit + 15 doctests pass
- [x] \`RUSTDOCFLAGS=\"--cfg docsrs\" cargo +nightly doc -p hf-hub --features blocking --no-deps\` — warning-free
- [ ] Read-only integration tests with \`HF_TOKEN\`
- [ ] Write integration tests with \`HF_TEST_WRITE=1\`
- [ ] Manual sanity check of \`hfrs models info openai-community/gpt2\` and \`hfrs datasets info squad\`