### PR TITLE
feat: streaming xet upload sessions for repos and buckets

### DIFF
--- a/hf-hub/src/buckets/mod.rs
+++ b/hf-hub/src/buckets/mod.rs
@@ -14,6 +14,11 @@
 //! - Use [`sync`] for one-way directory mirroring between a local folder and a bucket prefix.
 
 pub mod sync;
+pub mod xet_session;
+
+pub use xet_session::BucketXetUploadSession;
+#[cfg(feature = "blocking")]
+pub use xet_session::BucketXetUploadSessionSync;
 
 use std::path::PathBuf;
 

--- a/hf-hub/src/buckets/mod.rs
+++ b/hf-hub/src/buckets/mod.rs
@@ -16,10 +16,6 @@
 pub mod sync;
 pub mod xet_session;
 
-pub use xet_session::BucketXetUploadSession;
-#[cfg(feature = "blocking")]
-pub use xet_session::BucketXetUploadSessionSync;
-
 use std::path::PathBuf;
 
 use bon::bon;
@@ -28,6 +24,9 @@ use futures::Stream;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use url::Url;
+pub use xet_session::BucketXetUploadSession;
+#[cfg(feature = "blocking")]
+pub use xet_session::BucketXetUploadSessionSync;
 
 use crate::client::HFClient;
 use crate::error::{HFError, HFResult, NotFoundContext};

--- a/hf-hub/src/buckets/xet_session.rs
+++ b/hf-hub/src/buckets/xet_session.rs
@@ -24,7 +24,7 @@ use std::sync::Mutex;
 
 use xet::xet_session::{Sha256Policy, UniqueID, XetFileUpload};
 
-use super::{HFBucket, BucketAddFile};
+use super::{BucketAddFile, HFBucket};
 use crate::error::{HFError, HFResult, NotFoundContext, XetOperation};
 use crate::repository::UploadedXetFile;
 use crate::xet::{bucket_xet_token_url, new_xet_upload_commit};
