### PR TITLE
feat: re-add opt-in rustls-tls feature

### DIFF
--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -35,6 +35,7 @@ sha2 = "0.11"
 [features]
 default = []
 blocking = ["tokio/rt"]
+rustls-tls = ["reqwest/rustls"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Human summary: adding this optional feature back in as it appears to be commonly used. Don't need to worry about the hf-xet reqwest dependency since it requires uses rustls-tls by default and we're not changing the features used on it.

## Summary
- Adds a `rustls-tls` cargo feature on `hf-hub` that wires through to reqwest's `rustls` feature (reqwest 0.13 dropped the `-tls` suffix on the feature name; the hf-hub feature keeps the conventional `rustls-tls` label for consumers).
- Additive only: native-tls remains the default and is still compiled in. Enabling `rustls-tls` compiles the rustls backend alongside, letting downstreams pick it via reqwest's `ClientBuilder` if they construct their own client.

## Test plan
- [x] `cargo check -p hf-hub` (default features)
- [x] `cargo check -p hf-hub --features rustls-tls`
- [x] `cargo check -p hf-hub --all-features`