### PR TITLE
ci: consume setup-hf-registry-proxies action from hf-workflows

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,7 +45,7 @@ jobs:
           toolchain: stable
 
       - name: Set up HF registry proxies
-        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
+        uses: huggingface/hf-workflows/.github/actions/setup-hf-registry-proxies@21845492ef47d4e46b07a3b2a6e14fd4748c39cc  # main
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Set up HF registry proxies
-        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
+        uses: huggingface/hf-workflows/.github/actions/setup-hf-registry-proxies@21845492ef47d4e46b07a3b2a6e14fd4748c39cc  # main
 
       - name: Cache Cargo Registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
           components: rustfmt
 
       - name: Set up HF registry proxies
-        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
+        uses: huggingface/hf-workflows/.github/actions/setup-hf-registry-proxies@21845492ef47d4e46b07a3b2a6e14fd4748c39cc  # main
 
       - name: Check formatting
         run: cargo +nightly fmt --all -- --check
@@ -43,7 +43,7 @@ jobs:
           components: clippy
 
       - name: Set up HF registry proxies
-        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
+        uses: huggingface/hf-workflows/.github/actions/setup-hf-registry-proxies@21845492ef47d4e46b07a3b2a6e14fd4748c39cc  # main
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Set up HF registry proxies
         if: matrix.use_hf_registries
-        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
+        uses: huggingface/hf-workflows/.github/actions/setup-hf-registry-proxies@21845492ef47d4e46b07a3b2a6e14fd4748c39cc  # main
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
 
@@ -116,7 +116,7 @@ jobs:
           toolchain: nightly
 
       - name: Set up HF registry proxies
-        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
+        uses: huggingface/hf-workflows/.github/actions/setup-hf-registry-proxies@21845492ef47d4e46b07a3b2a6e14fd4748c39cc  # main
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
 
@@ -136,7 +136,7 @@ jobs:
           toolchain: stable
 
       - name: Set up HF registry proxies
-        run: curl -sSL https://registries.huggingface.tech/setup.sh | bash
+        uses: huggingface/hf-workflows/.github/actions/setup-hf-registry-proxies@21845492ef47d4e46b07a3b2a6e14fd4748c39cc  # main
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
 


### PR DESCRIPTION
## Summary

Replace the eight inline `curl -sSL .../setup.sh | bash` invocations
across `rust.yml`, `rust-release.yml`, and `benchmarks.yml` with the
sha-pinned cross-repo action at
[huggingface/hf-workflows/.github/actions/setup-hf-registry-proxies@2184549](https://github.com/huggingface/hf-workflows/pull/62).

The bootstrap is now reviewed once on hf-workflows and pinned by sha at
each call site; `registries.huggingface.tech` is no longer
fetched-and-executed at the start of every CI run.

## Test plan

- [ ] CI on this PR is green on `aws-general-8-plus`.
- [ ] Windows / macOS matrix legs of `build-and-test` still skip the
      action via `if: matrix.use_hf_registries`.