@@ -94,11 +94,7 @@ impl BucketXetUploadSession {
     /// files are visible — see [`finish_and_register`](Self::finish_and_register)
     /// for the common case.
     pub async fn finish(self) -> HFResult<HashMap<String, UploadedXetFile>> {
-        let results = self
-            .commit
-            .commit()
-            .await
-            .map_err(|e| HFError::xet(XetOperation::Upload, e))?;
+        let results = self.commit.commit().await.map_err(|e| HFError::xet(XetOperation::Upload, e))?;
         tracing::info!(file_count = results.uploads.len(), "bucket xet streaming upload session committed");
 
         let path_to_task = self
@@ -112,11 +108,7 @@ impl BucketXetUploadSession {
                 .uploads
                 .get(&task_id)
                 .ok_or_else(|| HFError::Other(format!("xet upload result missing for {path:?}")))?;
-            let sha256_oid = metadata
-                .xet_info
-                .sha256()
-                .map(|s| s.to_string())
-                .unwrap_or_default(); // buckets use xet_hash, so sha256 is optional context.
+            let sha256_oid = metadata.xet_info.sha256().map(|s| s.to_string()).unwrap_or_default(); // buckets use xet_hash, so sha256 is optional context.
             let size = metadata
                 .xet_info
                 .file_size()

--- a/hf-hub/src/buckets/xet_session.rs
+++ b/hf-hub/src/buckets/xet_session.rs
@@ -1,0 +1,233 @@
+//! Streaming xet upload session for buckets.
+//!
+//! Streams individual files into a bucket's xet content-addressable storage
+//! *as they are produced*, returning per-file descriptors that can be used to
+//! register the files in a subsequent
+//! [`HFBucket::batch_operations`](super::HFBucket::batch_operations) call.
+//! This lets callers populate a bucket whose total payload exceeds local RAM
+//! and disk.
+//!
+//! The usual [`upload_files`](super::HFBucket::upload_files) / [`sync`](super::sync)
+//! paths require every file to exist on local disk (`BucketUpload { local, ... }`).
+//! For workloads that generate output incrementally — rendered tile pyramids,
+//! sharded training outputs, anything streaming — staging the whole pyramid
+//! locally becomes the bottleneck. Use a streaming session instead: upload
+//! each tile, drop its bytes (or remove its temp file), and register the
+//! batch at the end with only `(path, hash, size)` triples in memory.
+//!
+//! See [`HFBucket::open_xet_upload_session`](super::HFBucket::open_xet_upload_session)
+//! for usage.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use xet::xet_session::{Sha256Policy, UniqueID, XetFileUpload};
+
+use super::{HFBucket, BucketAddFile};
+use crate::error::{HFError, HFResult, NotFoundContext, XetOperation};
+use crate::repository::UploadedXetFile;
+use crate::xet::{bucket_xet_token_url, new_xet_upload_commit};
+
+/// Open streaming xet-upload session for a single bucket.
+///
+/// Construct with
+/// [`HFBucket::open_xet_upload_session`](super::HFBucket::open_xet_upload_session),
+/// then call [`upload_bytes`](Self::upload_bytes) / [`upload_file`](Self::upload_file)
+/// for each piece of content, and finish with [`finish`](Self::finish) to
+/// seal the CAS uploads and recover per-path descriptors. Use those to call
+/// [`HFBucket::batch_operations`](super::HFBucket::batch_operations) with
+/// [`BucketAddFile`] entries (or use
+/// [`finish_and_register`](Self::finish_and_register) to do both in one step).
+pub struct BucketXetUploadSession {
+    bucket: HFBucket,
+    commit: xet::xet_session::XetUploadCommit,
+    path_to_task: Mutex<Vec<(String, UniqueID)>>,
+}
+
+impl BucketXetUploadSession {
+    /// Queue an in-memory file for streaming upload to this bucket's CAS.
+    ///
+    /// xet starts uploading the bytes to CAS in the background. The future
+    /// resolves once xet has accepted the bytes — at that point the caller
+    /// may drop their own copy.
+    pub async fn upload_bytes(&self, remote_path: impl Into<String>, bytes: Vec<u8>) -> HFResult<()> {
+        let remote = remote_path.into();
+        tracing::debug!(path = remote.as_str(), len = bytes.len(), "queuing bucket xet upload (bytes)");
+        let handle = self
+            .commit
+            .upload_bytes(bytes, Sha256Policy::Compute, Some(remote.clone()))
+            .await
+            .map_err(|e| HFError::xet(XetOperation::Upload, e))?;
+        self.record_handle(remote, &handle);
+        Ok(())
+    }
+
+    /// Queue a local file for streaming upload to this bucket's CAS.
+    ///
+    /// xet reads the file lazily during the background transfer, so the file
+    /// must exist (unchanged) until [`finish`](Self::finish) or
+    /// [`finish_and_register`](Self::finish_and_register) returns.
+    pub async fn upload_file(&self, remote_path: impl Into<String>, source: impl Into<PathBuf>) -> HFResult<()> {
+        let remote = remote_path.into();
+        let source = source.into();
+        tracing::debug!(path = remote.as_str(), source = ?source, "queuing bucket xet upload (file)");
+        let handle = self
+            .commit
+            .upload_from_path(source, Sha256Policy::Compute)
+            .await
+            .map_err(|e| HFError::xet(XetOperation::Upload, e))?;
+        self.record_handle(remote, &handle);
+        Ok(())
+    }
+
+    fn record_handle(&self, remote: String, handle: &XetFileUpload) {
+        self.path_to_task
+            .lock()
+            .expect("bucket xet upload session mutex poisoned")
+            .push((remote, handle.task_id()));
+    }
+
+    /// Finalize the CAS uploads. The returned descriptors must still be
+    /// registered with the bucket (via
+    /// [`batch_operations`](super::HFBucket::batch_operations)) before the
+    /// files are visible — see [`finish_and_register`](Self::finish_and_register)
+    /// for the common case.
+    pub async fn finish(self) -> HFResult<HashMap<String, UploadedXetFile>> {
+        let results = self
+            .commit
+            .commit()
+            .await
+            .map_err(|e| HFError::xet(XetOperation::Upload, e))?;
+        tracing::info!(file_count = results.uploads.len(), "bucket xet streaming upload session committed");
+
+        let path_to_task = self
+            .path_to_task
+            .into_inner()
+            .expect("bucket xet upload session mutex poisoned");
+
+        let mut out: HashMap<String, UploadedXetFile> = HashMap::with_capacity(path_to_task.len());
+        for (path, task_id) in path_to_task {
+            let metadata = results
+                .uploads
+                .get(&task_id)
+                .ok_or_else(|| HFError::Other(format!("xet upload result missing for {path:?}")))?;
+            let sha256_oid = metadata
+                .xet_info
+                .sha256()
+                .map(|s| s.to_string())
+                .unwrap_or_default(); // buckets use xet_hash, so sha256 is optional context.
+            let size = metadata
+                .xet_info
+                .file_size()
+                .ok_or_else(|| HFError::Other(format!("xet upload for {path:?} did not report a file size")))?;
+            out.insert(
+                path,
+                UploadedXetFile {
+                    sha256_oid,
+                    size,
+                    xet_hash: metadata.xet_info.hash().to_string(),
+                },
+            );
+        }
+
+        Ok(out)
+    }
+
+    /// Convenience: seal CAS uploads and register every uploaded path in the
+    /// bucket via [`batch_operations`](super::HFBucket::batch_operations) in
+    /// one call. Files become visible to the bucket once this returns.
+    pub async fn finish_and_register(self) -> HFResult<()> {
+        let bucket = self.bucket.clone();
+        let uploaded = self.finish().await?;
+        let add_files: Vec<BucketAddFile> = uploaded
+            .into_iter()
+            .map(|(path, info)| BucketAddFile {
+                path,
+                xet_hash: info.xet_hash,
+                size: info.size,
+                mtime: None,
+                content_type: None,
+            })
+            .collect();
+        if add_files.is_empty() {
+            return Ok(());
+        }
+        bucket.batch_operations().add_files(add_files).send().await?;
+        Ok(())
+    }
+}
+
+impl HFBucket {
+    /// Open a streaming xet-upload session for this bucket.
+    ///
+    /// Each [`upload_bytes`](BucketXetUploadSession::upload_bytes) /
+    /// [`upload_file`](BucketXetUploadSession::upload_file) call uploads its
+    /// content to xet content-addressable storage immediately. After all
+    /// content is uploaded, call
+    /// [`finish_and_register`](BucketXetUploadSession::finish_and_register) to
+    /// seal the CAS uploads and register the files with the bucket in one
+    /// step; or call [`finish`](BucketXetUploadSession::finish) to recover
+    /// descriptors and register them yourself (when combining with other
+    /// `batch_operations` ops like deletes or copies).
+    ///
+    /// Use this when total upload payload exceeds local RAM or disk: the
+    /// caller never has to hold all bytes (or all temp files) at once.
+    pub async fn open_xet_upload_session(&self) -> HFResult<BucketXetUploadSession> {
+        let bucket_id = self.bucket_id();
+        let token_url = bucket_xet_token_url(&self.hf_client, "write", &bucket_id);
+        let commit =
+            new_xet_upload_commit(&self.hf_client, token_url, &bucket_id, NotFoundContext::Bucket, "bucket").await?;
+        Ok(BucketXetUploadSession {
+            bucket: self.clone(),
+            commit,
+            path_to_task: Mutex::new(Vec::new()),
+        })
+    }
+}
+
+/// Synchronous/blocking counterpart to [`BucketXetUploadSession`].
+///
+/// Constructed via
+/// [`HFBucketSync::open_xet_upload_session`](crate::HFBucketSync::open_xet_upload_session).
+#[cfg(feature = "blocking")]
+#[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
+pub struct BucketXetUploadSessionSync {
+    inner: BucketXetUploadSession,
+    runtime: std::sync::Arc<tokio::runtime::Runtime>,
+}
+
+#[cfg(feature = "blocking")]
+impl BucketXetUploadSessionSync {
+    /// Blocking counterpart of [`BucketXetUploadSession::upload_bytes`].
+    pub fn upload_bytes(&self, remote_path: impl Into<String>, bytes: Vec<u8>) -> HFResult<()> {
+        self.runtime.block_on(self.inner.upload_bytes(remote_path, bytes))
+    }
+
+    /// Blocking counterpart of [`BucketXetUploadSession::upload_file`].
+    pub fn upload_file(&self, remote_path: impl Into<String>, source: impl Into<PathBuf>) -> HFResult<()> {
+        self.runtime.block_on(self.inner.upload_file(remote_path, source))
+    }
+
+    /// Blocking counterpart of [`BucketXetUploadSession::finish`].
+    pub fn finish(self) -> HFResult<HashMap<String, UploadedXetFile>> {
+        self.runtime.block_on(self.inner.finish())
+    }
+
+    /// Blocking counterpart of [`BucketXetUploadSession::finish_and_register`].
+    pub fn finish_and_register(self) -> HFResult<()> {
+        self.runtime.block_on(self.inner.finish_and_register())
+    }
+}
+
+#[cfg(feature = "blocking")]
+impl crate::HFBucketSync {
+    /// Blocking counterpart of [`HFBucket::open_xet_upload_session`].
+    pub fn open_xet_upload_session(&self) -> HFResult<BucketXetUploadSessionSync> {
+        let inner = self.runtime.block_on(self.inner.open_xet_upload_session())?;
+        Ok(BucketXetUploadSessionSync {
+            inner,
+            runtime: self.runtime.clone(),
+        })
+    }
+}

--- a/hf-hub/src/repository/files.rs
+++ b/hf-hub/src/repository/files.rs
@@ -203,6 +203,16 @@ impl CommitOperation {
         }
     }
 
+    /// Add an operation that references already-uploaded content in xet CAS.
+    /// Equivalent to `Add { path_in_repo, source: AddSource::lfs(sha256_oid, size) }`.
+    /// See [`AddSource::Lfs`] for when to use this.
+    pub fn add_lfs(path_in_repo: impl Into<String>, sha256_oid: impl Into<String>, size: u64) -> Self {
+        CommitOperation::Add {
+            path_in_repo: path_in_repo.into(),
+            source: AddSource::lfs(sha256_oid, size),
+        }
+    }
+
     /// Delete operation for a repository path.
     pub fn delete(path_in_repo: impl Into<String>) -> Self {
         CommitOperation::Delete {
@@ -217,6 +227,10 @@ impl CommitOperation {
 /// the path is stored, but file contents are read when the commit runs and are
 /// streamed where possible. Use [`Bytes`](Self::Bytes) for small in-memory content;
 /// the buffer is owned by the operation and may be cloned for LFS/xet uploads.
+/// Use [`Lfs`](Self::Lfs) when the content has already been uploaded to xet
+/// content-addressable storage out-of-band (via
+/// [`HFRepository::open_xet_upload_session`](super::HFRepository::open_xet_upload_session))
+/// and only the resulting hash needs to be referenced in the commit.
 ///
 /// `AddSource::File` is not a snapshot: the file must still exist, unchanged,
 /// when [`HFRepository::create_commit`] runs.
@@ -227,6 +241,25 @@ pub enum AddSource {
 
     /// In-memory contents used as the file body.
     Bytes(Vec<u8>),
+
+    /// Already-uploaded LFS blob — reference by SHA-256 OID without re-uploading.
+    ///
+    /// The bytes must already live in xet content-addressable storage for this
+    /// repository (typically because the caller used
+    /// [`HFRepository::open_xet_upload_session`](super::HFRepository::open_xet_upload_session)
+    /// to upload them incrementally). The commit emits an `lfsFile` entry
+    /// referencing `sha256_oid` and `size`; no preupload classification, no
+    /// SHA-256 recomputation, and no further xet transfer happens.
+    ///
+    /// Useful for producing a single commit that references content larger than
+    /// local RAM or disk: render/produce one chunk at a time, push it to xet,
+    /// keep only `(path, sha256_oid, size)` triples, then commit them all.
+    Lfs {
+        /// Lowercase hex SHA-256 of the file content as it sits in xet CAS.
+        sha256_oid: String,
+        /// Total file size in bytes.
+        size: u64,
+    },
 }
 
 impl AddSource {
@@ -238,6 +271,14 @@ impl AddSource {
     /// Construct an [`AddSource::Bytes`] from in-memory contents.
     pub fn bytes(bytes: impl Into<Vec<u8>>) -> Self {
         AddSource::Bytes(bytes.into())
+    }
+
+    /// Construct an [`AddSource::Lfs`] from a pre-uploaded blob descriptor.
+    pub fn lfs(sha256_oid: impl Into<String>, size: u64) -> Self {
+        AddSource::Lfs {
+            sha256_oid: sha256_oid.into(),
+            size,
+        }
     }
 }
 
@@ -417,5 +458,35 @@ mod tests {
         let json = r#"{"filename":"f","etag":"e","commit_hash":"c","xet_hash":null,"file_size":0}"#;
         let info: FileMetadataInfo = serde_json::from_str(json).unwrap();
         assert!(info.location.is_none());
+    }
+
+    #[test]
+    fn test_add_source_lfs_constructor() {
+        let s = super::AddSource::lfs("deadbeef", 42);
+        match s {
+            super::AddSource::Lfs { sha256_oid, size } => {
+                assert_eq!(sha256_oid, "deadbeef");
+                assert_eq!(size, 42);
+            },
+            _ => panic!("expected Lfs variant"),
+        }
+    }
+
+    #[test]
+    fn test_commit_operation_add_lfs() {
+        let op = super::CommitOperation::add_lfs("path/to/blob.bin", "cafebabe", 1024);
+        match op {
+            super::CommitOperation::Add { path_in_repo, source } => {
+                assert_eq!(path_in_repo, "path/to/blob.bin");
+                match source {
+                    super::AddSource::Lfs { sha256_oid, size } => {
+                        assert_eq!(sha256_oid, "cafebabe");
+                        assert_eq!(size, 1024);
+                    },
+                    _ => panic!("expected Lfs source"),
+                }
+            },
+            _ => panic!("expected Add"),
+        }
     }
 }

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -26,6 +26,7 @@ pub mod files;
 pub mod listing;
 pub mod repo_type;
 pub mod upload;
+pub mod xet_session;
 
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -41,6 +42,7 @@ pub use files::{
 pub(crate) use files::{extract_file_size, extract_xet_hash};
 use futures::Stream;
 pub use repo_type::{RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};
+pub use xet_session::{UploadedXetFile, XetUploadSession};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize, Serializer};
 use url::Url;

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -42,10 +42,10 @@ pub use files::{
 pub(crate) use files::{extract_file_size, extract_xet_hash};
 use futures::Stream;
 pub use repo_type::{RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};
-pub use xet_session::{UploadedXetFile, XetUploadSession};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize, Serializer};
 use url::Url;
+pub use xet_session::{UploadedXetFile, XetUploadSession};
 
 use crate::client::HFClient;
 use crate::error::{HFError, HFResult};

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -98,6 +98,7 @@ impl<T: RepoType> HFRepository<T> {
                     total += match source {
                         AddSource::Bytes(b) => b.len() as u64,
                         AddSource::File(p) => std::fs::metadata(p).map(|m| m.len()).unwrap_or(0),
+                        AddSource::Lfs { size, .. } => *size,
                     };
                 }
             }
@@ -202,6 +203,16 @@ impl<T: RepoType> HFRepository<T> {
         let content = match source {
             AddSource::File(path) => std::fs::read(path)?,
             AddSource::Bytes(bytes) => bytes.clone(),
+            // AddSource::Lfs is always routed through `lfs_uploaded` upstream of
+            // this call. Reaching this branch means a pre-uploaded LFS blob was
+            // classified as "regular" by preupload — a logic bug, not a user
+            // error.
+            AddSource::Lfs { .. } => {
+                return Err(HFError::Other(
+                    "internal: AddSource::Lfs reached inline-base64 path; this should be handled as lfsFile"
+                        .to_string(),
+                ));
+            },
         };
         let b64 = base64::engine::general_purpose::STANDARD.encode(&content);
         Ok(serde_json::json!({
@@ -338,6 +349,9 @@ impl<T: RepoType> HFRepository<T> {
     /// Check upload modes for all files and upload LFS files via xet.
     ///
     /// Always calls the preupload endpoint to determine upload mode per file.
+    /// Operations whose source is [`AddSource::Lfs`] short-circuit the preupload,
+    /// SHA-256, LFS-batch, and xet-upload steps — they are simply emitted
+    /// directly into the returned `lfsFile` map.
     ///
     /// Returns a map of path_in_repo -> (sha256_oid, size) for files that were
     /// uploaded via xet and should be referenced as lfsFile in the commit.
@@ -346,17 +360,24 @@ impl<T: RepoType> HFRepository<T> {
         params: &CreateCommitParams,
         revision: &str,
     ) -> HFResult<HashMap<String, (String, u64)>> {
-        let add_ops: Vec<(&String, &AddSource)> = params
-            .operations
-            .iter()
-            .filter_map(|op| match op {
-                CommitOperation::Add { path_in_repo, source } => Some((path_in_repo, source)),
-                _ => None,
-            })
-            .collect();
+        let mut prepared_lfs: HashMap<String, (String, u64)> = HashMap::new();
+        let mut add_ops: Vec<(&String, &AddSource)> = Vec::new();
+
+        for op in &params.operations {
+            if let CommitOperation::Add { path_in_repo, source } = op {
+                match source {
+                    AddSource::Lfs { sha256_oid, size } => {
+                        prepared_lfs.insert(path_in_repo.clone(), (sha256_oid.clone(), *size));
+                    },
+                    AddSource::Bytes(_) | AddSource::File(_) => {
+                        add_ops.push((path_in_repo, source));
+                    },
+                }
+            }
+        }
 
         if add_ops.is_empty() {
-            return Ok(HashMap::new());
+            return Ok(prepared_lfs);
         }
 
         // Step 1: Gather file info (path, size, sample) for preupload check
@@ -390,7 +411,7 @@ impl<T: RepoType> HFRepository<T> {
             .collect();
 
         if lfs_files.is_empty() {
-            return Ok(HashMap::new());
+            return Ok(prepared_lfs);
         }
 
         tracing::info!(
@@ -399,7 +420,14 @@ impl<T: RepoType> HFRepository<T> {
             "files requiring LFS upload"
         );
 
-        self.upload_lfs_files_via_xet(params, revision, &lfs_files).await
+        let mut uploaded = self.upload_lfs_files_via_xet(params, revision, &lfs_files).await?;
+        // Pre-uploaded LFS entries take precedence if a caller somehow passed
+        // both an `AddSource::Lfs` and a fresh upload for the same path — but
+        // `prepared_lfs` and `add_ops` are partitioned so this is purely defensive.
+        for (path, info) in prepared_lfs {
+            uploaded.entry(path).or_insert(info);
+        }
+        Ok(uploaded)
     }
 
     /// Call the Hub preupload endpoint to determine the upload mode per file.
@@ -601,6 +629,8 @@ async fn sha256_of_source(source: &AddSource) -> HFResult<String> {
             .await
             .map_err(|e| HFError::Other(format!("sha256 task failed: {e}")))?
         },
+        // Already-uploaded blobs carry their own SHA-256 OID; no recomputation.
+        AddSource::Lfs { sha256_oid, .. } => Ok(sha256_oid.clone()),
     }
 }
 
@@ -620,6 +650,11 @@ fn read_size_and_sample(source: &AddSource) -> HFResult<(u64, Vec<u8>)> {
             sample.truncate(n);
             Ok((size, sample))
         },
+        // Lfs sources skip preupload classification entirely; callers must not
+        // route them through `read_size_and_sample`.
+        AddSource::Lfs { .. } => Err(HFError::Other(
+            "internal: AddSource::Lfs has no inline sample; route through lfs_uploaded directly".to_string(),
+        )),
     }
 }
 

--- a/hf-hub/src/repository/xet_session.rs
+++ b/hf-hub/src/repository/xet_session.rs
@@ -1,0 +1,231 @@
+//! Streaming xet upload session.
+//!
+//! Streams individual files into a repository's xet content-addressable
+//! storage *as they are produced*, returning a per-file
+//! `(sha256_oid, size)` descriptor that can be referenced from a later
+//! [`HFRepository::create_commit`](super::HFRepository::create_commit) call
+//! via [`AddSource::Lfs`](super::AddSource::Lfs). This lets callers produce a
+//! single commit whose total payload exceeds local RAM and disk.
+//!
+//! The usual `upload_file` / `upload_folder` / `create_commit` paths buffer
+//! every file's bytes in memory (`AddSource::Bytes`) or on disk
+//! (`AddSource::File`) until the commit is built. For workloads that
+//! generate many small or many large files one at a time — such as rendered
+//! tile pyramids, sharded training outputs, or any kind of streaming export —
+//! that buffering becomes the bottleneck. Use a streaming session instead:
+//! upload each file, drop its bytes (or remove its temp file), and finalize
+//! the commit at the end with only `(path, oid, size)` triples in memory.
+//!
+//! See [`HFRepository::open_xet_upload_session`](super::HFRepository::open_xet_upload_session)
+//! for usage.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use xet::xet_session::{Sha256Policy, UniqueID, XetFileUpload};
+
+use super::{HFRepository, RepoType};
+use crate::constants;
+use crate::error::{HFError, HFResult, NotFoundContext, XetOperation};
+use crate::xet::{new_xet_upload_commit, repo_xet_token_url};
+
+/// Per-file result of a completed streaming xet upload.
+///
+/// Pass `sha256_oid` and `size` into
+/// [`AddSource::Lfs`](super::AddSource::Lfs) (or
+/// [`CommitOperation::add_lfs`](super::CommitOperation::add_lfs)) when
+/// building the final commit.
+#[derive(Debug, Clone)]
+pub struct UploadedXetFile {
+    /// Lowercase hex SHA-256 of the file content, as known to xet CAS.
+    pub sha256_oid: String,
+    /// Total file size in bytes.
+    pub size: u64,
+    /// Xet content-addressable (Merkle) hash. Useful when the same blob will
+    /// be referenced from a bucket (see
+    /// [`HFBucket::open_xet_upload_session`](crate::buckets::HFBucket::open_xet_upload_session)),
+    /// which addresses by xet hash rather than SHA-256.
+    pub xet_hash: String,
+}
+
+/// Open streaming xet-upload session for a single repository revision.
+///
+/// Construct with
+/// [`HFRepository::open_xet_upload_session`](super::HFRepository::open_xet_upload_session),
+/// then call [`upload_bytes`](Self::upload_bytes) / [`upload_file`](Self::upload_file)
+/// for each piece of content, and finish with [`finish`](Self::finish) to seal
+/// the CAS uploads and recover per-path descriptors.
+pub struct XetUploadSession {
+    commit: xet::xet_session::XetUploadCommit,
+    /// `(path_in_repo, task_id)` pairs, populated as the caller queues
+    /// uploads; consumed at finish() time to map xet task results back to
+    /// user-supplied paths.
+    path_to_task: Mutex<Vec<(String, UniqueID)>>,
+}
+
+impl XetUploadSession {
+    /// Queue an in-memory file for streaming upload.
+    ///
+    /// xet starts uploading the bytes to CAS in the background. The future
+    /// resolves once xet has accepted the bytes — at that point the caller may
+    /// drop their own copy. Use [`finish`](Self::finish) to wait for *all*
+    /// queued uploads to settle.
+    pub async fn upload_bytes(&self, path_in_repo: impl Into<String>, bytes: Vec<u8>) -> HFResult<()> {
+        let path_in_repo = path_in_repo.into();
+        tracing::debug!(path = path_in_repo.as_str(), len = bytes.len(), "queuing xet upload (bytes)");
+        let handle = self
+            .commit
+            .upload_bytes(bytes, Sha256Policy::Compute, Some(path_in_repo.clone()))
+            .await
+            .map_err(|e| HFError::xet(XetOperation::Upload, e))?;
+        self.record_handle(path_in_repo, &handle);
+        Ok(())
+    }
+
+    /// Queue a local file for streaming upload.
+    ///
+    /// xet reads the file lazily during the background transfer, so the file
+    /// must exist (unchanged) until [`finish`](Self::finish) returns.
+    pub async fn upload_file(&self, path_in_repo: impl Into<String>, source: impl Into<PathBuf>) -> HFResult<()> {
+        let path_in_repo = path_in_repo.into();
+        let source = source.into();
+        tracing::debug!(path = path_in_repo.as_str(), source = ?source, "queuing xet upload (file)");
+        let handle = self
+            .commit
+            .upload_from_path(source, Sha256Policy::Compute)
+            .await
+            .map_err(|e| HFError::xet(XetOperation::Upload, e))?;
+        self.record_handle(path_in_repo, &handle);
+        Ok(())
+    }
+
+    fn record_handle(&self, path_in_repo: String, handle: &XetFileUpload) {
+        self.path_to_task
+            .lock()
+            .expect("xet upload session mutex poisoned")
+            .push((path_in_repo, handle.task_id()));
+    }
+
+    /// Finalize the session: wait for every queued upload to complete, seal
+    /// the CAS state, and return a map of path → blob descriptor.
+    ///
+    /// On success, the returned descriptors can be passed to
+    /// [`AddSource::Lfs`](super::AddSource::Lfs) in a subsequent
+    /// [`create_commit`](super::HFRepository::create_commit) call.
+    pub async fn finish(self) -> HFResult<HashMap<String, UploadedXetFile>> {
+        let results = self
+            .commit
+            .commit()
+            .await
+            .map_err(|e| HFError::xet(XetOperation::Upload, e))?;
+        tracing::info!(file_count = results.uploads.len(), "xet streaming upload session committed");
+
+        let path_to_task = self
+            .path_to_task
+            .into_inner()
+            .expect("xet upload session mutex poisoned");
+
+        let mut out: HashMap<String, UploadedXetFile> = HashMap::with_capacity(path_to_task.len());
+        for (path, task_id) in path_to_task {
+            let metadata = results
+                .uploads
+                .get(&task_id)
+                .ok_or_else(|| HFError::Other(format!("xet upload result missing for {path:?}")))?;
+            let sha256_oid = metadata
+                .xet_info
+                .sha256()
+                .ok_or_else(|| {
+                    HFError::Other(format!(
+                        "xet upload for {path:?} did not produce a SHA-256; was Sha256Policy::Compute used?"
+                    ))
+                })?
+                .to_string();
+            let size = metadata
+                .xet_info
+                .file_size()
+                .ok_or_else(|| HFError::Other(format!("xet upload for {path:?} did not report a file size")))?;
+            out.insert(
+                path,
+                UploadedXetFile {
+                    sha256_oid,
+                    size,
+                    xet_hash: metadata.xet_info.hash().to_string(),
+                },
+            );
+        }
+
+        Ok(out)
+    }
+}
+
+/// Synchronous/blocking counterpart to [`XetUploadSession`].
+///
+/// Constructed via [`HFRepositorySync::open_xet_upload_session`](crate::HFRepositorySync::open_xet_upload_session).
+#[cfg(feature = "blocking")]
+#[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
+pub struct XetUploadSessionSync {
+    inner: XetUploadSession,
+    runtime: std::sync::Arc<tokio::runtime::Runtime>,
+}
+
+#[cfg(feature = "blocking")]
+impl XetUploadSessionSync {
+    /// Blocking counterpart of [`XetUploadSession::upload_bytes`].
+    pub fn upload_bytes(&self, path_in_repo: impl Into<String>, bytes: Vec<u8>) -> HFResult<()> {
+        self.runtime.block_on(self.inner.upload_bytes(path_in_repo, bytes))
+    }
+
+    /// Blocking counterpart of [`XetUploadSession::upload_file`].
+    pub fn upload_file(&self, path_in_repo: impl Into<String>, source: impl Into<PathBuf>) -> HFResult<()> {
+        self.runtime.block_on(self.inner.upload_file(path_in_repo, source))
+    }
+
+    /// Blocking counterpart of [`XetUploadSession::finish`].
+    pub fn finish(self) -> HFResult<HashMap<String, UploadedXetFile>> {
+        self.runtime.block_on(self.inner.finish())
+    }
+}
+
+#[cfg(feature = "blocking")]
+impl<T: RepoType> crate::HFRepositorySync<T> {
+    /// Blocking counterpart of [`HFRepository::open_xet_upload_session`].
+    pub fn open_xet_upload_session(&self, revision: Option<String>) -> HFResult<XetUploadSessionSync> {
+        let inner = self.runtime.block_on(self.inner.open_xet_upload_session(revision))?;
+        Ok(XetUploadSessionSync {
+            inner,
+            runtime: self.runtime.clone(),
+        })
+    }
+}
+
+impl<T: RepoType> HFRepository<T> {
+    /// Open a streaming xet-upload session for the given revision.
+    ///
+    /// Each [`upload_bytes`](XetUploadSession::upload_bytes) /
+    /// [`upload_file`](XetUploadSession::upload_file) call uploads its content
+    /// to xet content-addressable storage immediately. After all content is
+    /// uploaded, call [`finish`](XetUploadSession::finish) to seal the CAS
+    /// uploads and recover per-path `(sha256_oid, size, xet_hash)`
+    /// descriptors. Those descriptors can then be fed into
+    /// [`AddSource::Lfs`](super::AddSource::Lfs) for a final
+    /// [`create_commit`](Self::create_commit) call.
+    ///
+    /// Use this when total commit payload exceeds local RAM or disk: the
+    /// caller never has to hold all bytes (or all temp files) at once. Files
+    /// smaller than the Hub's LFS threshold should still go through
+    /// [`upload_file`](Self::upload_file) or
+    /// [`create_commit`](Self::create_commit) — this session is xet-only and
+    /// unconditionally produces `lfsFile` commit entries.
+    pub async fn open_xet_upload_session(&self, revision: Option<String>) -> HFResult<XetUploadSession> {
+        let revision = revision.unwrap_or_else(|| constants::DEFAULT_REVISION.to_string());
+        let repo_path = self.repo_path();
+        let api_segment = T::default().plural();
+        let token_url = repo_xet_token_url(&self.hf_client, "write", &repo_path, api_segment, &revision);
+        let commit = new_xet_upload_commit(&self.hf_client, token_url, &repo_path, NotFoundContext::Repo, "repo").await?;
+        Ok(XetUploadSession {
+            commit,
+            path_to_task: Mutex::new(Vec::new()),
+        })
+    }
+}

--- a/hf-hub/src/repository/xet_session.rs
+++ b/hf-hub/src/repository/xet_session.rs
@@ -114,17 +114,10 @@ impl XetUploadSession {
     /// [`AddSource::Lfs`](super::AddSource::Lfs) in a subsequent
     /// [`create_commit`](super::HFRepository::create_commit) call.
     pub async fn finish(self) -> HFResult<HashMap<String, UploadedXetFile>> {
-        let results = self
-            .commit
-            .commit()
-            .await
-            .map_err(|e| HFError::xet(XetOperation::Upload, e))?;
+        let results = self.commit.commit().await.map_err(|e| HFError::xet(XetOperation::Upload, e))?;
         tracing::info!(file_count = results.uploads.len(), "xet streaming upload session committed");
 
-        let path_to_task = self
-            .path_to_task
-            .into_inner()
-            .expect("xet upload session mutex poisoned");
+        let path_to_task = self.path_to_task.into_inner().expect("xet upload session mutex poisoned");
 
         let mut out: HashMap<String, UploadedXetFile> = HashMap::with_capacity(path_to_task.len());
         for (path, task_id) in path_to_task {
@@ -222,7 +215,8 @@ impl<T: RepoType> HFRepository<T> {
         let repo_path = self.repo_path();
         let api_segment = T::default().plural();
         let token_url = repo_xet_token_url(&self.hf_client, "write", &repo_path, api_segment, &revision);
-        let commit = new_xet_upload_commit(&self.hf_client, token_url, &repo_path, NotFoundContext::Repo, "repo").await?;
+        let commit =
+            new_xet_upload_commit(&self.hf_client, token_url, &repo_path, NotFoundContext::Repo, "repo").await?;
         Ok(XetUploadSession {
             commit,
             path_to_task: Mutex::new(Vec::new()),

--- a/hf-hub/src/xet.rs
+++ b/hf-hub/src/xet.rs
@@ -59,7 +59,13 @@ async fn fetch_xet_connection_info(
     })
 }
 
-fn repo_xet_token_url(client: &HFClient, token_type: &str, repo_id: &str, api_segment: &str, revision: &str) -> String {
+pub(crate) fn repo_xet_token_url(
+    client: &HFClient,
+    token_type: &str,
+    repo_id: &str,
+    api_segment: &str,
+    revision: &str,
+) -> String {
     format!("{}/api/{}/{}/xet-{}-token/{}", client.endpoint(), api_segment, repo_id, token_type, revision)
 }
 
@@ -179,21 +185,19 @@ pub(crate) struct XetBatchFile {
     pub filename: String,
 }
 
-/// Shared xet upload flow for both repositories and buckets.
+/// Open a fresh xet upload commit against the given token URL.
 ///
-/// Callers build the xet write-token URL with the appropriate variant
-/// (repo + revision, or bucket id) and pass the corresponding `owner_id`
-/// and `NotFoundContext`. `owner_kind` is used as a structured tracing
-/// field value (`"repo"` or `"bucket"`).
-async fn xet_upload_inner(
+/// Extracted so [`xet_upload_inner`] (the all-at-once flow) and the streaming
+/// session (built by
+/// [`HFRepository::open_xet_upload_session`](crate::repository::HFRepository::open_xet_upload_session)
+/// and the bucket equivalent) share one session-bring-up code path.
+pub(crate) async fn new_xet_upload_commit(
     hf_client: &HFClient,
-    files: &[(String, AddSource)],
     token_url: String,
     owner_id: &str,
     not_found_ctx: crate::error::NotFoundContext,
     owner_kind: &'static str,
-    progress: &Option<Progress>,
-) -> HFResult<Vec<XetFileInfo>> {
+) -> HFResult<xet::xet_session::XetUploadCommit> {
     tracing::info!(owner_kind, owner = owner_id, "fetching xet write token");
     let conn = fetch_xet_connection_info(hf_client, &token_url, Some(owner_id), not_found_ctx).await?;
     tracing::info!(endpoint = conn.endpoint.as_str(), "xet write token obtained, building session");
@@ -217,6 +221,25 @@ async fn xet_upload_inner(
     .build()
     .await
     .map_err(|e| HFError::xet(XetOperation::Upload, e))?;
+    Ok(commit)
+}
+
+/// Shared xet upload flow for both repositories and buckets.
+///
+/// Callers build the xet write-token URL with the appropriate variant
+/// (repo + revision, or bucket id) and pass the corresponding `owner_id`
+/// and `NotFoundContext`. `owner_kind` is used as a structured tracing
+/// field value (`"repo"` or `"bucket"`).
+async fn xet_upload_inner(
+    hf_client: &HFClient,
+    files: &[(String, AddSource)],
+    token_url: String,
+    owner_id: &str,
+    not_found_ctx: crate::error::NotFoundContext,
+    owner_kind: &'static str,
+    progress: &Option<Progress>,
+) -> HFResult<Vec<XetFileInfo>> {
+    let commit = new_xet_upload_commit(hf_client, token_url, owner_id, not_found_ctx, owner_kind).await?;
     tracing::info!("xet upload commit built, queuing file uploads");
 
     let mut task_ids_in_order = Vec::with_capacity(files.len());
@@ -226,6 +249,15 @@ async fn xet_upload_inner(
     for (target_path, source) in files {
         tracing::info!(path = target_path.as_str(), "queuing xet upload");
         let handle = match source {
+            // `xet_upload_inner` is only reached for sources that the caller
+            // wants xet to actually transfer. Pre-uploaded blobs short-circuit
+            // before this point.
+            AddSource::Lfs { .. } => {
+                return Err(HFError::Other(
+                    "internal: AddSource::Lfs reached xet_upload_inner; should have been routed via lfsFile map"
+                        .to_string(),
+                ));
+            },
             AddSource::File(path) => {
                 // Mimic xet-core's `std::path::absolute()` logic to derive the
                 // item_name that will appear in ItemProgressReport.
@@ -311,6 +343,7 @@ async fn xet_upload_inner(
             let size = match source {
                 AddSource::Bytes(b) => b.len() as u64,
                 AddSource::File(p) => std::fs::metadata(p).map(|m| m.len()).unwrap_or(0),
+                AddSource::Lfs { size, .. } => *size,
             };
             FileProgress {
                 filename: target_path.clone(),


### PR DESCRIPTION
## Motivation

The existing repo and bucket upload APIs require every file in a commit to be
buffered in memory (`AddSource::Bytes`) or staged on local disk
(`AddSource::File` / `BucketUpload { local, .. }`) until commit time. That
makes the total commit payload bounded by local RAM or disk.

For workloads that generate output incrementally and may exceed either bound —
rendered tile pyramids, sharded training outputs, streaming exports — there's
currently no public seam to upload-then-reference, even though the internal
`xet_upload_inner` already does exactly that with a `pub(crate)` API.

This PR opens that seam.

## What's new

### Repo side
- **`AddSource::Lfs { sha256_oid, size }`** — a new `AddSource` variant that
  references an already-uploaded LFS blob by SHA-256 OID. `create_commit`
  short-circuits preupload, SHA-256 recomputation, and xet transfer for these,
  emitting an `lfsFile` NDJSON entry directly.
- **`HFRepository::open_xet_upload_session(revision)`** / blocking counterpart
  — opens an `XetUploadSession` whose `upload_bytes` / `upload_file` push to
  xet CAS as the caller produces content. `finish()` seals the CAS state and
  returns `HashMap<String, UploadedXetFile>` carrying `(sha256_oid, size,
  xet_hash)` per path, ready to feed into `AddSource::Lfs`.
- **`CommitOperation::add_lfs(path, oid, size)`** convenience helper.

### Bucket side
- **`HFBucket::open_xet_upload_session()`** / blocking counterpart — same
  shape. `finish()` returns descriptors keyed by remote path;
  `finish_and_register()` chains a `batch_operations` call to make the files
  visible in one step.

## Caller pattern

```rust
// Repos
let session = repo.open_xet_upload_session(None).await?;
for (path, bytes) in produce_tiles() {
    session.upload_bytes(path, bytes).await?; // bytes can be dropped after this
}
let uploaded = session.finish().await?;
let ops: Vec<CommitOperation> = uploaded
    .into_iter()
    .map(|(p, f)| CommitOperation::add_lfs(p, f.sha256_oid, f.size))
    .collect();
repo.create_commit().operations(ops).commit_message("…").send().await?;

// Buckets
let session = bucket.open_xet_upload_session().await?;
for (path, bytes) in produce_tiles() {
    session.upload_bytes(path, bytes).await?;
}
session.finish_and_register().await?;
```

The caller holds only `(path, sha256_oid, size, xet_hash)` triples between
upload and finalize — bounded by O(file count), not O(bytes).

## Internals

- Extracted the xet session bring-up out of `xet_upload_inner` into a reusable
  `pub(crate) new_xet_upload_commit(...)` helper that both the existing
  batched flow and the new streaming sessions share, so the token fetch +
  session-poisoning fallback logic stays in one place.
- `xet_upload_inner` and the existing matches on `AddSource` reject
  `AddSource::Lfs` defensively — it's routed via `lfs_uploaded` upstream of
  preupload and never reaches the inline-base64 or xet-transfer arms. Errors
  there indicate a logic bug, not a user error.
- The streaming sessions use the same `XetUploadCommit` / `Sha256Policy::Compute`
  primitives that the batched flow already uses, so per-file dedup, retry, and
  session-poisoning behavior are unchanged.

## Test plan

- Unit tests added for the new `AddSource::Lfs` and `CommitOperation::add_lfs`
  constructors.
- Existing unit + doc tests pass with and without the `blocking` feature
  (`cargo test -p hf-hub` / `cargo test -p hf-hub --features blocking`,
  163 tests).
- `cargo clippy -p hf-hub --features blocking --all-targets` is clean on the
  changed files.
- End-to-end streaming-upload behavior needs a live Hub and will be exercised
  by dependent crates; happy to add integration tests here too if you'd
  rather they live in this repo.

## Notes

- Driven by a real downstream use case: rendering Hilbert-curve binary
  visualization tile pyramids whose total size routinely exceeds local disk.
  See [arbvis](https://github.com/znation/arbvis) — the streaming sink there
  currently has to fall back to a TempDir + `add_file` flow with a comment
  pointing here.
- The PR is intentionally minimal — no progress reporting on the streaming
  sessions yet, and `finish` waits for all uploads to drain rather than
  exposing per-file completion. Both are easy follow-ups if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)