### PR TITLE
feat: add HFRepository::upload_large_folder (resumable, xet-optimized large-folder upload)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,8 +178,12 @@ hf-hub/
 │   │   │   ├── listing.rs          # list_files, list_tree, get_paths_info, get_file_metadata
 │   │   │   ├── download.rs         # download_file, download_file_stream, download_file_to_bytes,
 │   │   │   │                       #   snapshot_download (private helper structs live here)
-│   │   │   └── upload.rs           # upload_file, upload_folder, create_commit, delete_file/folder
-│   │   │                           #   (private helper structs live here)
+│   │   │   ├── upload.rs           # upload_file, upload_folder, create_commit, delete_file/folder
+│   │   │   │                       #   (private helper structs live here)
+│   │   │   └── upload_large_folder/   # Resumable large-folder upload (Python parity + xet improvements)
+│   │   │       ├── mod.rs             # upload_large_folder method, orchestration, UploadLargeFolderReport
+│   │   │       ├── local_folder.rs    # byte-compatible .cache/huggingface/upload metadata + flock
+│   │   │       └── pipeline.rs        # adaptive commit batching, stage seeding
 │   │   ├── spaces.rs               # Spaces component: HFSpace handle, SpaceRuntime, SpaceVariable,
 │   │   │                           #   runtime/hardware/secrets/variables/duplicate
 │   │   ├── users.rs                # Users component: User/Organization/OrgMembership, whoami,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,8 @@ hf-hub/
 │   │   │   └── upload_large_folder/   # Resumable large-folder upload (Python parity + xet improvements)
 │   │   │       ├── mod.rs             # upload_large_folder method, orchestration, UploadLargeFolderReport
 │   │   │       ├── local_folder.rs    # byte-compatible .cache/huggingface/upload metadata + flock
-│   │   │       └── pipeline.rs        # adaptive commit batching, stage seeding
+│   │   │       └── pipeline.rs        # tuning (PipelineConfig), oldest-anchored TimedBatchBuffer,
+│   │   │                              #   StatusCounters/emit_status, CommitReady, stage seeding
 │   │   ├── spaces.rs               # Spaces component: HFSpace handle, SpaceRuntime, SpaceVariable,
 │   │   │                           #   runtime/hardware/secrets/variables/duplicate
 │   │   ├── users.rs                # Users component: User/Organization/OrgMembership, whoami,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1156,7 @@ dependencies = [
  "base64",
  "bon",
  "bytes",
+ "fs2",
  "futures",
  "globset",
  "hf-xet",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -64,6 +64,10 @@ name = "diff"
 path = "diff.rs"
 
 [[example]]
+name = "upload_large_folder"
+path = "upload_large_folder.rs"
+
+[[example]]
 name = "blocking_read"
 path = "blocking_read.rs"
 required-features = ["blocking"]

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -81,6 +81,7 @@ impl ProgressHandler for PrintProgressHandler {
                 UploadEvent::Complete => {
                     println!("Upload complete.");
                 },
+                UploadEvent::LargeFolderStatus { .. } => {},
             },
         }
     }

--- a/examples/upload_large_folder.rs
+++ b/examples/upload_large_folder.rs
@@ -1,0 +1,60 @@
+//! Upload a large local folder using the high-level repo handle, with a simple
+//! aggregate progress logger. Run with:
+//!   HF_TOKEN=hf_xxx cargo run -p examples --example upload_large_folder -- <owner> <name> <folder>
+
+use std::sync::Arc;
+
+use hf_hub::HFClient;
+use hf_hub::progress::{ProgressEvent, ProgressHandler, UploadEvent};
+
+struct Logger;
+
+impl ProgressHandler for Logger {
+    fn on_progress(&self, event: &ProgressEvent) {
+        match event {
+            ProgressEvent::Upload(UploadEvent::LargeFolderStatus {
+                committed,
+                files_total,
+                preuploaded,
+                lfs_total,
+                dedup_bytes_saved,
+                ..
+            }) => {
+                println!(
+                    "committed {committed}/{files_total} | lfs {preuploaded}/{lfs_total} uploaded | dedup saved {dedup_bytes_saved} bytes"
+                );
+            },
+            ProgressEvent::Upload(UploadEvent::Complete) => println!("done"),
+            _ => {},
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let owner = args.next().expect("owner");
+    let name = args.next().expect("name");
+    let folder = args.next().expect("folder path");
+
+    let token = std::env::var("HF_TOKEN").expect("HF_TOKEN");
+    let client = HFClient::builder().token(token).build()?;
+    let repo = client.model(&owner, &name);
+
+    let report = repo
+        .upload_large_folder()
+        .folder_path(std::path::PathBuf::from(folder))
+        .progress(Arc::new(Logger))
+        .send()
+        .await?;
+
+    println!(
+        "uploaded {} files in {} commits ({} via lfs, {} bytes, {} deduped)",
+        report.total_files,
+        report.commits.len(),
+        report.files_uploaded_lfs,
+        report.bytes_uploaded,
+        report.dedup_bytes_saved
+    );
+    Ok(())
+}

--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -31,6 +31,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"
 hf-xet = { version = "1.5.2" }
 sha2 = "0.11"
+fs2 = "0.4"
 
 [features]
 default = []

--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -39,7 +39,7 @@ blocking = ["tokio/rt"]
 rustls-tls = ["reqwest/rustls"]
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 tempfile = "3"
 serial_test = "3"
 

--- a/hf-hub/src/progress.rs
+++ b/hf-hub/src/progress.rs
@@ -257,6 +257,32 @@ pub enum UploadEvent {
     /// transfer is done; the call itself is silent until `Complete`.
     Committing,
 
+    /// Coarse, aggregate status for `upload_large_folder`. Mirrors the Python
+    /// status report as structured data. Per-file progress is intentionally
+    /// omitted (a large folder has too many files); consumers render counts and
+    /// the aggregate byte fields from `Progress`.
+    LargeFolderStatus {
+        /// Total files in the upload set.
+        files_total: usize,
+        /// Files whose content hash is known (regular hashed in-memory, or lfs
+        /// hashed during the xet clean pass).
+        hashed: usize,
+        /// Files whose upload mode (regular/lfs) has been determined.
+        upload_mode_known: usize,
+        /// Files classified as lfs.
+        lfs_total: usize,
+        /// lfs files whose data has been uploaded to CAS.
+        preuploaded: usize,
+        /// Files committed to the repo.
+        committed: usize,
+        /// Files the Hub told us to ignore.
+        ignored: usize,
+        /// Logical bytes uploaded to CAS so far.
+        bytes_uploaded: u64,
+        /// Bytes saved by xet deduplication so far.
+        dedup_bytes_saved: u64,
+    },
+
     /// Terminal event on success. Not emitted on failure — check the returned `Result`.
     Complete,
 }
@@ -356,6 +382,44 @@ impl EmitEvent for Option<Progress> {
         if let Some(h) = self {
             h.on_progress(&event.into());
         }
+    }
+}
+
+#[cfg(test)]
+mod large_folder_status_tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct Capture(Mutex<Vec<String>>);
+    impl ProgressHandler for Capture {
+        fn on_progress(&self, event: &ProgressEvent) {
+            if let ProgressEvent::Upload(UploadEvent::LargeFolderStatus {
+                committed, files_total, ..
+            }) = event
+            {
+                self.0.lock().unwrap().push(format!("{committed}/{files_total}"));
+            }
+        }
+    }
+
+    #[test]
+    fn large_folder_status_emits() {
+        let cap = Arc::new(Capture::default());
+        let progress = Progress::from(cap.clone());
+        progress.emit(UploadEvent::LargeFolderStatus {
+            files_total: 10,
+            hashed: 4,
+            upload_mode_known: 6,
+            lfs_total: 3,
+            preuploaded: 1,
+            committed: 2,
+            ignored: 0,
+            bytes_uploaded: 1234,
+            dedup_bytes_saved: 56,
+        });
+        assert_eq!(cap.0.lock().unwrap().as_slice(), &["2/10".to_string()]);
     }
 }
 

--- a/hf-hub/src/progress.rs
+++ b/hf-hub/src/progress.rs
@@ -281,6 +281,13 @@ pub enum UploadEvent {
         bytes_uploaded: u64,
         /// Bytes saved by xet deduplication so far.
         dedup_bytes_saved: u64,
+        /// Files whose work was reused from a previous run (resume): already
+        /// uploaded (lfs) or already committed when this run started. Not
+        /// re-uploaded this run.
+        skipped: usize,
+        /// Logical bytes of the `skipped` files — the upload work this run
+        /// avoided by resuming a previous run.
+        skipped_bytes: u64,
     },
 
     /// Terminal event on success. Not emitted on failure — check the returned `Result`.
@@ -418,6 +425,8 @@ mod large_folder_status_tests {
             ignored: 0,
             bytes_uploaded: 1234,
             dedup_bytes_saved: 56,
+            skipped: 0,
+            skipped_bytes: 0,
         });
         assert_eq!(cap.0.lock().unwrap().as_slice(), &["2/10".to_string()]);
     }

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -43,6 +43,7 @@ use futures::Stream;
 pub use repo_type::{RepoType, RepoTypeAny, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize, Serializer};
+pub use upload_large_folder::UploadLargeFolderReport;
 use url::Url;
 
 use crate::client::HFClient;

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -26,6 +26,7 @@ pub mod files;
 pub mod listing;
 pub mod repo_type;
 pub mod upload;
+pub mod upload_large_folder;
 
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -115,8 +115,6 @@ impl<T: RepoType> HFRepository<T> {
         let lfs_uploaded: HashMap<String, (String, u64)> =
             self.preupload_and_upload_lfs_files(&params, revision).await?;
 
-        let mut ndjson_lines: Vec<Vec<u8>> = Vec::new();
-
         let mut header_value = serde_json::json!({
             "summary": params.commit_message,
             "description": params.commit_description.as_deref().unwrap_or(""),
@@ -125,10 +123,10 @@ impl<T: RepoType> HFRepository<T> {
             header_value["parentCommit"] = serde_json::Value::String(parent.clone());
         }
         let header_line = serde_json::json!({"key": "header", "value": header_value});
-        ndjson_lines.push(serde_json::to_vec(&header_line)?);
 
+        let mut entries: Vec<serde_json::Value> = Vec::new();
         for op in &params.operations {
-            let line = match op {
+            let entry = match op {
                 CommitOperation::Add { path_in_repo, source } => {
                     if let Some((oid, size)) = lfs_uploaded.get(path_in_repo) {
                         tracing::info!(
@@ -158,16 +156,10 @@ impl<T: RepoType> HFRepository<T> {
                     })
                 },
             };
-            ndjson_lines.push(serde_json::to_vec(&line)?);
+            entries.push(entry);
         }
 
-        let body: Vec<u8> = ndjson_lines
-            .into_iter()
-            .flat_map(|mut line| {
-                line.push(b'\n');
-                line
-            })
-            .collect();
+        let body = build_commit_ndjson(&header_line, &entries)?;
 
         params.progress.emit(UploadEvent::Committing);
 
@@ -623,6 +615,19 @@ fn read_size_and_sample(source: &AddSource) -> HFResult<(u64, Vec<u8>)> {
     }
 }
 
+/// Serializes a commit header value plus per-operation entry values into the
+/// newline-delimited JSON body the Hub `/commit` endpoint expects.
+fn build_commit_ndjson(header: &serde_json::Value, entries: &[serde_json::Value]) -> HFResult<Vec<u8>> {
+    let mut body: Vec<u8> = Vec::new();
+    body.extend(serde_json::to_vec(header)?);
+    body.push(b'\n');
+    for entry in entries {
+        body.extend(serde_json::to_vec(entry)?);
+        body.push(b'\n');
+    }
+    Ok(body)
+}
+
 /// Recursively collect files from a directory into CommitOperation::Add entries.
 /// Respects allow_patterns and ignore_patterns (glob-style).
 fn collect_files_recursive(
@@ -1065,5 +1070,27 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
                 .create_pr(create_pr)
                 .send(),
         )
+    }
+}
+
+#[cfg(test)]
+mod ndjson_tests {
+    use super::*;
+
+    #[test]
+    fn build_commit_ndjson_orders_header_then_entries() {
+        let header = serde_json::json!({"key": "header", "value": {"summary": "msg"}});
+        let entries = vec![
+            serde_json::json!({"key": "lfsFile", "value": {"path": "a", "algo": "sha256", "oid": "x", "size": 1}}),
+            serde_json::json!({"key": "deletedFile", "value": {"path": "b"}}),
+        ];
+        let body = build_commit_ndjson(&header, &entries).unwrap();
+        let text = String::from_utf8(body).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains("\"header\""));
+        assert!(lines[1].contains("\"lfsFile\""));
+        assert!(lines[2].contains("\"deletedFile\""));
+        assert!(text.ends_with('\n'));
     }
 }

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -27,6 +27,19 @@ use crate::error::{HFError, HFResult};
 use crate::progress::{EmitEvent, Progress, UploadEvent};
 use crate::{constants, retry};
 
+/// A file whose upload has already been resolved, ready to be referenced in a
+/// commit without further classification or transfer.
+pub(crate) enum ResolvedAdd {
+    /// Inline a (small, "regular") file's bytes as base64.
+    Inline { path_in_repo: String, source: AddSource },
+    /// Reference an already-uploaded lfs/xet object by its sha256 oid and size.
+    Lfs {
+        path_in_repo: String,
+        oid: String,
+        size: u64,
+    },
+}
+
 /// Internal options struct for [`HFRepository::create_commit`]. Built by the bon-generated
 /// `create_commit()` builder.
 struct CreateCommitParams {
@@ -487,6 +500,81 @@ impl<T: RepoType> HFRepository<T> {
             .collect();
 
         Ok(result)
+    }
+
+    /// Builds and POSTs a single commit from already-resolved operations. Emits
+    /// `Committing` before the call. Does not run preupload or xet — callers must
+    /// have resolved every add already.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn commit_resolved_operations(
+        &self,
+        adds: &[ResolvedAdd],
+        deletes: &[String],
+        commit_message: &str,
+        commit_description: Option<&str>,
+        revision: &str,
+        create_pr: bool,
+        parent_commit: Option<&str>,
+        progress: &Option<Progress>,
+    ) -> HFResult<CommitInfo> {
+        let url = format!("{}/commit/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), revision);
+
+        let mut header_value = serde_json::json!({
+            "summary": commit_message,
+            "description": commit_description.unwrap_or(""),
+        });
+        if let Some(parent) = parent_commit {
+            header_value["parentCommit"] = serde_json::Value::String(parent.to_string());
+        }
+        let header_line = serde_json::json!({"key": "header", "value": header_value});
+
+        let mut entries: Vec<serde_json::Value> = Vec::with_capacity(adds.len() + deletes.len());
+        for add in adds {
+            match add {
+                ResolvedAdd::Lfs {
+                    path_in_repo,
+                    oid,
+                    size,
+                } => {
+                    entries.push(serde_json::json!({
+                        "key": "lfsFile",
+                        "value": {"path": path_in_repo, "algo": "sha256", "oid": oid, "size": size}
+                    }));
+                },
+                ResolvedAdd::Inline { path_in_repo, source } => {
+                    entries.push(Self::inline_base64_entry(path_in_repo, source).await?);
+                },
+            }
+        }
+        for path in deletes {
+            entries.push(serde_json::json!({"key": "deletedFile", "value": {"path": path}}));
+        }
+
+        let body = build_commit_ndjson(&header_line, &entries)?;
+
+        progress.emit(UploadEvent::Committing);
+
+        let mut headers = self.hf_client.auth_headers();
+        headers.insert(reqwest::header::CONTENT_TYPE, "application/x-ndjson".parse().unwrap());
+        let response = retry::retry(self.hf_client.retry_config(), || {
+            let mut req = self
+                .hf_client
+                .http_client()
+                .post(&url)
+                .headers(headers.clone())
+                .body(body.clone());
+            if create_pr {
+                req = req.query(&[("create_pr", "1")]);
+            }
+            req.send()
+        })
+        .await?;
+        let repo_path = self.repo_path();
+        let response = self
+            .hf_client
+            .check_response(response, Some(&repo_path), crate::error::NotFoundContext::Repo)
+            .await?;
+        Ok(response.json().await?)
     }
 
     /// Call the LFS batch endpoint to negotiate the transfer method.

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -409,7 +409,7 @@ impl<T: RepoType> HFRepository<T> {
 
     /// Call the Hub preupload endpoint to determine the upload mode per file.
     /// Returns a map of path -> upload mode ("lfs" or "regular").
-    async fn fetch_upload_modes(
+    pub(crate) async fn fetch_upload_modes(
         &self,
         repo_id: &str,
         api_segment: &str,
@@ -684,7 +684,7 @@ async fn sha256_of_source(source: &AddSource) -> HFResult<String> {
     }
 }
 
-fn read_size_and_sample(source: &AddSource) -> HFResult<(u64, Vec<u8>)> {
+pub(crate) fn read_size_and_sample(source: &AddSource) -> HFResult<(u64, Vec<u8>)> {
     match source {
         AddSource::Bytes(bytes) => {
             let size = bytes.len() as u64;

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -390,7 +390,11 @@ impl<T: RepoType> HFRepository<T> {
         let lfs_files: Vec<&(String, u64, Vec<u8>, &AddSource)> = file_infos
             .iter()
             .filter(|(path, size, _, _)| {
-                *size > 0 && upload_modes.get(path.as_str()).map(|m| m == "lfs").unwrap_or(false)
+                *size > 0
+                    && upload_modes
+                        .get(path.as_str())
+                        .map(|info| info.upload_mode == "lfs")
+                        .unwrap_or(false)
             })
             .collect();
 
@@ -407,15 +411,15 @@ impl<T: RepoType> HFRepository<T> {
         self.upload_lfs_files_via_xet(params, revision, &lfs_files).await
     }
 
-    /// Call the Hub preupload endpoint to determine the upload mode per file.
-    /// Returns a map of path -> upload mode ("lfs" or "regular").
+    /// Call the Hub preupload endpoint to classify each file. Returns a map of
+    /// path -> [`PreuploadInfo`] (upload mode plus the Hub's should-ignore flag).
     pub(crate) async fn fetch_upload_modes(
         &self,
         repo_id: &str,
         api_segment: &str,
         revision: &str,
         files: &[(&str, u64, &[u8])],
-    ) -> HFResult<HashMap<String, String>> {
+    ) -> HFResult<HashMap<String, PreuploadInfo>> {
         let url = format!("{}/preupload/{}", self.hf_client.api_url(api_segment, repo_id), revision);
 
         let files_payload: Vec<serde_json::Value> = files
@@ -449,7 +453,19 @@ impl<T: RepoType> HFRepository<T> {
 
         let preupload: PreuploadResponse = response.json().await?;
 
-        Ok(preupload.files.into_iter().map(|f| (f.path, f.upload_mode)).collect())
+        Ok(preupload
+            .files
+            .into_iter()
+            .map(|f| {
+                (
+                    f.path,
+                    PreuploadInfo {
+                        upload_mode: f.upload_mode,
+                        should_ignore: f.should_ignore,
+                    },
+                )
+            })
+            .collect())
     }
 
     /// Compute SHA256, negotiate LFS batch transfer, and upload via xet.
@@ -637,11 +653,21 @@ impl<T: RepoType> HFRepository<T> {
 struct PreuploadFileInfo {
     path: String,
     upload_mode: String,
+    #[serde(default)]
+    should_ignore: bool,
 }
 
 #[derive(Debug, serde::Deserialize)]
 struct PreuploadResponse {
     files: Vec<PreuploadFileInfo>,
+}
+
+/// Per-file result of the preupload classification endpoint: the upload mode
+/// (`"lfs"`/`"regular"`) plus the Hub's should-ignore flag for the file.
+#[derive(Debug)]
+pub(crate) struct PreuploadInfo {
+    pub upload_mode: String,
+    pub should_ignore: bool,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -1180,5 +1206,20 @@ mod ndjson_tests {
         assert!(lines[1].contains("\"lfsFile\""));
         assert!(lines[2].contains("\"deletedFile\""));
         assert!(text.ends_with('\n'));
+    }
+
+    #[test]
+    fn preupload_response_parses_should_ignore() {
+        let json = r#"{"files":[
+            {"path":"a","uploadMode":"lfs","shouldIgnore":true},
+            {"path":"b","uploadMode":"regular"}
+        ]}"#;
+        let resp: PreuploadResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.files[0].path, "a");
+        assert_eq!(resp.files[0].upload_mode, "lfs");
+        assert!(resp.files[0].should_ignore);
+        // Absent shouldIgnore defaults to false.
+        assert_eq!(resp.files[1].upload_mode, "regular");
+        assert!(!resp.files[1].should_ignore);
     }
 }

--- a/hf-hub/src/repository/upload_large_folder/local_folder.rs
+++ b/hf-hub/src/repository/upload_large_folder/local_folder.rs
@@ -181,6 +181,110 @@ impl Drop for MetadataLock {
     }
 }
 
+const S3_EXPIRATION_SECS: f64 = 20.0 * 3600.0;
+
+/// Reads metadata for a file, applying Python's recovery rules:
+/// - missing file -> fresh metadata sized from the target file (if it exists).
+/// - parse error -> delete the corrupt file, return fresh metadata.
+/// - file mtime newer than recorded timestamp -> stale, return fresh metadata.
+/// - `is_uploaded && !is_committed` older than 20h -> reset `is_uploaded`.
+pub(crate) fn read_upload_metadata(paths: &LocalUploadFilePaths) -> HFResult<LocalUploadFileMetadata> {
+    let _guard = MetadataLock::acquire(&paths.lock_path)?;
+
+    let file_size = std::fs::metadata(&paths.file_path).map(|m| m.len()).unwrap_or(0);
+
+    if !paths.metadata_path.exists() {
+        return Ok(LocalUploadFileMetadata::new(file_size));
+    }
+
+    let raw = std::fs::read_to_string(&paths.metadata_path)?;
+    let parsed = match parse_metadata(&raw) {
+        Ok(m) => m,
+        Err(_) => {
+            tracing::warn!(path = %paths.metadata_path.display(), "corrupt upload metadata; resetting");
+            let _ = std::fs::remove_file(&paths.metadata_path);
+            return Ok(LocalUploadFileMetadata::new(file_size));
+        },
+    };
+
+    // Staleness: if the target file changed after the metadata was written, the
+    // hash/mode no longer apply.
+    if let Ok(file_meta) = std::fs::metadata(&paths.file_path)
+        && let Ok(modified) = file_meta.modified()
+        && let Ok(mtime) = modified.duration_since(UNIX_EPOCH)
+    {
+        let ts = parsed.timestamp.unwrap_or(0.0);
+        if mtime.as_secs_f64() > ts {
+            return Ok(LocalUploadFileMetadata::new(file_meta.len()));
+        }
+    }
+
+    let mut parsed = parsed;
+    if parsed.is_uploaded
+        && !parsed.is_committed
+        && now_unix_secs() - parsed.timestamp.unwrap_or(0.0) > S3_EXPIRATION_SECS
+    {
+        parsed.is_uploaded = false;
+    }
+    Ok(parsed)
+}
+
+fn parse_metadata(raw: &str) -> Result<LocalUploadFileMetadata, &'static str> {
+    let mut lines = raw.split('\n');
+    let timestamp: f64 = lines
+        .next()
+        .ok_or("missing timestamp")?
+        .trim()
+        .parse()
+        .map_err(|_| "bad timestamp")?;
+    let size: u64 = lines.next().ok_or("missing size")?.trim().parse().map_err(|_| "bad size")?;
+    let should_ignore = parse_opt_bool(lines.next().ok_or("missing should_ignore")?)?;
+    let sha256 = parse_opt_str(lines.next().ok_or("missing sha256")?);
+    let upload_mode = parse_opt_str(lines.next().ok_or("missing upload_mode")?);
+    if let Some(ref m) = upload_mode
+        && m != "regular"
+        && m != "lfs"
+    {
+        return Err("invalid upload_mode");
+    }
+    let remote_oid = parse_opt_str(lines.next().ok_or("missing remote_oid")?);
+    let is_uploaded = parse_bool(lines.next().ok_or("missing is_uploaded")?)?;
+    let is_committed = parse_bool(lines.next().ok_or("missing is_committed")?)?;
+
+    Ok(LocalUploadFileMetadata {
+        size,
+        timestamp: Some(timestamp),
+        should_ignore,
+        sha256,
+        upload_mode,
+        remote_oid,
+        is_uploaded,
+        is_committed,
+    })
+}
+
+fn parse_opt_str(line: &str) -> Option<String> {
+    let v = line.trim();
+    if v.is_empty() { None } else { Some(v.to_string()) }
+}
+
+fn parse_opt_bool(line: &str) -> Result<Option<bool>, &'static str> {
+    match line.trim() {
+        "" => Ok(None),
+        "0" => Ok(Some(false)),
+        "1" => Ok(Some(true)),
+        _ => Err("bad optional bool"),
+    }
+}
+
+fn parse_bool(line: &str) -> Result<bool, &'static str> {
+    match line.trim() {
+        "0" => Ok(false),
+        "1" => Ok(true),
+        _ => Err("bad bool"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -259,5 +363,99 @@ mod tests {
         assert_eq!(lines[5], ""); // remote_oid None
         assert_eq!(lines[6], "0"); // is_uploaded false
         assert_eq!(lines[7], "0"); // is_committed false
+    }
+
+    fn touch_file(path: &std::path::Path, bytes: &[u8]) {
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    #[test]
+    fn round_trip_read_after_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = get_local_upload_paths(dir.path(), "f.bin").unwrap();
+        touch_file(&paths.file_path, b"hello");
+        let mut meta = LocalUploadFileMetadata::new(5);
+        meta.upload_mode = Some("regular".to_string());
+        meta.is_committed = true;
+        meta.save(&paths).unwrap();
+
+        let read = read_upload_metadata(&paths).unwrap();
+        assert_eq!(read.size, 5);
+        assert_eq!(read.upload_mode.as_deref(), Some("regular"));
+        assert!(read.is_committed);
+        assert!(read.should_ignore.is_none());
+    }
+
+    #[test]
+    fn corrupt_metadata_is_deleted_and_reset() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = get_local_upload_paths(dir.path(), "c.bin").unwrap();
+        touch_file(&paths.file_path, b"abcd");
+        std::fs::write(&paths.metadata_path, "not a valid metadata file").unwrap();
+        let read = read_upload_metadata(&paths).unwrap();
+        assert_eq!(read.size, 4); // from stat
+        assert!(read.sha256.is_none());
+        assert!(!paths.metadata_path.exists()); // corrupt file removed
+    }
+
+    #[test]
+    fn stale_metadata_when_file_newer_than_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = get_local_upload_paths(dir.path(), "s.bin").unwrap();
+        touch_file(&paths.file_path, b"xyz");
+        let mut meta = LocalUploadFileMetadata::new(3);
+        meta.sha256 = Some("abc".to_string());
+        meta.save(&paths).unwrap();
+        rewrite_timestamp(&paths.metadata_path, 1.0);
+
+        let read = read_upload_metadata(&paths).unwrap();
+        assert!(read.sha256.is_none()); // discarded as stale -> fresh
+    }
+
+    #[test]
+    fn s3_gc_resets_is_uploaded_after_20h() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = get_local_upload_paths(dir.path(), "g.bin").unwrap();
+        touch_file(&paths.file_path, b"zz");
+        let mut meta = LocalUploadFileMetadata::new(2);
+        meta.upload_mode = Some("lfs".to_string());
+        meta.sha256 = Some("aa".to_string());
+        meta.is_uploaded = true;
+        meta.save(&paths).unwrap();
+        rewrite_timestamp(&paths.metadata_path, now_unix_secs() - 21.0 * 3600.0);
+        // Backdate the TARGET file's mtime to older than the recorded timestamp so
+        // the staleness check does NOT fire — this isolates the 20h GC rule.
+        let f = std::fs::OpenOptions::new().write(true).open(&paths.file_path).unwrap();
+        f.set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(22 * 3600))
+            .unwrap();
+
+        let read = read_upload_metadata(&paths).unwrap();
+        assert!(!read.is_uploaded); // reset by the 20h GC rule (not by staleness)
+    }
+
+    /// Overwrites only line 1 (timestamp) of an existing metadata file.
+    fn rewrite_timestamp(metadata_path: &std::path::Path, ts: f64) {
+        let content = std::fs::read_to_string(metadata_path).unwrap();
+        let mut lines: Vec<String> = content.split('\n').map(str::to_string).collect();
+        lines[0] = ts.to_string();
+        std::fs::write(metadata_path, lines.join("\n")).unwrap();
+    }
+
+    #[test]
+    fn reads_python_written_fixture() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = get_local_upload_paths(dir.path(), "model.bin").unwrap();
+        touch_file(&paths.file_path, &[0u8; 10]);
+        // Metadata exactly as Python writes: timestamp far in the future so the
+        // staleness check passes; sha256 + lfs + uploaded, not committed.
+        let body = "99999999999.0\n10\n0\n0123abcd\nlfs\n\n1\n0\n";
+        std::fs::write(&paths.metadata_path, body).unwrap();
+        let read = read_upload_metadata(&paths).unwrap();
+        assert_eq!(read.size, 10);
+        assert_eq!(read.upload_mode.as_deref(), Some("lfs"));
+        assert_eq!(read.sha256.as_deref(), Some("0123abcd"));
+        assert!(read.is_uploaded);
+        assert!(!read.is_committed);
+        assert_eq!(read.should_ignore, Some(false));
     }
 }

--- a/hf-hub/src/repository/upload_large_folder/local_folder.rs
+++ b/hf-hub/src/repository/upload_large_folder/local_folder.rs
@@ -9,6 +9,7 @@ use fs2::FileExt;
 
 use crate::error::HFResult;
 
+#[derive(Clone)]
 pub(crate) struct LocalUploadFilePaths {
     pub path_in_repo: String,
     pub file_path: PathBuf,
@@ -80,6 +81,7 @@ pub(crate) fn get_local_upload_paths(local_dir: &Path, path_in_repo: &str) -> HF
     })
 }
 
+#[derive(Clone)]
 pub(crate) struct LocalUploadFileMetadata {
     pub size: u64,
     pub timestamp: Option<f64>,

--- a/hf-hub/src/repository/upload_large_folder/local_folder.rs
+++ b/hf-hub/src/repository/upload_large_folder/local_folder.rs
@@ -3,6 +3,9 @@
 //! large-folder uploads interoperable with the Python tool.
 
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use fs2::FileExt;
 
 use crate::error::HFResult;
 
@@ -77,6 +80,107 @@ pub(crate) fn get_local_upload_paths(local_dir: &Path, path_in_repo: &str) -> HF
     })
 }
 
+pub(crate) struct LocalUploadFileMetadata {
+    pub size: u64,
+    pub timestamp: Option<f64>,
+    pub should_ignore: Option<bool>,
+    pub sha256: Option<String>,
+    pub upload_mode: Option<String>,
+    pub remote_oid: Option<String>,
+    pub is_uploaded: bool,
+    pub is_committed: bool,
+}
+
+impl LocalUploadFileMetadata {
+    /// Fresh metadata that knows only the file size (used for new files and as
+    /// the recovery fallback for missing/corrupt/stale metadata).
+    pub(crate) fn new(size: u64) -> Self {
+        Self {
+            size,
+            timestamp: None,
+            should_ignore: None,
+            sha256: None,
+            upload_mode: None,
+            remote_oid: None,
+            is_uploaded: false,
+            is_committed: false,
+        }
+    }
+
+    /// Serialize as Python's exact 8-line format under an advisory lock, then
+    /// update `self.timestamp` to the value written.
+    pub(crate) fn save(&mut self, paths: &LocalUploadFilePaths) -> HFResult<()> {
+        let _guard = MetadataLock::acquire(&paths.lock_path)?;
+        let now = now_unix_secs();
+
+        let mut out = String::new();
+        out.push_str(&format!("{now}\n"));
+        out.push_str(&format!("{}\n", self.size));
+        out.push_str(&opt_bool_line(self.should_ignore));
+        out.push_str(&opt_str_line(self.sha256.as_deref()));
+        out.push_str(&opt_str_line(self.upload_mode.as_deref()));
+        out.push_str(&opt_str_line(self.remote_oid.as_deref()));
+        out.push_str(&format!("{}\n", bool_digit(self.is_uploaded)));
+        out.push_str(&format!("{}\n", bool_digit(self.is_committed)));
+
+        std::fs::write(&paths.metadata_path, out)?;
+        self.timestamp = Some(now);
+        Ok(())
+    }
+}
+
+fn bool_digit(b: bool) -> u8 {
+    if b { 1 } else { 0 }
+}
+
+fn opt_bool_line(b: Option<bool>) -> String {
+    match b {
+        Some(v) => format!("{}\n", bool_digit(v)),
+        None => "\n".to_string(),
+    }
+}
+
+fn opt_str_line(s: Option<&str>) -> String {
+    match s {
+        Some(v) => format!("{v}\n"),
+        None => "\n".to_string(),
+    }
+}
+
+fn now_unix_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+/// Advisory exclusive lock on `<path>.lock`, flock-based and compatible with
+/// Python `huggingface_hub`'s `WeakFileLock` (also flock on Unix). Released on drop.
+pub(crate) struct MetadataLock {
+    file: std::fs::File,
+}
+
+impl MetadataLock {
+    pub(crate) fn acquire(lock_path: &Path) -> HFResult<Self> {
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(lock_path)?;
+        file.lock_exclusive()?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for MetadataLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,5 +208,56 @@ mod tests {
         let hf = dir.path().join(".cache/huggingface");
         assert!(hf.join("CACHEDIR.TAG").is_file());
         assert_eq!(std::fs::read_to_string(hf.join(".gitignore")).unwrap(), "*");
+    }
+
+    #[test]
+    fn save_writes_eight_lines_python_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = get_local_upload_paths(dir.path(), "a.bin").unwrap();
+        let mut meta = LocalUploadFileMetadata {
+            size: 123,
+            timestamp: None,
+            should_ignore: Some(false),
+            sha256: Some("deadbeef".to_string()),
+            upload_mode: Some("lfs".to_string()),
+            remote_oid: None,
+            is_uploaded: true,
+            is_committed: false,
+        };
+        meta.save(&paths).unwrap();
+
+        let content = std::fs::read_to_string(&paths.metadata_path).unwrap();
+        let lines: Vec<&str> = content.split('\n').collect();
+        assert_eq!(lines.len(), 9); // 8 content lines + trailing empty from final '\n'
+        assert!(lines[0].parse::<f64>().is_ok()); // timestamp
+        assert_eq!(lines[1], "123"); // size
+        assert_eq!(lines[2], "0"); // should_ignore = false
+        assert_eq!(lines[3], "deadbeef"); // sha256
+        assert_eq!(lines[4], "lfs"); // upload_mode
+        assert_eq!(lines[5], ""); // remote_oid = None
+        assert_eq!(lines[6], "1"); // is_uploaded
+        assert_eq!(lines[7], "0"); // is_committed
+        assert_eq!(lines[8], ""); // trailing
+        assert!(meta.timestamp.is_some());
+    }
+
+    #[test]
+    fn save_blank_lines_for_none_optionals() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = get_local_upload_paths(dir.path(), "b.bin").unwrap();
+        let mut meta = LocalUploadFileMetadata::new(7);
+        meta.save(&paths).unwrap();
+        let lines: Vec<String> = std::fs::read_to_string(&paths.metadata_path)
+            .unwrap()
+            .split('\n')
+            .map(str::to_string)
+            .collect();
+        assert_eq!(lines[1], "7");
+        assert_eq!(lines[2], ""); // should_ignore None
+        assert_eq!(lines[3], ""); // sha256 None
+        assert_eq!(lines[4], ""); // upload_mode None
+        assert_eq!(lines[5], ""); // remote_oid None
+        assert_eq!(lines[6], "0"); // is_uploaded false
+        assert_eq!(lines[7], "0"); // is_committed false
     }
 }

--- a/hf-hub/src/repository/upload_large_folder/local_folder.rs
+++ b/hf-hub/src/repository/upload_large_folder/local_folder.rs
@@ -1,0 +1,5 @@
+//! Byte-compatible reimplementation of Python `huggingface_hub`'s local upload
+//! cache (`.cache/huggingface/upload/<path>.metadata`), enabling resumable
+//! large-folder uploads interoperable with the Python tool.
+
+use std::path::PathBuf;

--- a/hf-hub/src/repository/upload_large_folder/local_folder.rs
+++ b/hf-hub/src/repository/upload_large_folder/local_folder.rs
@@ -2,4 +2,107 @@
 //! cache (`.cache/huggingface/upload/<path>.metadata`), enabling resumable
 //! large-folder uploads interoperable with the Python tool.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use crate::error::HFResult;
+
+pub(crate) struct LocalUploadFilePaths {
+    pub path_in_repo: String,
+    pub file_path: PathBuf,
+    pub lock_path: PathBuf,
+    pub metadata_path: PathBuf,
+}
+
+/// Returns `<local_dir>/.cache/huggingface`, creating it and its standard
+/// `CACHEDIR.TAG` + `.gitignore` ("*") marker files if missing.
+pub(crate) fn ensure_huggingface_dir(local_dir: &Path) -> HFResult<PathBuf> {
+    let hf_dir = local_dir.join(".cache").join("huggingface");
+    std::fs::create_dir_all(&hf_dir)?;
+
+    let cachedir_tag = hf_dir.join("CACHEDIR.TAG");
+    if !cachedir_tag.exists() {
+        std::fs::write(
+            &cachedir_tag,
+            "Signature: 8a477f597d28d172789f06886806bc55\n# This file is a cache directory tag created by huggingface_hub.\n",
+        )?;
+    }
+    let gitignore = hf_dir.join(".gitignore");
+    if !gitignore.exists() {
+        std::fs::write(&gitignore, "*")?;
+    }
+    Ok(hf_dir)
+}
+
+/// Computes the file, metadata, and lock paths for `path_in_repo`, eagerly
+/// creating the parent directories of both the target file and its metadata.
+/// `path_in_repo` is always stored with `/` separators (repo convention); the
+/// on-disk paths use the OS separator via `Path::join`. The metadata/lock
+/// suffixes are APPENDED to the full filename (Python parity): `model.safetensors`
+/// -> `model.safetensors.metadata` / `model.safetensors.lock`.
+pub(crate) fn get_local_upload_paths(local_dir: &Path, path_in_repo: &str) -> HFResult<LocalUploadFilePaths> {
+    let hf_dir = ensure_huggingface_dir(local_dir)?;
+
+    let mut file_path = local_dir.to_path_buf();
+    for segment in path_in_repo.split('/') {
+        file_path.push(segment);
+    }
+
+    let mut base = hf_dir.join("upload");
+    for segment in path_in_repo.split('/') {
+        base.push(segment);
+    }
+    let metadata_path = {
+        let mut s = base.clone().into_os_string();
+        s.push(".metadata");
+        PathBuf::from(s)
+    };
+    let lock_path = {
+        let mut s = base.into_os_string();
+        s.push(".lock");
+        PathBuf::from(s)
+    };
+
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if let Some(parent) = metadata_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    Ok(LocalUploadFilePaths {
+        path_in_repo: path_in_repo.to_string(),
+        file_path,
+        lock_path,
+        metadata_path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paths_layout_matches_python() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = get_local_upload_paths(dir.path(), "sub/dir/model.safetensors").unwrap();
+        assert_eq!(paths.path_in_repo, "sub/dir/model.safetensors");
+        assert_eq!(paths.file_path, dir.path().join("sub/dir/model.safetensors"));
+        assert_eq!(
+            paths.metadata_path,
+            dir.path().join(".cache/huggingface/upload/sub/dir/model.safetensors.metadata")
+        );
+        assert_eq!(paths.lock_path, dir.path().join(".cache/huggingface/upload/sub/dir/model.safetensors.lock"));
+        // Parent dirs created eagerly.
+        assert!(paths.metadata_path.parent().unwrap().is_dir());
+        assert!(paths.file_path.parent().unwrap().is_dir());
+    }
+
+    #[test]
+    fn cache_dir_scaffolding_written() {
+        let dir = tempfile::tempdir().unwrap();
+        ensure_huggingface_dir(dir.path()).unwrap();
+        let hf = dir.path().join(".cache/huggingface");
+        assert!(hf.join("CACHEDIR.TAG").is_file());
+        assert_eq!(std::fs::read_to_string(hf.join(".gitignore")).unwrap(), "*");
+    }
+}

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -32,7 +32,7 @@ pub struct UploadLargeFolderReport {
     pub files_committed_inline: usize,
     /// Files the Hub told us to ignore.
     pub files_ignored: usize,
-    /// Logical content bytes uploaded to CAS (before dedup).
+    /// Bytes actually transferred to CAS (post-dedup).
     pub bytes_uploaded: u64,
     /// Bytes saved by xet deduplication.
     pub dedup_bytes_saved: u64,

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -6,9 +6,18 @@ pub mod pipeline;
 
 use std::path::{Path, PathBuf};
 
+use bon::bon;
+
+use crate::constants;
 use crate::error::{HFError, HFResult};
-use crate::repository::CommitInfo;
-use crate::repository::files::matches_any_glob;
+use crate::progress::{EmitEvent, Progress, UploadEvent};
+use crate::repository::files::{AddSource, matches_any_glob};
+use crate::repository::upload::ResolvedAdd;
+use crate::repository::upload_large_folder::local_folder::{
+    LocalUploadFileMetadata, LocalUploadFilePaths, get_local_upload_paths, read_upload_metadata,
+};
+use crate::repository::upload_large_folder::pipeline::{CommitChunkSizer, WorkStage, seed_stage};
+use crate::repository::{CommitInfo, HFRepository, RepoType};
 
 /// Summary returned by [`HFRepository::upload_large_folder`].
 #[derive(Debug, Clone, Default)]
@@ -104,6 +113,367 @@ fn collect(
         }
     }
     Ok(())
+}
+
+struct Item {
+    paths: LocalUploadFilePaths,
+    file_path: PathBuf,
+    meta: LocalUploadFileMetadata,
+    sample: Vec<u8>,
+    size: u64,
+}
+
+#[bon]
+impl<T: RepoType> HFRepository<T> {
+    /// Upload a large local folder to this repository as a sequence of resumable,
+    /// adaptively-batched commits. Mirrors Python `huggingface_hub.upload_large_folder`
+    /// with a byte-compatible on-disk cache (`<folder>/.cache/huggingface/upload/`),
+    /// so a partial upload by either tool can be resumed by the other.
+    #[builder(finish_fn = send, derive(Debug, Clone))]
+    pub async fn upload_large_folder(
+        &self,
+        /// Local folder to upload.
+        folder_path: PathBuf,
+        /// Destination prefix within the repo. Defaults to the repo root.
+        #[builder(into)]
+        path_in_repo: Option<String>,
+        /// Branch to commit to. Defaults to the main branch.
+        #[builder(into)]
+        revision: Option<String>,
+        /// Commit message used for every batch. Defaults to
+        /// "Add files using upload-large-folder tool".
+        #[builder(into)]
+        commit_message: Option<String>,
+        /// Commit description used for every batch.
+        #[builder(into)]
+        commit_description: Option<String>,
+        /// Commit onto a PR instead of the branch.
+        #[builder(default)]
+        create_pr: bool,
+        /// When the repo is created (it is created if missing), whether it is private.
+        private: Option<bool>,
+        /// Include-only globs (repo-relative).
+        allow_patterns: Option<Vec<String>>,
+        /// Exclude globs (repo-relative), appended to the built-in defaults.
+        ignore_patterns: Option<Vec<String>>,
+        /// Bound on concurrent classify/read tasks (reserved in v1; xet manages
+        /// upload parallelism internally). Defaults to available_parallelism()/2.
+        num_workers: Option<usize>,
+        /// Progress handler (aggregate + LargeFolderStatus events; no per-file).
+        #[builder(into)]
+        progress: Option<Progress>,
+    ) -> crate::error::HFResult<UploadLargeFolderReport> {
+        self.upload_large_folder_impl(UploadLargeFolderArgs {
+            folder_path,
+            path_in_repo,
+            revision,
+            commit_message,
+            commit_description,
+            create_pr,
+            private,
+            allow_patterns,
+            ignore_patterns,
+            num_workers,
+            progress,
+        })
+        .await
+    }
+}
+
+struct UploadLargeFolderArgs {
+    folder_path: PathBuf,
+    path_in_repo: Option<String>,
+    revision: Option<String>,
+    commit_message: Option<String>,
+    commit_description: Option<String>,
+    create_pr: bool,
+    private: Option<bool>,
+    allow_patterns: Option<Vec<String>>,
+    ignore_patterns: Option<Vec<String>>,
+    num_workers: Option<usize>,
+    progress: Option<Progress>,
+}
+
+impl<T: RepoType> HFRepository<T> {
+    async fn upload_large_folder_impl(
+        &self,
+        args: UploadLargeFolderArgs,
+    ) -> crate::error::HFResult<UploadLargeFolderReport> {
+        // num_workers is reserved for future concurrency tuning (xet manages its
+        // own upload parallelism in v1).
+        let _ = args.num_workers;
+
+        let revision = args.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION).to_string();
+        let commit_message = args
+            .commit_message
+            .unwrap_or_else(|| "Add files using upload-large-folder tool".to_string());
+
+        let folder = args.folder_path.canonicalize()?;
+        if !folder.is_dir() {
+            return Err(crate::error::HFError::InvalidParameter(format!(
+                "folder_path {} is not a directory",
+                folder.display()
+            )));
+        }
+
+        // Ensure the repo exists (create-if-missing), matching Python.
+        self.hf_client
+            .create_repository()
+            .repo_id(self.repo_path())
+            .repo_type(*self.repo_type())
+            .maybe_private(args.private)
+            .exist_ok(true)
+            .send()
+            .await?;
+
+        // Discover and seed.
+        let discovered =
+            discover_files(&folder, args.path_in_repo.as_deref(), &args.allow_patterns, &args.ignore_patterns)?;
+        let total_files = discovered.len();
+
+        let mut items: Vec<Item> = Vec::with_capacity(discovered.len());
+        for (repo_path, file_path) in discovered {
+            let paths = get_local_upload_paths(&folder, &repo_path)?;
+            let meta = read_upload_metadata(&paths)?;
+            let (size, sample) = crate::repository::upload::read_size_and_sample(&AddSource::File(file_path.clone()))?;
+            items.push(Item {
+                paths,
+                file_path,
+                meta,
+                sample,
+                size,
+            });
+        }
+
+        let total_bytes: u64 = items.iter().map(|i| i.size).sum();
+        args.progress.emit(UploadEvent::Start {
+            total_files,
+            total_bytes,
+        });
+
+        self.classify_items(&mut items, &revision).await?;
+
+        let mut sizer = CommitChunkSizer::new();
+        let mut bytes_uploaded = 0u64;
+        let mut dedup_bytes_saved = 0u64;
+        self.upload_lfs_stage(
+            &mut items,
+            &revision,
+            &args.progress,
+            &mut sizer,
+            &mut bytes_uploaded,
+            &mut dedup_bytes_saved,
+        )
+        .await?;
+
+        let commits = self
+            .commit_stage(
+                &mut items,
+                &commit_message,
+                args.commit_description.as_deref(),
+                &revision,
+                args.create_pr,
+                &args.progress,
+                &mut sizer,
+            )
+            .await?;
+
+        let files_uploaded_lfs = items.iter().filter(|i| i.meta.upload_mode.as_deref() == Some("lfs")).count();
+        let files_ignored = items.iter().filter(|i| i.meta.should_ignore == Some(true)).count();
+        let files_committed_inline = items
+            .iter()
+            .filter(|i| i.meta.is_committed && i.meta.upload_mode.as_deref() == Some("regular"))
+            .count();
+
+        args.progress.emit(UploadEvent::Complete);
+
+        Ok(UploadLargeFolderReport {
+            commits,
+            total_files,
+            files_uploaded_lfs,
+            files_committed_inline,
+            files_ignored,
+            bytes_uploaded,
+            dedup_bytes_saved,
+        })
+    }
+
+    /// Classify every item whose mode is unknown via `/preupload` (batched 256),
+    /// persisting `upload_mode` to the cache. Empty files are always regular.
+    async fn classify_items(&self, items: &mut [Item], revision: &str) -> crate::error::HFResult<()> {
+        let to_classify: Vec<usize> = items
+            .iter()
+            .enumerate()
+            .filter(|(_, i)| seed_stage(&i.meta) == WorkStage::Classify)
+            .map(|(idx, _)| idx)
+            .collect();
+
+        for chunk in to_classify.chunks(256) {
+            let payload: Vec<(&str, u64, &[u8])> = chunk
+                .iter()
+                .map(|&idx| (items[idx].paths.path_in_repo.as_str(), items[idx].size, items[idx].sample.as_slice()))
+                .collect();
+            let modes = self
+                .fetch_upload_modes(&self.repo_path(), self.repo_type.plural(), revision, &payload)
+                .await?;
+            for &idx in chunk {
+                let path = items[idx].paths.path_in_repo.clone();
+                let mode = if items[idx].size == 0 {
+                    "regular".to_string()
+                } else {
+                    modes.get(&path).cloned().unwrap_or_else(|| "regular".to_string())
+                };
+                items[idx].meta.upload_mode = Some(mode);
+                items[idx].meta.save(&items[idx].paths)?;
+            }
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn upload_lfs_stage(
+        &self,
+        items: &mut [Item],
+        revision: &str,
+        progress: &Option<Progress>,
+        sizer: &mut CommitChunkSizer,
+        bytes_uploaded: &mut u64,
+        dedup_bytes_saved: &mut u64,
+    ) -> crate::error::HFResult<()> {
+        loop {
+            let batch: Vec<usize> = items
+                .iter()
+                .enumerate()
+                .filter(|(_, i)| seed_stage(&i.meta) == WorkStage::PreuploadLfs)
+                .map(|(idx, _)| idx)
+                .take(sizer.target().min(256))
+                .collect();
+            if batch.is_empty() {
+                break;
+            }
+
+            let files_in: Vec<(String, AddSource)> = batch
+                .iter()
+                .map(|&idx| (items[idx].paths.path_in_repo.clone(), AddSource::File(items[idx].file_path.clone())))
+                .collect();
+
+            let result = self.xet_upload_batch(&files_in, revision, progress).await?;
+            *bytes_uploaded += result.transfer_bytes;
+            *dedup_bytes_saved += result.dedup_bytes_saved;
+
+            let by_path: std::collections::HashMap<String, (String, u64)> =
+                result.files.into_iter().map(|f| (f.path_in_repo, (f.oid, f.size))).collect();
+
+            for &idx in &batch {
+                let path = items[idx].paths.path_in_repo.clone();
+                if let Some((oid, _size)) = by_path.get(&path) {
+                    items[idx].meta.sha256 = Some(oid.clone());
+                    items[idx].meta.is_uploaded = true;
+                    items[idx].meta.save(&items[idx].paths)?;
+                }
+            }
+            self.emit_status(items, *bytes_uploaded, *dedup_bytes_saved, progress);
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn commit_stage(
+        &self,
+        items: &mut [Item],
+        commit_message: &str,
+        commit_description: Option<&str>,
+        revision: &str,
+        create_pr: bool,
+        progress: &Option<Progress>,
+        sizer: &mut CommitChunkSizer,
+    ) -> crate::error::HFResult<Vec<crate::repository::CommitInfo>> {
+        let mut commits = Vec::new();
+        loop {
+            let batch: Vec<usize> = items
+                .iter()
+                .enumerate()
+                .filter(|(_, i)| seed_stage(&i.meta) == WorkStage::Commit)
+                .map(|(idx, _)| idx)
+                .take(sizer.target())
+                .collect();
+            if batch.is_empty() {
+                break;
+            }
+
+            let mut adds: Vec<ResolvedAdd> = Vec::with_capacity(batch.len());
+            for &idx in &batch {
+                let path = items[idx].paths.path_in_repo.clone();
+                if items[idx].meta.upload_mode.as_deref() == Some("lfs") {
+                    let oid = items[idx].meta.sha256.clone().ok_or_else(|| {
+                        crate::error::HFError::Other(format!("missing oid for uploaded lfs file {path}"))
+                    })?;
+                    adds.push(ResolvedAdd::Lfs {
+                        path_in_repo: path,
+                        oid,
+                        size: items[idx].size,
+                    });
+                } else {
+                    adds.push(ResolvedAdd::Inline {
+                        path_in_repo: path,
+                        source: AddSource::File(items[idx].file_path.clone()),
+                    });
+                }
+            }
+
+            let start = std::time::Instant::now();
+            let info = self
+                .commit_resolved_operations(
+                    &adds,
+                    &[],
+                    commit_message,
+                    commit_description,
+                    revision,
+                    create_pr,
+                    None,
+                    progress,
+                )
+                .await;
+            let duration = start.elapsed().as_secs_f64();
+
+            match info {
+                Ok(info) => {
+                    for &idx in &batch {
+                        items[idx].meta.is_committed = true;
+                        items[idx].meta.save(&items[idx].paths)?;
+                    }
+                    sizer.update(true, batch.len(), duration);
+                    commits.push(info);
+                },
+                Err(e) => {
+                    sizer.update(false, batch.len(), duration);
+                    return Err(e);
+                },
+            }
+        }
+        Ok(commits)
+    }
+
+    fn emit_status(&self, items: &[Item], bytes_uploaded: u64, dedup_bytes_saved: u64, progress: &Option<Progress>) {
+        let files_total = items.len();
+        let upload_mode_known = items.iter().filter(|i| i.meta.upload_mode.is_some()).count();
+        let lfs_total = items.iter().filter(|i| i.meta.upload_mode.as_deref() == Some("lfs")).count();
+        let preuploaded = items.iter().filter(|i| i.meta.is_uploaded).count();
+        let committed = items.iter().filter(|i| i.meta.is_committed).count();
+        let ignored = items.iter().filter(|i| i.meta.should_ignore == Some(true)).count();
+        let hashed = items.iter().filter(|i| i.meta.sha256.is_some()).count();
+        progress.emit(UploadEvent::LargeFolderStatus {
+            files_total,
+            hashed,
+            upload_mode_known,
+            lfs_total,
+            preuploaded,
+            committed,
+            ignored,
+            bytes_uploaded,
+            dedup_bytes_saved,
+        });
+    }
 }
 
 #[cfg(test)]

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -483,6 +483,45 @@ impl<T: RepoType> HFRepository<T> {
     }
 }
 
+#[cfg(feature = "blocking")]
+#[bon]
+impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
+    /// Blocking counterpart of [`HFRepository::upload_large_folder`]. See the async
+    /// method for parameters and behavior.
+    #[builder(finish_fn = send, derive(Debug, Clone))]
+    pub fn upload_large_folder(
+        &self,
+        folder_path: PathBuf,
+        #[builder(into)] path_in_repo: Option<String>,
+        #[builder(into)] revision: Option<String>,
+        #[builder(into)] commit_message: Option<String>,
+        #[builder(into)] commit_description: Option<String>,
+        #[builder(default)] create_pr: bool,
+        private: Option<bool>,
+        allow_patterns: Option<Vec<String>>,
+        ignore_patterns: Option<Vec<String>>,
+        num_workers: Option<usize>,
+        #[builder(into)] progress: Option<crate::progress::Progress>,
+    ) -> crate::error::HFResult<UploadLargeFolderReport> {
+        self.runtime.block_on(
+            self.inner
+                .upload_large_folder()
+                .folder_path(folder_path)
+                .maybe_path_in_repo(path_in_repo)
+                .maybe_revision(revision)
+                .maybe_commit_message(commit_message)
+                .maybe_commit_description(commit_description)
+                .create_pr(create_pr)
+                .maybe_private(private)
+                .maybe_allow_patterns(allow_patterns)
+                .maybe_ignore_patterns(ignore_patterns)
+                .maybe_num_workers(num_workers)
+                .maybe_progress(progress)
+                .send(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod discovery_tests {
     use super::*;

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -26,15 +26,17 @@ pub struct UploadLargeFolderReport {
     pub commits: Vec<CommitInfo>,
     /// Total files in the upload set after filtering.
     pub total_files: usize,
-    /// Files uploaded via xet/lfs.
+    /// Files classified as lfs (uploaded via xet). Counts lfs-mode files in the set, including ones skipped on a
+    /// resumed run because they were already uploaded.
     pub files_uploaded_lfs: usize,
     /// Files committed inline (regular).
     pub files_committed_inline: usize,
     /// Files the Hub told us to ignore.
     pub files_ignored: usize,
-    /// Bytes actually transferred to CAS (post-dedup).
+    /// Bytes actually transferred to CAS (post-dedup) during THIS invocation. A resumed run skips already-uploaded
+    /// files, so this counts only the current run's transfers.
     pub bytes_uploaded: u64,
-    /// Bytes saved by xet deduplication.
+    /// Bytes saved by xet deduplication during this invocation.
     pub dedup_bytes_saved: u64,
 }
 
@@ -341,6 +343,9 @@ impl<T: RepoType> HFRepository<T> {
         dedup_bytes_saved: &mut u64,
     ) -> crate::error::HFResult<()> {
         loop {
+            // lfs upload batches reuse the commit sizer's current target (initially 50);
+            // the sizer is only grown/shrunk by commit feedback, so before any commit this
+            // is effectively a fixed 50-file (capped at 256) preupload batch.
             let batch: Vec<usize> = items
                 .iter()
                 .enumerate()

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -1,0 +1,5 @@
+//! `HFRepository::upload_large_folder`: resumable, xet-optimized upload of a
+//! large local folder as a sequence of adaptively-batched commits.
+
+pub mod local_folder;
+pub mod pipeline;

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -4,9 +4,14 @@
 pub mod local_folder;
 pub mod pipeline;
 
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
 
 use bon::bon;
+use futures::future::FutureExt;
+use futures::stream::{FuturesUnordered, StreamExt};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use crate::constants;
 use crate::error::{HFError, HFResult};
@@ -16,7 +21,9 @@ use crate::repository::upload::ResolvedAdd;
 use crate::repository::upload_large_folder::local_folder::{
     LocalUploadFileMetadata, LocalUploadFilePaths, get_local_upload_paths, read_upload_metadata,
 };
-use crate::repository::upload_large_folder::pipeline::{MAX_COMMIT_FILES, WorkStage, seed_stage};
+use crate::repository::upload_large_folder::pipeline::{
+    CommitReady, PipelineConfig, StatusCounters, TimedBatchBuffer, WorkStage, seed_stage, sleep_or_pending,
+};
 use crate::repository::{CommitInfo, HFRepository, RepoType};
 
 /// Summary returned by [`HFRepository::upload_large_folder`].
@@ -125,6 +132,72 @@ struct Item {
     size: u64,
 }
 
+/// An lfs file awaiting upload, buffered in the producer's staging buffer.
+struct StagedLfs {
+    idx: usize,
+    path_in_repo: String,
+    file_path: PathBuf,
+    size: u64,
+}
+
+/// Result of classifying one file via `/preupload`.
+struct ClassifyResult {
+    idx: usize,
+    upload_mode: String,
+    should_ignore: bool,
+}
+
+/// Output of one producer work future.
+enum WorkOutput {
+    Classified(Vec<ClassifyResult>),
+    Uploaded {
+        entries: Vec<StagedLfs>,
+        result: crate::xet::XetBatchResult,
+    },
+}
+
+impl<T: RepoType> HFRepository<T> {
+    /// Classify a chunk of files via `/preupload`. Owns its input; borrows only
+    /// `&self` + `revision`. Empty files are forced to "regular".
+    async fn classify_chunk(
+        &self,
+        input: Vec<(usize, String, u64, Vec<u8>)>,
+        revision: &str,
+    ) -> HFResult<WorkOutput> {
+        let repo_path = self.repo_path();
+        let api_segment = self.repo_type.plural();
+        let payload: Vec<(&str, u64, &[u8])> =
+            input.iter().map(|(_, path, size, sample)| (path.as_str(), *size, sample.as_slice())).collect();
+        let infos = self.fetch_upload_modes(&repo_path, api_segment, revision, &payload).await?;
+        let results = input
+            .iter()
+            .map(|(idx, path, size, _)| {
+                let info = infos.get(path);
+                let should_ignore = info.map(|i| i.should_ignore).unwrap_or(false);
+                let upload_mode = if *size == 0 {
+                    "regular".to_string()
+                } else {
+                    info.map(|i| i.upload_mode.clone()).unwrap_or_else(|| "regular".to_string())
+                };
+                ClassifyResult { idx: *idx, upload_mode, should_ignore }
+            })
+            .collect();
+        Ok(WorkOutput::Classified(results))
+    }
+
+    /// Upload one batch of lfs files as a single xet `UploadCommit`. Suppresses
+    /// per-batch progress (passes `&None`); the orchestrator emits aggregate
+    /// `LargeFolderStatus` instead.
+    async fn upload_chunk(&self, entries: Vec<StagedLfs>, revision: &str) -> HFResult<WorkOutput> {
+        let files_in: Vec<(String, AddSource)> = entries
+            .iter()
+            .map(|e| (e.path_in_repo.clone(), AddSource::File(e.file_path.clone())))
+            .collect();
+        let result = self.xet_upload_batch(&files_in, revision, &None).await?;
+        Ok(WorkOutput::Uploaded { entries, result })
+    }
+}
+
 #[bon]
 impl<T: RepoType> HFRepository<T> {
     /// Upload a large local folder to this repository as a sequence of resumable,
@@ -158,8 +231,10 @@ impl<T: RepoType> HFRepository<T> {
         allow_patterns: Option<Vec<String>>,
         /// Exclude globs (repo-relative), appended to the built-in defaults.
         ignore_patterns: Option<Vec<String>>,
-        /// Bound on concurrent classify/read tasks (reserved in v1; xet manages
-        /// upload parallelism internally). Defaults to available_parallelism()/2.
+        /// Max concurrent producer tasks — `/preupload` classify requests and
+        /// in-flight xet `UploadCommit` batches share this single budget. The Hub
+        /// committer is always single-flight and is not counted here. Defaults to
+        /// `available_parallelism() / 2` (min 1).
         num_workers: Option<usize>,
         /// Progress handler (aggregate + LargeFolderStatus events; no per-file).
         #[builder(into)]
@@ -201,10 +276,6 @@ impl<T: RepoType> HFRepository<T> {
         &self,
         args: UploadLargeFolderArgs,
     ) -> crate::error::HFResult<UploadLargeFolderReport> {
-        // num_workers is reserved for future concurrency tuning (xet manages its
-        // own upload parallelism in v1).
-        let _ = args.num_workers;
-
         let revision = args.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION).to_string();
         let commit_message = args
             .commit_message
@@ -228,7 +299,6 @@ impl<T: RepoType> HFRepository<T> {
             .send()
             .await?;
 
-        // Discover and seed.
         let discovered =
             discover_files(&folder, args.path_in_repo.as_deref(), &args.allow_patterns, &args.ignore_patterns)?;
         let total_files = discovered.len();
@@ -238,44 +308,33 @@ impl<T: RepoType> HFRepository<T> {
             let paths = get_local_upload_paths(&folder, &repo_path)?;
             let meta = read_upload_metadata(&paths)?;
             let (size, sample) = crate::repository::upload::read_size_and_sample(&AddSource::File(file_path.clone()))?;
-            items.push(Item {
-                paths,
-                file_path,
-                meta,
-                sample,
-                size,
-            });
+            items.push(Item { paths, file_path, meta, sample, size });
         }
 
         let total_bytes: u64 = items.iter().map(|i| i.size).sum();
-        args.progress.emit(UploadEvent::Start {
-            total_files,
-            total_bytes,
-        });
+        args.progress.emit(UploadEvent::Start { total_files, total_bytes });
 
-        self.classify_items(&mut items, &revision).await?;
+        let config = PipelineConfig::from_num_workers(args.num_workers);
+        let counters = StatusCounters::default();
+        let (tx, rx) = unbounded_channel::<CommitReady>();
 
-        let mut bytes_uploaded = 0u64;
-        let mut dedup_bytes_saved = 0u64;
-        self.upload_lfs_stage(
-            &mut items,
+        let producer = self.run_producer(&mut items, tx, &revision, &config, &counters, &args.progress);
+        let committer = self.run_committer(
+            rx,
+            &commit_message,
+            args.commit_description.as_deref(),
             &revision,
+            args.create_pr,
+            &config,
+            &counters,
             &args.progress,
-            &mut bytes_uploaded,
-            &mut dedup_bytes_saved,
-        )
-        .await?;
+        );
 
-        let commits = self
-            .commit_stage(
-                &mut items,
-                &commit_message,
-                args.commit_description.as_deref(),
-                &revision,
-                args.create_pr,
-                &args.progress,
-            )
-            .await?;
+        let ((), (commits, committed_indices)) = tokio::try_join!(producer, committer)?;
+
+        for idx in committed_indices {
+            items[idx].meta.is_committed = true;
+        }
 
         let files_uploaded_lfs = items.iter().filter(|i| i.meta.upload_mode.as_deref() == Some("lfs")).count();
         let files_ignored = items.iter().filter(|i| i.meta.should_ignore == Some(true)).count();
@@ -292,190 +351,299 @@ impl<T: RepoType> HFRepository<T> {
             files_uploaded_lfs,
             files_committed_inline,
             files_ignored,
-            bytes_uploaded,
-            dedup_bytes_saved,
+            bytes_uploaded: counters.bytes_uploaded.load(Ordering::Relaxed),
+            dedup_bytes_saved: counters.dedup_bytes_saved.load(Ordering::Relaxed),
         })
     }
 
-    /// Classify every item whose mode is unknown via `/preupload` (batched 256),
-    /// persisting `upload_mode` and the Hub's `should_ignore` flag to the cache.
-    /// Empty files are always regular. Files the Hub marks ignored are recorded
-    /// so [`seed_stage`] routes them to `Done` (never uploaded or committed).
-    async fn classify_items(&self, items: &mut [Item], revision: &str) -> crate::error::HFResult<()> {
-        let to_classify: Vec<usize> = items
-            .iter()
-            .enumerate()
-            .filter(|(_, i)| seed_stage(&i.meta) == WorkStage::Classify)
-            .map(|(idx, _)| idx)
-            .collect();
-
-        for chunk in to_classify.chunks(256) {
-            let payload: Vec<(&str, u64, &[u8])> = chunk
-                .iter()
-                .map(|&idx| (items[idx].paths.path_in_repo.as_str(), items[idx].size, items[idx].sample.as_slice()))
-                .collect();
-            let infos = self
-                .fetch_upload_modes(&self.repo_path(), self.repo_type.plural(), revision, &payload)
-                .await?;
-            for &idx in chunk {
-                let path = items[idx].paths.path_in_repo.clone();
-                let info = infos.get(&path);
-                let should_ignore = info.map(|i| i.should_ignore).unwrap_or(false);
-                let mode = if items[idx].size == 0 {
-                    "regular".to_string()
-                } else {
-                    info.map(|i| i.upload_mode.clone()).unwrap_or_else(|| "regular".to_string())
-                };
-                items[idx].meta.upload_mode = Some(mode);
-                items[idx].meta.should_ignore = Some(should_ignore);
-                items[idx].meta.save(&items[idx].paths)?;
-            }
-        }
-        Ok(())
-    }
-
-    async fn upload_lfs_stage(
+    /// Producer half of the pipeline. Owns `items`, classifies + uploads with a
+    /// shared `num_workers`-bounded concurrency budget, and streams per-file
+    /// `CommitReady` messages to the committer. Closes the channel when done.
+    async fn run_producer(
         &self,
         items: &mut [Item],
+        tx: UnboundedSender<CommitReady>,
         revision: &str,
+        config: &PipelineConfig,
+        counters: &StatusCounters,
         progress: &Option<Progress>,
-        bytes_uploaded: &mut u64,
-        dedup_bytes_saved: &mut u64,
-    ) -> crate::error::HFResult<()> {
+    ) -> HFResult<()> {
+        counters.files_total.store(items.len(), Ordering::Relaxed);
+
+        let mut to_classify: VecDeque<usize> = VecDeque::new();
+        let mut staging: TimedBatchBuffer<StagedLfs> = TimedBatchBuffer::new();
+
+        // Initial routing from persisted metadata (resume + already-classified).
+        for idx in 0..items.len() {
+            match seed_stage(&items[idx].meta) {
+                WorkStage::Done => {
+                    if items[idx].meta.should_ignore == Some(true) {
+                        counters.ignored.fetch_add(1, Ordering::Relaxed);
+                    }
+                    if items[idx].meta.is_committed {
+                        counters.committed.fetch_add(1, Ordering::Relaxed);
+                    }
+                },
+                WorkStage::Classify => to_classify.push_back(idx),
+                WorkStage::PreuploadLfs => {
+                    counters.upload_mode_known.fetch_add(1, Ordering::Relaxed);
+                    counters.lfs_total.fetch_add(1, Ordering::Relaxed);
+                    staging.push(StagedLfs {
+                        idx,
+                        path_in_repo: items[idx].paths.path_in_repo.clone(),
+                        file_path: items[idx].file_path.clone(),
+                        size: items[idx].size,
+                    });
+                },
+                WorkStage::Commit => {
+                    counters.upload_mode_known.fetch_add(1, Ordering::Relaxed);
+                    if items[idx].meta.upload_mode.as_deref() == Some("lfs") {
+                        counters.lfs_total.fetch_add(1, Ordering::Relaxed);
+                        counters.preuploaded.fetch_add(1, Ordering::Relaxed);
+                        let oid = items[idx].meta.sha256.clone().ok_or_else(|| {
+                            HFError::Other(format!("missing oid for uploaded lfs file {}", items[idx].paths.path_in_repo))
+                        })?;
+                        let _ = tx.send(CommitReady {
+                            idx,
+                            resolved: ResolvedAdd::Lfs {
+                                path_in_repo: items[idx].paths.path_in_repo.clone(),
+                                oid,
+                                size: items[idx].size,
+                            },
+                            paths: items[idx].paths.clone(),
+                            meta: items[idx].meta.clone(),
+                        });
+                    } else {
+                        let _ = tx.send(CommitReady {
+                            idx,
+                            resolved: ResolvedAdd::Inline {
+                                path_in_repo: items[idx].paths.path_in_repo.clone(),
+                                source: AddSource::File(items[idx].file_path.clone()),
+                            },
+                            paths: items[idx].paths.clone(),
+                            meta: items[idx].meta.clone(),
+                        });
+                    }
+                },
+            }
+        }
+        pipeline::emit_status(counters, progress);
+
+        // Element type (a boxed Send future) is inferred from the `.boxed()` pushes below.
+        let mut inflight = FuturesUnordered::new();
+        let mut classify_inflight: usize = 0usize;
+        let mut stale_flush_pending = false;
+
         loop {
-            let batch: Vec<usize> = items
-                .iter()
-                .enumerate()
-                .filter(|(_, i)| seed_stage(&i.meta) == WorkStage::PreuploadLfs)
-                .map(|(idx, _)| idx)
-                .take(256)
-                .collect();
-            if batch.is_empty() {
+            // Dispatch classify work while under the shared concurrency cap.
+            while inflight.len() < config.num_workers && !to_classify.is_empty() {
+                let mut chunk_input: Vec<(usize, String, u64, Vec<u8>)> = Vec::with_capacity(256);
+                for _ in 0..256 {
+                    match to_classify.pop_front() {
+                        Some(idx) => chunk_input.push((
+                            idx,
+                            items[idx].paths.path_in_repo.clone(),
+                            items[idx].size,
+                            items[idx].sample.clone(),
+                        )),
+                        None => break,
+                    }
+                }
+                classify_inflight += 1;
+                inflight.push(self.classify_chunk(chunk_input, revision).boxed());
+            }
+
+            let classify_done = to_classify.is_empty() && classify_inflight == 0;
+
+            // Dispatch upload batches: full, drained, or a pending stale flush.
+            while inflight.len() < config.num_workers
+                && !staging.is_empty()
+                && (staging.len() >= config.xet_batch_size || classify_done || stale_flush_pending)
+            {
+                let batch = staging.take(config.xet_batch_size);
+                inflight.push(self.upload_chunk(batch, revision).boxed());
+                stale_flush_pending = false;
+            }
+
+            if inflight.is_empty() && to_classify.is_empty() && staging.is_empty() {
                 break;
             }
 
-            let files_in: Vec<(String, AddSource)> = batch
-                .iter()
-                .map(|&idx| (items[idx].paths.path_in_repo.clone(), AddSource::File(items[idx].file_path.clone())))
-                .collect();
-
-            let result = self.xet_upload_batch(&files_in, revision, progress).await?;
-            *bytes_uploaded += result.transfer_bytes;
-            *dedup_bytes_saved += result.dedup_bytes_saved;
-
-            let by_path: std::collections::HashMap<String, (String, u64)> =
-                result.files.into_iter().map(|f| (f.path_in_repo, (f.oid, f.size))).collect();
-
-            for &idx in &batch {
-                let path = items[idx].paths.path_in_repo.clone();
-                match by_path.get(&path) {
-                    Some((oid, _size)) => {
-                        items[idx].meta.sha256 = Some(oid.clone());
-                        items[idx].meta.is_uploaded = true;
-                        items[idx].meta.save(&items[idx].paths)?;
-                    },
-                    None => {
-                        return Err(crate::error::HFError::Other(format!(
-                            "xet_upload_batch returned no result for {path}; aborting to avoid an upload loop"
-                        )));
-                    },
+            let deadline = staging.deadline(config.max_xet_batch_wait);
+            tokio::select! {
+                maybe = inflight.next(), if !inflight.is_empty() => {
+                    let out = maybe.expect("guarded by !inflight.is_empty()")?;
+                    match out {
+                        WorkOutput::Classified(results) => {
+                            classify_inflight -= 1;
+                            for r in results {
+                                items[r.idx].meta.upload_mode = Some(r.upload_mode.clone());
+                                items[r.idx].meta.should_ignore = Some(r.should_ignore);
+                                items[r.idx].meta.save(&items[r.idx].paths)?;
+                                counters.upload_mode_known.fetch_add(1, Ordering::Relaxed);
+                                if r.should_ignore {
+                                    counters.ignored.fetch_add(1, Ordering::Relaxed);
+                                } else if r.upload_mode == "lfs" {
+                                    counters.lfs_total.fetch_add(1, Ordering::Relaxed);
+                                    staging.push(StagedLfs {
+                                        idx: r.idx,
+                                        path_in_repo: items[r.idx].paths.path_in_repo.clone(),
+                                        file_path: items[r.idx].file_path.clone(),
+                                        size: items[r.idx].size,
+                                    });
+                                } else {
+                                    let _ = tx.send(CommitReady {
+                                        idx: r.idx,
+                                        resolved: ResolvedAdd::Inline {
+                                            path_in_repo: items[r.idx].paths.path_in_repo.clone(),
+                                            source: AddSource::File(items[r.idx].file_path.clone()),
+                                        },
+                                        paths: items[r.idx].paths.clone(),
+                                        meta: items[r.idx].meta.clone(),
+                                    });
+                                }
+                            }
+                            pipeline::emit_status(counters, progress);
+                        },
+                        WorkOutput::Uploaded { entries, result } => {
+                            let by_path: HashMap<String, String> =
+                                result.files.into_iter().map(|f| (f.path_in_repo, f.oid)).collect();
+                            counters.bytes_uploaded.fetch_add(result.transfer_bytes, Ordering::Relaxed);
+                            counters.dedup_bytes_saved.fetch_add(result.dedup_bytes_saved, Ordering::Relaxed);
+                            for e in entries {
+                                let oid = by_path.get(&e.path_in_repo).cloned().ok_or_else(|| {
+                                    HFError::Other(format!(
+                                        "xet_upload_batch returned no result for {}; aborting to avoid an upload loop",
+                                        e.path_in_repo
+                                    ))
+                                })?;
+                                items[e.idx].meta.sha256 = Some(oid.clone());
+                                items[e.idx].meta.is_uploaded = true;
+                                items[e.idx].meta.save(&items[e.idx].paths)?;
+                                counters.hashed.fetch_add(1, Ordering::Relaxed);
+                                counters.preuploaded.fetch_add(1, Ordering::Relaxed);
+                                let _ = tx.send(CommitReady {
+                                    idx: e.idx,
+                                    resolved: ResolvedAdd::Lfs { path_in_repo: e.path_in_repo, oid, size: e.size },
+                                    paths: items[e.idx].paths.clone(),
+                                    meta: items[e.idx].meta.clone(),
+                                });
+                            }
+                            pipeline::emit_status(counters, progress);
+                        },
+                    }
+                }
+                _ = sleep_or_pending(deadline), if !staging.is_empty() => {
+                    stale_flush_pending = true;
                 }
             }
-            self.emit_status(items, *bytes_uploaded, *dedup_bytes_saved, progress);
         }
+
+        drop(tx);
         Ok(())
     }
 
-    async fn commit_stage(
+    /// Commit up to `max` buffered files in one Hub commit, persist `is_committed`
+    /// for each on success, and record committed indices. Single call site of
+    /// `commit_resolved_operations` in the pipeline.
+    #[allow(clippy::too_many_arguments)]
+    async fn commit_batch(
         &self,
-        items: &mut [Item],
+        buffer: &mut TimedBatchBuffer<CommitReady>,
+        max: usize,
         commit_message: &str,
         commit_description: Option<&str>,
         revision: &str,
         create_pr: bool,
+        counters: &StatusCounters,
         progress: &Option<Progress>,
-    ) -> crate::error::HFResult<Vec<crate::repository::CommitInfo>> {
-        let mut commits = Vec::new();
-        loop {
-            let batch: Vec<usize> = items
-                .iter()
-                .enumerate()
-                .filter(|(_, i)| seed_stage(&i.meta) == WorkStage::Commit)
-                .map(|(idx, _)| idx)
-                .take(MAX_COMMIT_FILES)
-                .collect();
-            if batch.is_empty() {
-                break;
-            }
-
-            let mut adds: Vec<ResolvedAdd> = Vec::with_capacity(batch.len());
-            for &idx in &batch {
-                let path = items[idx].paths.path_in_repo.clone();
-                if items[idx].meta.upload_mode.as_deref() == Some("lfs") {
-                    let oid = items[idx].meta.sha256.clone().ok_or_else(|| {
-                        crate::error::HFError::Other(format!("missing oid for uploaded lfs file {path}"))
-                    })?;
-                    adds.push(ResolvedAdd::Lfs {
-                        path_in_repo: path,
-                        oid,
-                        size: items[idx].size,
-                    });
-                } else {
-                    adds.push(ResolvedAdd::Inline {
-                        path_in_repo: path,
-                        source: AddSource::File(items[idx].file_path.clone()),
-                    });
-                }
-            }
-
-            let info = self
-                .commit_resolved_operations(
-                    &adds,
-                    &[],
-                    commit_message,
-                    commit_description,
-                    revision,
-                    create_pr,
-                    None,
-                    progress,
-                )
-                .await;
-
-            match info {
-                Ok(info) => {
-                    for &idx in &batch {
-                        items[idx].meta.is_committed = true;
-                        items[idx].meta.save(&items[idx].paths)?;
-                    }
-                    commits.push(info);
-                },
-                Err(e) => {
-                    return Err(e);
-                },
-            }
+        commits: &mut Vec<CommitInfo>,
+        committed_indices: &mut Vec<usize>,
+    ) -> HFResult<()> {
+        let batch = buffer.take(max);
+        if batch.is_empty() {
+            return Ok(());
         }
-        Ok(commits)
+        let mut adds: Vec<ResolvedAdd> = Vec::with_capacity(batch.len());
+        let mut metas: Vec<(usize, LocalUploadFilePaths, LocalUploadFileMetadata)> = Vec::with_capacity(batch.len());
+        for cr in batch {
+            adds.push(cr.resolved);
+            metas.push((cr.idx, cr.paths, cr.meta));
+        }
+        let info = self
+            .commit_resolved_operations(&adds, &[], commit_message, commit_description, revision, create_pr, None, progress)
+            .await?;
+        for (idx, paths, mut meta) in metas {
+            meta.is_committed = true;
+            meta.save(&paths)?;
+            committed_indices.push(idx);
+            counters.committed.fetch_add(1, Ordering::Relaxed);
+        }
+        commits.push(info);
+        pipeline::emit_status(counters, progress);
+        Ok(())
     }
 
-    fn emit_status(&self, items: &[Item], bytes_uploaded: u64, dedup_bytes_saved: u64, progress: &Option<Progress>) {
-        let files_total = items.len();
-        let upload_mode_known = items.iter().filter(|i| i.meta.upload_mode.is_some()).count();
-        let lfs_total = items.iter().filter(|i| i.meta.upload_mode.as_deref() == Some("lfs")).count();
-        let preuploaded = items.iter().filter(|i| i.meta.is_uploaded).count();
-        let committed = items.iter().filter(|i| i.meta.is_committed).count();
-        let ignored = items.iter().filter(|i| i.meta.should_ignore == Some(true)).count();
-        let hashed = items.iter().filter(|i| i.meta.sha256.is_some()).count();
-        progress.emit(UploadEvent::LargeFolderStatus {
-            files_total,
-            hashed,
-            upload_mode_known,
-            lfs_total,
-            preuploaded,
-            committed,
-            ignored,
-            bytes_uploaded,
-            dedup_bytes_saved,
-        });
+    /// Committer half of the pipeline. Single task, single-flight commits. Drains
+    /// `rx` into a `TimedBatchBuffer`; commits on full / stale (oldest-anchored) /
+    /// channel-close.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_committer(
+        &self,
+        mut rx: UnboundedReceiver<CommitReady>,
+        commit_message: &str,
+        commit_description: Option<&str>,
+        revision: &str,
+        create_pr: bool,
+        config: &PipelineConfig,
+        counters: &StatusCounters,
+        progress: &Option<Progress>,
+    ) -> HFResult<(Vec<CommitInfo>, Vec<usize>)> {
+        let mut buffer: TimedBatchBuffer<CommitReady> = TimedBatchBuffer::new();
+        let mut commits: Vec<CommitInfo> = Vec::new();
+        let mut committed_indices: Vec<usize> = Vec::new();
+        let mut closed = false;
+
+        loop {
+            while buffer.len() >= config.max_commit_files {
+                self.commit_batch(
+                    &mut buffer, config.max_commit_files, commit_message, commit_description, revision,
+                    create_pr, counters, progress, &mut commits, &mut committed_indices,
+                )
+                .await?;
+            }
+
+            if closed {
+                if buffer.is_empty() {
+                    break;
+                }
+                self.commit_batch(
+                    &mut buffer, config.max_commit_files, commit_message, commit_description, revision,
+                    create_pr, counters, progress, &mut commits, &mut committed_indices,
+                )
+                .await?;
+                continue;
+            }
+
+            let deadline = buffer.deadline(config.max_commit_wait);
+            tokio::select! {
+                recv = rx.recv() => {
+                    match recv {
+                        Some(cr) => buffer.push(cr),
+                        None => closed = true,
+                    }
+                }
+                _ = sleep_or_pending(deadline), if !buffer.is_empty() => {
+                    self.commit_batch(
+                        &mut buffer, config.max_commit_files, commit_message, commit_description, revision,
+                        create_pr, counters, progress, &mut commits, &mut committed_indices,
+                    )
+                    .await?;
+                }
+            }
+        }
+
+        Ok((commits, committed_indices))
     }
 }
 
@@ -496,6 +664,8 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         private: Option<bool>,
         allow_patterns: Option<Vec<String>>,
         ignore_patterns: Option<Vec<String>>,
+        /// Max concurrent producer tasks (classify + xet upload batches); the Hub
+        /// committer is always single-flight. Defaults to `available_parallelism() / 2`.
         num_workers: Option<usize>,
         #[builder(into)] progress: Option<crate::progress::Progress>,
     ) -> crate::error::HFResult<UploadLargeFolderReport> {

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -366,10 +366,17 @@ impl<T: RepoType> HFRepository<T> {
 
             for &idx in &batch {
                 let path = items[idx].paths.path_in_repo.clone();
-                if let Some((oid, _size)) = by_path.get(&path) {
-                    items[idx].meta.sha256 = Some(oid.clone());
-                    items[idx].meta.is_uploaded = true;
-                    items[idx].meta.save(&items[idx].paths)?;
+                match by_path.get(&path) {
+                    Some((oid, _size)) => {
+                        items[idx].meta.sha256 = Some(oid.clone());
+                        items[idx].meta.is_uploaded = true;
+                        items[idx].meta.save(&items[idx].paths)?;
+                    },
+                    None => {
+                        return Err(crate::error::HFError::Other(format!(
+                            "xet_upload_batch returned no result for {path}; aborting to avoid an upload loop"
+                        )));
+                    },
                 }
             }
             self.emit_status(items, *bytes_uploaded, *dedup_bytes_saved, progress);

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -16,7 +16,7 @@ use crate::repository::upload::ResolvedAdd;
 use crate::repository::upload_large_folder::local_folder::{
     LocalUploadFileMetadata, LocalUploadFilePaths, get_local_upload_paths, read_upload_metadata,
 };
-use crate::repository::upload_large_folder::pipeline::{CommitChunkSizer, WorkStage, seed_stage};
+use crate::repository::upload_large_folder::pipeline::{MAX_COMMIT_FILES, WorkStage, seed_stage};
 use crate::repository::{CommitInfo, HFRepository, RepoType};
 
 /// Summary returned by [`HFRepository::upload_large_folder`].
@@ -255,14 +255,12 @@ impl<T: RepoType> HFRepository<T> {
 
         self.classify_items(&mut items, &revision).await?;
 
-        let mut sizer = CommitChunkSizer::new();
         let mut bytes_uploaded = 0u64;
         let mut dedup_bytes_saved = 0u64;
         self.upload_lfs_stage(
             &mut items,
             &revision,
             &args.progress,
-            &mut sizer,
             &mut bytes_uploaded,
             &mut dedup_bytes_saved,
         )
@@ -276,7 +274,6 @@ impl<T: RepoType> HFRepository<T> {
                 &revision,
                 args.create_pr,
                 &args.progress,
-                &mut sizer,
             )
             .await?;
 
@@ -337,26 +334,21 @@ impl<T: RepoType> HFRepository<T> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn upload_lfs_stage(
         &self,
         items: &mut [Item],
         revision: &str,
         progress: &Option<Progress>,
-        sizer: &mut CommitChunkSizer,
         bytes_uploaded: &mut u64,
         dedup_bytes_saved: &mut u64,
     ) -> crate::error::HFResult<()> {
         loop {
-            // lfs upload batches reuse the commit sizer's current target (initially 50);
-            // the sizer is only grown/shrunk by commit feedback, so before any commit this
-            // is effectively a fixed 50-file (capped at 256) preupload batch.
             let batch: Vec<usize> = items
                 .iter()
                 .enumerate()
                 .filter(|(_, i)| seed_stage(&i.meta) == WorkStage::PreuploadLfs)
                 .map(|(idx, _)| idx)
-                .take(sizer.target().min(256))
+                .take(256)
                 .collect();
             if batch.is_empty() {
                 break;
@@ -394,7 +386,6 @@ impl<T: RepoType> HFRepository<T> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn commit_stage(
         &self,
         items: &mut [Item],
@@ -403,7 +394,6 @@ impl<T: RepoType> HFRepository<T> {
         revision: &str,
         create_pr: bool,
         progress: &Option<Progress>,
-        sizer: &mut CommitChunkSizer,
     ) -> crate::error::HFResult<Vec<crate::repository::CommitInfo>> {
         let mut commits = Vec::new();
         loop {
@@ -412,7 +402,7 @@ impl<T: RepoType> HFRepository<T> {
                 .enumerate()
                 .filter(|(_, i)| seed_stage(&i.meta) == WorkStage::Commit)
                 .map(|(idx, _)| idx)
-                .take(sizer.target())
+                .take(MAX_COMMIT_FILES)
                 .collect();
             if batch.is_empty() {
                 break;
@@ -438,7 +428,6 @@ impl<T: RepoType> HFRepository<T> {
                 }
             }
 
-            let start = std::time::Instant::now();
             let info = self
                 .commit_resolved_operations(
                     &adds,
@@ -451,7 +440,6 @@ impl<T: RepoType> HFRepository<T> {
                     progress,
                 )
                 .await;
-            let duration = start.elapsed().as_secs_f64();
 
             match info {
                 Ok(info) => {
@@ -459,11 +447,9 @@ impl<T: RepoType> HFRepository<T> {
                         items[idx].meta.is_committed = true;
                         items[idx].meta.save(&items[idx].paths)?;
                     }
-                    sizer.update(true, batch.len(), duration);
                     commits.push(info);
                 },
                 Err(e) => {
-                    sizer.update(false, batch.len(), duration);
                     return Err(e);
                 },
             }

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -3,3 +3,117 @@
 
 pub mod local_folder;
 pub mod pipeline;
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{HFError, HFResult};
+use crate::repository::files::matches_any_glob;
+
+const DEFAULT_IGNORE_PATTERNS: &[&str] = &[
+    ".git",
+    ".git/**",
+    "**/.git/**",
+    ".cache/huggingface",
+    ".cache/huggingface/**",
+    "**/.cache/huggingface/**",
+];
+
+/// Recursively collects `(repo_path, absolute_file_path)` for every file under
+/// `folder` that survives the default ignores, the user allow/ignore globs, and
+/// is then prefixed by `path_in_repo`. Repo paths use `/` separators.
+fn discover_files(
+    folder: &Path,
+    path_in_repo: Option<&str>,
+    allow_patterns: &Option<Vec<String>>,
+    ignore_patterns: &Option<Vec<String>>,
+) -> HFResult<Vec<(String, PathBuf)>> {
+    let mut default_and_user_ignores: Vec<String> = DEFAULT_IGNORE_PATTERNS.iter().map(|s| s.to_string()).collect();
+    if let Some(user) = ignore_patterns {
+        default_and_user_ignores.extend(user.iter().cloned());
+    }
+
+    let prefix = path_in_repo.map(|p| p.trim_matches('/').to_string()).filter(|p| !p.is_empty());
+
+    let mut out = Vec::new();
+    collect(folder, folder, allow_patterns, &default_and_user_ignores, prefix.as_deref(), &mut out)?;
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+fn collect(
+    root: &Path,
+    current: &Path,
+    allow: &Option<Vec<String>>,
+    ignore: &[String],
+    prefix: Option<&str>,
+    out: &mut Vec<(String, PathBuf)>,
+) -> HFResult<()> {
+    for entry in std::fs::read_dir(current)? {
+        let entry = entry?;
+        let path = entry.path();
+        let meta = entry.metadata()?;
+        if meta.is_dir() {
+            collect(root, &path, allow, ignore, prefix, out)?;
+        } else if meta.is_file() {
+            let relative = path.strip_prefix(root).map_err(|e| {
+                HFError::InvalidParameter(format!("path {} not under {}: {e}", path.display(), root.display()))
+            })?;
+            let rel: String = relative
+                .components()
+                .filter_map(|c| match c {
+                    std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("/");
+
+            if let Some(allow) = allow
+                && !matches_any_glob(allow, &rel)
+            {
+                continue;
+            }
+            if matches_any_glob(ignore, &rel) {
+                continue;
+            }
+
+            let repo_path = match prefix {
+                Some(p) => format!("{p}/{rel}"),
+                None => rel,
+            };
+            out.push((repo_path, path));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod discovery_tests {
+    use super::*;
+
+    fn write(root: &std::path::Path, rel: &str, bytes: &[u8]) {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, bytes).unwrap();
+    }
+
+    #[test]
+    fn discovers_files_applies_default_and_user_ignores_and_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.txt", b"1");
+        write(dir.path(), "sub/b.bin", b"22");
+        write(dir.path(), ".git/config", b"x");
+        write(dir.path(), ".cache/huggingface/upload/a.txt.metadata", b"meta");
+        write(dir.path(), "skip.me", b"z");
+
+        let found = discover_files(dir.path(), Some("models"), &None, &Some(vec!["*.me".to_string()])).unwrap();
+
+        let repo_paths: std::collections::BTreeSet<String> =
+            found.iter().map(|(repo_path, _)| repo_path.clone()).collect();
+        assert_eq!(
+            repo_paths,
+            ["models/a.txt".to_string(), "models/sub/b.bin".to_string()]
+                .into_iter()
+                .collect()
+        );
+    }
+}

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -301,7 +301,9 @@ impl<T: RepoType> HFRepository<T> {
     }
 
     /// Classify every item whose mode is unknown via `/preupload` (batched 256),
-    /// persisting `upload_mode` to the cache. Empty files are always regular.
+    /// persisting `upload_mode` and the Hub's `should_ignore` flag to the cache.
+    /// Empty files are always regular. Files the Hub marks ignored are recorded
+    /// so [`seed_stage`] routes them to `Done` (never uploaded or committed).
     async fn classify_items(&self, items: &mut [Item], revision: &str) -> crate::error::HFResult<()> {
         let to_classify: Vec<usize> = items
             .iter()
@@ -315,17 +317,20 @@ impl<T: RepoType> HFRepository<T> {
                 .iter()
                 .map(|&idx| (items[idx].paths.path_in_repo.as_str(), items[idx].size, items[idx].sample.as_slice()))
                 .collect();
-            let modes = self
+            let infos = self
                 .fetch_upload_modes(&self.repo_path(), self.repo_type.plural(), revision, &payload)
                 .await?;
             for &idx in chunk {
                 let path = items[idx].paths.path_in_repo.clone();
+                let info = infos.get(&path);
+                let should_ignore = info.map(|i| i.should_ignore).unwrap_or(false);
                 let mode = if items[idx].size == 0 {
                     "regular".to_string()
                 } else {
-                    modes.get(&path).cloned().unwrap_or_else(|| "regular".to_string())
+                    info.map(|i| i.upload_mode.clone()).unwrap_or_else(|| "regular".to_string())
                 };
                 items[idx].meta.upload_mode = Some(mode);
+                items[idx].meta.should_ignore = Some(should_ignore);
                 items[idx].meta.save(&items[idx].paths)?;
             }
         }

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -7,7 +7,27 @@ pub mod pipeline;
 use std::path::{Path, PathBuf};
 
 use crate::error::{HFError, HFResult};
+use crate::repository::CommitInfo;
 use crate::repository::files::matches_any_glob;
+
+/// Summary returned by [`HFRepository::upload_large_folder`].
+#[derive(Debug, Clone, Default)]
+pub struct UploadLargeFolderReport {
+    /// The commits created, in the order they were committed (one per batch).
+    pub commits: Vec<CommitInfo>,
+    /// Total files in the upload set after filtering.
+    pub total_files: usize,
+    /// Files uploaded via xet/lfs.
+    pub files_uploaded_lfs: usize,
+    /// Files committed inline (regular).
+    pub files_committed_inline: usize,
+    /// Files the Hub told us to ignore.
+    pub files_ignored: usize,
+    /// Logical content bytes uploaded to CAS (before dedup).
+    pub bytes_uploaded: u64,
+    /// Bytes saved by xet deduplication.
+    pub dedup_bytes_saved: u64,
+}
 
 const DEFAULT_IGNORE_PATTERNS: &[&str] = &[
     ".git",

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -394,6 +394,8 @@ impl<T: RepoType> HFRepository<T> {
                     }
                     if item.meta.is_committed {
                         counters.committed.fetch_add(1, Ordering::Relaxed);
+                        counters.skipped.fetch_add(1, Ordering::Relaxed);
+                        counters.skipped_bytes.fetch_add(item.size, Ordering::Relaxed);
                     }
                 },
                 WorkStage::Classify => to_classify.push_back(idx),
@@ -412,11 +414,11 @@ impl<T: RepoType> HFRepository<T> {
                     if item.meta.upload_mode.as_deref() == Some("lfs") {
                         counters.lfs_total.fetch_add(1, Ordering::Relaxed);
                         counters.preuploaded.fetch_add(1, Ordering::Relaxed);
+                        // Already uploaded to CAS in a previous run — its upload was reused.
+                        counters.skipped.fetch_add(1, Ordering::Relaxed);
+                        counters.skipped_bytes.fetch_add(item.size, Ordering::Relaxed);
                         let oid = item.meta.sha256.clone().ok_or_else(|| {
-                            HFError::Other(format!(
-                                "missing oid for uploaded lfs file {}",
-                                item.paths.path_in_repo
-                            ))
+                            HFError::Other(format!("missing oid for uploaded lfs file {}", item.paths.path_in_repo))
                         })?;
                         let _ = tx.send(CommitReady {
                             idx,

--- a/hf-hub/src/repository/upload_large_folder/mod.rs
+++ b/hf-hub/src/repository/upload_large_folder/mod.rs
@@ -22,7 +22,8 @@ use crate::repository::upload_large_folder::local_folder::{
     LocalUploadFileMetadata, LocalUploadFilePaths, get_local_upload_paths, read_upload_metadata,
 };
 use crate::repository::upload_large_folder::pipeline::{
-    CommitReady, PipelineConfig, StatusCounters, TimedBatchBuffer, WorkStage, seed_stage, sleep_or_pending,
+    CommitReady, PREUPLOAD_BATCH_SIZE, PipelineConfig, StatusCounters, TimedBatchBuffer, WorkStage, seed_stage,
+    sleep_or_pending,
 };
 use crate::repository::{CommitInfo, HFRepository, RepoType};
 
@@ -159,15 +160,13 @@ enum WorkOutput {
 impl<T: RepoType> HFRepository<T> {
     /// Classify a chunk of files via `/preupload`. Owns its input; borrows only
     /// `&self` + `revision`. Empty files are forced to "regular".
-    async fn classify_chunk(
-        &self,
-        input: Vec<(usize, String, u64, Vec<u8>)>,
-        revision: &str,
-    ) -> HFResult<WorkOutput> {
+    async fn classify_chunk(&self, input: Vec<(usize, String, u64, Vec<u8>)>, revision: &str) -> HFResult<WorkOutput> {
         let repo_path = self.repo_path();
         let api_segment = self.repo_type.plural();
-        let payload: Vec<(&str, u64, &[u8])> =
-            input.iter().map(|(_, path, size, sample)| (path.as_str(), *size, sample.as_slice())).collect();
+        let payload: Vec<(&str, u64, &[u8])> = input
+            .iter()
+            .map(|(_, path, size, sample)| (path.as_str(), *size, sample.as_slice()))
+            .collect();
         let infos = self.fetch_upload_modes(&repo_path, api_segment, revision, &payload).await?;
         let results = input
             .iter()
@@ -179,7 +178,11 @@ impl<T: RepoType> HFRepository<T> {
                 } else {
                     info.map(|i| i.upload_mode.clone()).unwrap_or_else(|| "regular".to_string())
                 };
-                ClassifyResult { idx: *idx, upload_mode, should_ignore }
+                ClassifyResult {
+                    idx: *idx,
+                    upload_mode,
+                    should_ignore,
+                }
             })
             .collect();
         Ok(WorkOutput::Classified(results))
@@ -308,11 +311,20 @@ impl<T: RepoType> HFRepository<T> {
             let paths = get_local_upload_paths(&folder, &repo_path)?;
             let meta = read_upload_metadata(&paths)?;
             let (size, sample) = crate::repository::upload::read_size_and_sample(&AddSource::File(file_path.clone()))?;
-            items.push(Item { paths, file_path, meta, sample, size });
+            items.push(Item {
+                paths,
+                file_path,
+                meta,
+                sample,
+                size,
+            });
         }
 
         let total_bytes: u64 = items.iter().map(|i| i.size).sum();
-        args.progress.emit(UploadEvent::Start { total_files, total_bytes });
+        args.progress.emit(UploadEvent::Start {
+            total_files,
+            total_bytes,
+        });
 
         let config = PipelineConfig::from_num_workers(args.num_workers);
         let counters = StatusCounters::default();
@@ -374,13 +386,13 @@ impl<T: RepoType> HFRepository<T> {
         let mut staging: TimedBatchBuffer<StagedLfs> = TimedBatchBuffer::new();
 
         // Initial routing from persisted metadata (resume + already-classified).
-        for idx in 0..items.len() {
-            match seed_stage(&items[idx].meta) {
+        for (idx, item) in items.iter().enumerate() {
+            match seed_stage(&item.meta) {
                 WorkStage::Done => {
-                    if items[idx].meta.should_ignore == Some(true) {
+                    if item.meta.should_ignore == Some(true) {
                         counters.ignored.fetch_add(1, Ordering::Relaxed);
                     }
-                    if items[idx].meta.is_committed {
+                    if item.meta.is_committed {
                         counters.committed.fetch_add(1, Ordering::Relaxed);
                     }
                 },
@@ -390,38 +402,41 @@ impl<T: RepoType> HFRepository<T> {
                     counters.lfs_total.fetch_add(1, Ordering::Relaxed);
                     staging.push(StagedLfs {
                         idx,
-                        path_in_repo: items[idx].paths.path_in_repo.clone(),
-                        file_path: items[idx].file_path.clone(),
-                        size: items[idx].size,
+                        path_in_repo: item.paths.path_in_repo.clone(),
+                        file_path: item.file_path.clone(),
+                        size: item.size,
                     });
                 },
                 WorkStage::Commit => {
                     counters.upload_mode_known.fetch_add(1, Ordering::Relaxed);
-                    if items[idx].meta.upload_mode.as_deref() == Some("lfs") {
+                    if item.meta.upload_mode.as_deref() == Some("lfs") {
                         counters.lfs_total.fetch_add(1, Ordering::Relaxed);
                         counters.preuploaded.fetch_add(1, Ordering::Relaxed);
-                        let oid = items[idx].meta.sha256.clone().ok_or_else(|| {
-                            HFError::Other(format!("missing oid for uploaded lfs file {}", items[idx].paths.path_in_repo))
+                        let oid = item.meta.sha256.clone().ok_or_else(|| {
+                            HFError::Other(format!(
+                                "missing oid for uploaded lfs file {}",
+                                item.paths.path_in_repo
+                            ))
                         })?;
                         let _ = tx.send(CommitReady {
                             idx,
                             resolved: ResolvedAdd::Lfs {
-                                path_in_repo: items[idx].paths.path_in_repo.clone(),
+                                path_in_repo: item.paths.path_in_repo.clone(),
                                 oid,
-                                size: items[idx].size,
+                                size: item.size,
                             },
-                            paths: items[idx].paths.clone(),
-                            meta: items[idx].meta.clone(),
+                            paths: item.paths.clone(),
+                            meta: item.meta.clone(),
                         });
                     } else {
                         let _ = tx.send(CommitReady {
                             idx,
                             resolved: ResolvedAdd::Inline {
-                                path_in_repo: items[idx].paths.path_in_repo.clone(),
-                                source: AddSource::File(items[idx].file_path.clone()),
+                                path_in_repo: item.paths.path_in_repo.clone(),
+                                source: AddSource::File(item.file_path.clone()),
                             },
-                            paths: items[idx].paths.clone(),
-                            meta: items[idx].meta.clone(),
+                            paths: item.paths.clone(),
+                            meta: item.meta.clone(),
                         });
                     }
                 },
@@ -437,8 +452,8 @@ impl<T: RepoType> HFRepository<T> {
         loop {
             // Dispatch classify work while under the shared concurrency cap.
             while inflight.len() < config.num_workers && !to_classify.is_empty() {
-                let mut chunk_input: Vec<(usize, String, u64, Vec<u8>)> = Vec::with_capacity(256);
-                for _ in 0..256 {
+                let mut chunk_input: Vec<(usize, String, u64, Vec<u8>)> = Vec::with_capacity(PREUPLOAD_BATCH_SIZE);
+                for _ in 0..PREUPLOAD_BATCH_SIZE {
                     match to_classify.pop_front() {
                         Some(idx) => chunk_input.push((
                             idx,
@@ -571,7 +586,16 @@ impl<T: RepoType> HFRepository<T> {
             metas.push((cr.idx, cr.paths, cr.meta));
         }
         let info = self
-            .commit_resolved_operations(&adds, &[], commit_message, commit_description, revision, create_pr, None, progress)
+            .commit_resolved_operations(
+                &adds,
+                &[],
+                commit_message,
+                commit_description,
+                revision,
+                create_pr,
+                None,
+                progress,
+            )
             .await?;
         for (idx, paths, mut meta) in metas {
             meta.is_committed = true;
@@ -607,8 +631,16 @@ impl<T: RepoType> HFRepository<T> {
         loop {
             while buffer.len() >= config.max_commit_files {
                 self.commit_batch(
-                    &mut buffer, config.max_commit_files, commit_message, commit_description, revision,
-                    create_pr, counters, progress, &mut commits, &mut committed_indices,
+                    &mut buffer,
+                    config.max_commit_files,
+                    commit_message,
+                    commit_description,
+                    revision,
+                    create_pr,
+                    counters,
+                    progress,
+                    &mut commits,
+                    &mut committed_indices,
                 )
                 .await?;
             }
@@ -618,8 +650,16 @@ impl<T: RepoType> HFRepository<T> {
                     break;
                 }
                 self.commit_batch(
-                    &mut buffer, config.max_commit_files, commit_message, commit_description, revision,
-                    create_pr, counters, progress, &mut commits, &mut committed_indices,
+                    &mut buffer,
+                    config.max_commit_files,
+                    commit_message,
+                    commit_description,
+                    revision,
+                    create_pr,
+                    counters,
+                    progress,
+                    &mut commits,
+                    &mut committed_indices,
                 )
                 .await?;
                 continue;

--- a/hf-hub/src/repository/upload_large_folder/pipeline.rs
+++ b/hf-hub/src/repository/upload_large_folder/pipeline.rs
@@ -1,3 +1,67 @@
 //! Pipeline primitives for `upload_large_folder`: adaptive commit batching,
 //! per-file stage seeding, shared-session xet upload batches, and the
 //! single-flight committer.
+
+const COMMIT_SIZE_SCALE: [usize; 10] = [20, 50, 75, 100, 125, 200, 250, 400, 600, 1000];
+
+/// Adaptive commit-batch sizer mirroring Python's `COMMIT_SIZE_SCALE` logic.
+/// Starts at index 1 (= 50). Grows one step on a fast full commit, shrinks one
+/// step on failure, clamped to the scale bounds.
+pub(crate) struct CommitChunkSizer {
+    idx: usize,
+}
+
+impl CommitChunkSizer {
+    pub(crate) fn new() -> Self {
+        Self { idx: 1 }
+    }
+
+    pub(crate) fn target(&self) -> usize {
+        COMMIT_SIZE_SCALE[self.idx]
+    }
+
+    pub(crate) fn update(&mut self, success: bool, nb_items: usize, duration_secs: f64) {
+        if !success {
+            self.idx = self.idx.saturating_sub(1);
+        } else if nb_items >= COMMIT_SIZE_SCALE[self.idx] && duration_secs < 40.0 {
+            self.idx = (self.idx + 1).min(COMMIT_SIZE_SCALE.len() - 1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_sizer_grows_shrinks_clamps() {
+        let mut s = CommitChunkSizer::new();
+        assert_eq!(s.target(), 50); // index 1
+
+        // Fast, full commit -> grow.
+        s.update(true, 50, 10.0);
+        assert_eq!(s.target(), 75);
+
+        // Slow commit -> no growth.
+        s.update(true, 75, 45.0);
+        assert_eq!(s.target(), 75);
+
+        // Failure -> shrink.
+        s.update(false, 0, 1.0);
+        assert_eq!(s.target(), 50);
+
+        // Shrink never underflows past index 0.
+        let mut low = CommitChunkSizer::new();
+        low.update(false, 0, 1.0); // -> index 0 (20)
+        low.update(false, 0, 1.0); // stays at 0
+        assert_eq!(low.target(), 20);
+
+        // Grow clamps at the top (1000).
+        let mut high = CommitChunkSizer::new();
+        for _ in 0..50 {
+            let t = high.target();
+            high.update(true, t, 1.0);
+        }
+        assert_eq!(high.target(), 1000);
+    }
+}

--- a/hf-hub/src/repository/upload_large_folder/pipeline.rs
+++ b/hf-hub/src/repository/upload_large_folder/pipeline.rs
@@ -1,0 +1,3 @@
+//! Pipeline primitives for `upload_large_folder`: adaptive commit batching,
+//! per-file stage seeding, shared-session xet upload batches, and the
+//! single-flight committer.

--- a/hf-hub/src/repository/upload_large_folder/pipeline.rs
+++ b/hf-hub/src/repository/upload_large_folder/pipeline.rs
@@ -2,6 +2,8 @@
 //! per-file stage seeding, shared-session xet upload batches, and the
 //! single-flight committer.
 
+use crate::repository::upload_large_folder::local_folder::LocalUploadFileMetadata;
+
 const COMMIT_SIZE_SCALE: [usize; 10] = [20, 50, 75, 100, 125, 200, 250, 400, 600, 1000];
 
 /// Adaptive commit-batch sizer mirroring Python's `COMMIT_SIZE_SCALE` logic.
@@ -29,9 +31,69 @@ impl CommitChunkSizer {
     }
 }
 
+/// The next stage of work for a file, derived from its persisted metadata.
+/// Tolerant of both Rust- and Python-written caches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkStage {
+    Classify,
+    PreuploadLfs,
+    Commit,
+    Done,
+}
+
+pub(crate) fn seed_stage(meta: &LocalUploadFileMetadata) -> WorkStage {
+    if meta.is_committed || meta.should_ignore == Some(true) {
+        WorkStage::Done
+    } else if meta.upload_mode.is_none() {
+        WorkStage::Classify
+    } else if meta.upload_mode.as_deref() == Some("lfs") && !meta.is_uploaded {
+        WorkStage::PreuploadLfs
+    } else {
+        WorkStage::Commit
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::repository::upload_large_folder::local_folder::LocalUploadFileMetadata;
+
+    fn meta_with(
+        mode: Option<&str>,
+        sha: Option<&str>,
+        uploaded: bool,
+        committed: bool,
+        ignore: Option<bool>,
+    ) -> LocalUploadFileMetadata {
+        let mut m = LocalUploadFileMetadata::new(10);
+        m.upload_mode = mode.map(str::to_string);
+        m.sha256 = sha.map(str::to_string);
+        m.is_uploaded = uploaded;
+        m.is_committed = committed;
+        m.should_ignore = ignore;
+        m
+    }
+
+    #[test]
+    fn seed_stage_routing() {
+        // Fresh: no mode -> classify.
+        assert!(matches!(seed_stage(&meta_with(None, None, false, false, None)), WorkStage::Classify));
+        // Python wrote sha256 but no mode yet -> still classify.
+        assert!(matches!(seed_stage(&meta_with(None, Some("ab"), false, false, None)), WorkStage::Classify));
+        // lfs, not uploaded -> preupload.
+        assert!(matches!(
+            seed_stage(&meta_with(Some("lfs"), Some("ab"), false, false, None)),
+            WorkStage::PreuploadLfs
+        ));
+        // lfs, uploaded, not committed -> commit.
+        assert!(matches!(seed_stage(&meta_with(Some("lfs"), Some("ab"), true, false, None)), WorkStage::Commit));
+        // regular, not committed -> commit.
+        assert!(matches!(seed_stage(&meta_with(Some("regular"), None, false, false, None)), WorkStage::Commit));
+        // committed -> done.
+        assert!(matches!(seed_stage(&meta_with(Some("regular"), None, false, true, None)), WorkStage::Done));
+        // should_ignore -> done.
+        assert!(matches!(seed_stage(&meta_with(Some("regular"), None, false, false, Some(true))), WorkStage::Done));
+    }
 
     #[test]
     fn chunk_sizer_grows_shrinks_clamps() {

--- a/hf-hub/src/repository/upload_large_folder/pipeline.rs
+++ b/hf-hub/src/repository/upload_large_folder/pipeline.rs
@@ -15,6 +15,8 @@ use crate::repository::upload_large_folder::local_folder::{LocalUploadFileMetada
 /// Max files queued into a single xet `UploadCommit` before it is dispatched.
 /// Larger batches improve client-side dedup and reduce finalize round-trips.
 pub(crate) const XET_BATCH_SIZE: usize = 1024;
+/// Files per `/preupload` classify request (Hub endpoint limit).
+pub(crate) const PREUPLOAD_BATCH_SIZE: usize = 256;
 /// Max files in a single Hub commit (validated top of Python's old scale).
 pub(crate) const MAX_COMMIT_FILES: usize = 1000;
 /// How long the oldest queued lfs file may wait before a partial xet batch is
@@ -258,5 +260,4 @@ mod tests {
         let auto = PipelineConfig::from_num_workers(None);
         assert!(auto.num_workers >= 1);
     }
-
 }

--- a/hf-hub/src/repository/upload_large_folder/pipeline.rs
+++ b/hf-hub/src/repository/upload_large_folder/pipeline.rs
@@ -135,6 +135,10 @@ pub(crate) struct StatusCounters {
     pub ignored: AtomicUsize,
     pub bytes_uploaded: AtomicU64,
     pub dedup_bytes_saved: AtomicU64,
+    /// Files whose upload/commit was reused from a previous run (resume-seeded).
+    pub skipped: AtomicUsize,
+    /// Logical bytes of the skipped files.
+    pub skipped_bytes: AtomicU64,
 }
 
 /// Emit a `LargeFolderStatus` snapshot from the current counter values.
@@ -149,6 +153,8 @@ pub(crate) fn emit_status(counters: &StatusCounters, progress: &Option<Progress>
         ignored: counters.ignored.load(Ordering::Relaxed),
         bytes_uploaded: counters.bytes_uploaded.load(Ordering::Relaxed),
         dedup_bytes_saved: counters.dedup_bytes_saved.load(Ordering::Relaxed),
+        skipped: counters.skipped.load(Ordering::Relaxed),
+        skipped_bytes: counters.skipped_bytes.load(Ordering::Relaxed),
     });
 }
 

--- a/hf-hub/src/repository/upload_large_folder/pipeline.rs
+++ b/hf-hub/src/repository/upload_large_folder/pipeline.rs
@@ -1,33 +1,61 @@
-//! Pipeline primitives for `upload_large_folder`: adaptive commit batching,
-//! per-file stage seeding, shared-session xet upload batches, and the
-//! single-flight committer.
+//! Pipeline primitives for `upload_large_folder`: tuning config, the
+//! oldest-item-anchored batch buffer, per-file commit-ready messages, shared
+//! progress counters, and per-file stage seeding.
 
-use crate::repository::upload_large_folder::local_folder::LocalUploadFileMetadata;
+use std::collections::VecDeque;
+use std::time::Duration;
 
-const COMMIT_SIZE_SCALE: [usize; 10] = [20, 50, 75, 100, 125, 200, 250, 400, 600, 1000];
+use tokio::time::Instant;
 
-/// Adaptive commit-batch sizer mirroring Python's `COMMIT_SIZE_SCALE` logic.
-/// Starts at index 1 (= 50). Grows one step on a fast full commit, shrinks one
-/// step on failure, clamped to the scale bounds.
-pub(crate) struct CommitChunkSizer {
-    idx: usize,
+use crate::progress::{EmitEvent, Progress, UploadEvent};
+use crate::repository::upload::ResolvedAdd;
+use crate::repository::upload_large_folder::local_folder::{LocalUploadFileMetadata, LocalUploadFilePaths};
+
+/// Max files queued into a single xet `UploadCommit` before it is dispatched.
+/// Larger batches improve client-side dedup and reduce finalize round-trips.
+pub(crate) const XET_BATCH_SIZE: usize = 1024;
+/// Max files in a single Hub commit (validated top of Python's old scale).
+pub(crate) const MAX_COMMIT_FILES: usize = 1000;
+/// How long the oldest queued lfs file may wait before a partial xet batch is
+/// dispatched anyway.
+pub(crate) const MAX_XET_BATCH_WAIT: Duration = Duration::from_secs(300);
+/// How long the oldest queued commit-ready file may wait before a partial commit.
+pub(crate) const MAX_COMMIT_WAIT: Duration = Duration::from_secs(300);
+
+/// Tuning for one `upload_large_folder` run. Production builds it from
+/// `num_workers`; tests construct it directly with tiny timeouts.
+#[derive(Debug, Clone)]
+pub(crate) struct PipelineConfig {
+    pub num_workers: usize,
+    pub xet_batch_size: usize,
+    pub max_commit_files: usize,
+    pub max_xet_batch_wait: Duration,
+    pub max_commit_wait: Duration,
 }
 
-impl CommitChunkSizer {
-    pub(crate) fn new() -> Self {
-        Self { idx: 1 }
-    }
-
-    pub(crate) fn target(&self) -> usize {
-        COMMIT_SIZE_SCALE[self.idx]
-    }
-
-    pub(crate) fn update(&mut self, success: bool, nb_items: usize, duration_secs: f64) {
-        if !success {
-            self.idx = self.idx.saturating_sub(1);
-        } else if nb_items >= COMMIT_SIZE_SCALE[self.idx] && duration_secs < 40.0 {
-            self.idx = (self.idx + 1).min(COMMIT_SIZE_SCALE.len() - 1);
+impl PipelineConfig {
+    pub(crate) fn from_num_workers(num_workers: Option<usize>) -> Self {
+        Self {
+            num_workers: num_workers.map(|n| n.max(1)).unwrap_or_else(default_num_workers),
+            xet_batch_size: XET_BATCH_SIZE,
+            max_commit_files: MAX_COMMIT_FILES,
+            max_xet_batch_wait: MAX_XET_BATCH_WAIT,
+            max_commit_wait: MAX_COMMIT_WAIT,
         }
+    }
+}
+
+/// Default concurrency budget: half the available parallelism, at least 1.
+pub(crate) fn default_num_workers() -> usize {
+    (std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1) / 2).max(1)
+}
+
+/// Await `deadline` if present, else never resolve. Lets a `select!` arm be a
+/// no-op when no deadline is active (empty buffer).
+pub(crate) async fn sleep_or_pending(deadline: Option<Instant>) {
+    match deadline {
+        Some(d) => tokio::time::sleep_until(d).await,
+        None => std::future::pending::<()>().await,
     }
 }
 
@@ -96,34 +124,21 @@ mod tests {
     }
 
     #[test]
-    fn chunk_sizer_grows_shrinks_clamps() {
-        let mut s = CommitChunkSizer::new();
-        assert_eq!(s.target(), 50); // index 1
-
-        // Fast, full commit -> grow.
-        s.update(true, 50, 10.0);
-        assert_eq!(s.target(), 75);
-
-        // Slow commit -> no growth.
-        s.update(true, 75, 45.0);
-        assert_eq!(s.target(), 75);
-
-        // Failure -> shrink.
-        s.update(false, 0, 1.0);
-        assert_eq!(s.target(), 50);
-
-        // Shrink never underflows past index 0.
-        let mut low = CommitChunkSizer::new();
-        low.update(false, 0, 1.0); // -> index 0 (20)
-        low.update(false, 0, 1.0); // stays at 0
-        assert_eq!(low.target(), 20);
-
-        // Grow clamps at the top (1000).
-        let mut high = CommitChunkSizer::new();
-        for _ in 0..50 {
-            let t = high.target();
-            high.update(true, t, 1.0);
-        }
-        assert_eq!(high.target(), 1000);
+    fn default_num_workers_is_at_least_one() {
+        assert!(default_num_workers() >= 1);
     }
+
+    #[test]
+    fn pipeline_config_defaults() {
+        let cfg = PipelineConfig::from_num_workers(Some(4));
+        assert_eq!(cfg.num_workers, 4);
+        assert_eq!(cfg.xet_batch_size, 1024);
+        assert_eq!(cfg.max_commit_files, 1000);
+        assert_eq!(cfg.max_xet_batch_wait, std::time::Duration::from_secs(300));
+        assert_eq!(cfg.max_commit_wait, std::time::Duration::from_secs(300));
+
+        let auto = PipelineConfig::from_num_workers(None);
+        assert!(auto.num_workers >= 1);
+    }
+
 }

--- a/hf-hub/src/repository/upload_large_folder/pipeline.rs
+++ b/hf-hub/src/repository/upload_large_folder/pipeline.rs
@@ -3,6 +3,7 @@
 //! progress counters, and per-file stage seeding.
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tokio::time::Instant;
@@ -116,6 +117,47 @@ pub(crate) fn seed_stage(meta: &LocalUploadFileMetadata) -> WorkStage {
     } else {
         WorkStage::Commit
     }
+}
+
+/// Live progress counters shared between the producer and committer. Display
+/// only — the final report is computed from the post-join `items` scan plus the
+/// per-invocation byte counters here.
+#[derive(Default)]
+pub(crate) struct StatusCounters {
+    pub files_total: AtomicUsize,
+    pub hashed: AtomicUsize,
+    pub upload_mode_known: AtomicUsize,
+    pub lfs_total: AtomicUsize,
+    pub preuploaded: AtomicUsize,
+    pub committed: AtomicUsize,
+    pub ignored: AtomicUsize,
+    pub bytes_uploaded: AtomicU64,
+    pub dedup_bytes_saved: AtomicU64,
+}
+
+/// Emit a `LargeFolderStatus` snapshot from the current counter values.
+pub(crate) fn emit_status(counters: &StatusCounters, progress: &Option<Progress>) {
+    progress.emit(UploadEvent::LargeFolderStatus {
+        files_total: counters.files_total.load(Ordering::Relaxed),
+        hashed: counters.hashed.load(Ordering::Relaxed),
+        upload_mode_known: counters.upload_mode_known.load(Ordering::Relaxed),
+        lfs_total: counters.lfs_total.load(Ordering::Relaxed),
+        preuploaded: counters.preuploaded.load(Ordering::Relaxed),
+        committed: counters.committed.load(Ordering::Relaxed),
+        ignored: counters.ignored.load(Ordering::Relaxed),
+        bytes_uploaded: counters.bytes_uploaded.load(Ordering::Relaxed),
+        dedup_bytes_saved: counters.dedup_bytes_saved.load(Ordering::Relaxed),
+    });
+}
+
+/// One file, fully resolved and ready to be referenced in a Hub commit. Carries
+/// owned cache handles so the committer can persist `is_committed` immediately
+/// after a successful commit POST, without sharing the producer's `items`.
+pub(crate) struct CommitReady {
+    pub idx: usize,
+    pub resolved: ResolvedAdd,
+    pub paths: LocalUploadFilePaths,
+    pub meta: LocalUploadFileMetadata,
 }
 
 #[cfg(test)]

--- a/hf-hub/src/repository/upload_large_folder/pipeline.rs
+++ b/hf-hub/src/repository/upload_large_folder/pipeline.rs
@@ -59,6 +59,43 @@ pub(crate) async fn sleep_or_pending(deadline: Option<Instant>) {
     }
 }
 
+/// FIFO buffer that timestamps each item at push and exposes a flush deadline
+/// anchored to the OLDEST buffered item. The timer therefore does not run while
+/// the buffer is empty, and advances to the next-oldest item after a partial
+/// drain — so an item arriving after an idle gap gets its full wait window.
+pub(crate) struct TimedBatchBuffer<T> {
+    items: VecDeque<(Instant, T)>,
+}
+
+impl<T> TimedBatchBuffer<T> {
+    pub(crate) fn new() -> Self {
+        Self { items: VecDeque::new() }
+    }
+
+    pub(crate) fn push(&mut self, item: T) {
+        self.items.push_back((Instant::now(), item));
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Flush deadline = oldest item's enqueue instant + `max_wait`; `None` when empty.
+    pub(crate) fn deadline(&self, max_wait: Duration) -> Option<Instant> {
+        self.items.front().map(|(t, _)| *t + max_wait)
+    }
+
+    /// Drain up to `max` oldest items (fewer if the buffer is smaller).
+    pub(crate) fn take(&mut self, max: usize) -> Vec<T> {
+        let n = max.min(self.items.len());
+        self.items.drain(..n).map(|(_, item)| item).collect()
+    }
+}
+
 /// The next stage of work for a file, derived from its persisted metadata.
 /// Tolerant of both Rust- and Python-written caches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -121,6 +158,45 @@ mod tests {
         assert!(matches!(seed_stage(&meta_with(Some("regular"), None, false, true, None)), WorkStage::Done));
         // should_ignore -> done.
         assert!(matches!(seed_stage(&meta_with(Some("regular"), None, false, false, Some(true))), WorkStage::Done));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timed_buffer_deadline_anchored_to_oldest() {
+        let wait = std::time::Duration::from_secs(300);
+        let mut buf: TimedBatchBuffer<u32> = TimedBatchBuffer::new();
+        assert!(buf.is_empty());
+        assert!(buf.deadline(wait).is_none());
+
+        let t0 = tokio::time::Instant::now();
+        buf.push(1);
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf.deadline(wait), Some(t0 + wait));
+
+        tokio::time::advance(std::time::Duration::from_secs(100)).await;
+        buf.push(2); // enqueued 100s later
+        // Still anchored to item 1.
+        assert_eq!(buf.deadline(wait), Some(t0 + wait));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timed_buffer_take_advances_anchor() {
+        let wait = std::time::Duration::from_secs(300);
+        let mut buf: TimedBatchBuffer<u32> = TimedBatchBuffer::new();
+        let t0 = tokio::time::Instant::now();
+        buf.push(10);
+        tokio::time::advance(std::time::Duration::from_secs(100)).await;
+        buf.push(20);
+
+        let drained = buf.take(1);
+        assert_eq!(drained, vec![10]);
+        assert_eq!(buf.len(), 1);
+        // Anchor advanced to item 20 (enqueued at t0 + 100s).
+        assert_eq!(buf.deadline(wait), Some(t0 + std::time::Duration::from_secs(100) + wait));
+
+        let rest = buf.take(50);
+        assert_eq!(rest, vec![20]);
+        assert!(buf.is_empty());
+        assert!(buf.deadline(wait).is_none());
     }
 
     #[test]

--- a/hf-hub/src/xet.rs
+++ b/hf-hub/src/xet.rs
@@ -194,7 +194,6 @@ pub(crate) struct XetUploadedFile {
     pub path_in_repo: String,
     /// git sha256 oid (the LFS oid), produced by `Sha256Policy::Compute`.
     pub oid: String,
-    pub size: u64,
 }
 
 pub(crate) struct XetBatchResult {
@@ -707,19 +706,14 @@ impl<T: RepoType> HFRepository<T> {
         .await?;
 
         let mut files = Vec::with_capacity(files_in.len());
-        for ((path_in_repo, source), info) in files_in.iter().zip(&outcome.infos) {
+        for ((path_in_repo, _), info) in files_in.iter().zip(&outcome.infos) {
             let oid = info
                 .sha256()
                 .ok_or_else(|| HFError::Other(format!("xet did not return a sha256 for {path_in_repo}")))?
                 .to_string();
-            let size = info.file_size().unwrap_or_else(|| match source {
-                AddSource::Bytes(b) => b.len() as u64,
-                AddSource::File(p) => std::fs::metadata(p).map(|m| m.len()).unwrap_or(0),
-            });
             files.push(XetUploadedFile {
                 path_in_repo: path_in_repo.clone(),
                 oid,
-                size,
             });
         }
 

--- a/hf-hub/src/xet.rs
+++ b/hf-hub/src/xet.rs
@@ -179,6 +179,34 @@ pub(crate) struct XetBatchFile {
     pub filename: String,
 }
 
+/// Outcome of a xet upload commit: per-file infos (in input order) plus the
+/// batch's aggregate byte counts (for dedup reporting).
+pub(crate) struct XetUploadOutcome {
+    pub infos: Vec<XetFileInfo>,
+    /// Logical content bytes (pre-dedup).
+    pub total_bytes: u64,
+    /// Bytes actually transferred to CAS (post-dedup).
+    pub transfer_bytes: u64,
+}
+
+/// One file uploaded through xet for the large-folder path.
+pub(crate) struct XetUploadedFile {
+    pub path_in_repo: String,
+    /// git sha256 oid (the LFS oid), produced by `Sha256Policy::Compute`.
+    pub oid: String,
+    pub size: u64,
+}
+
+pub(crate) struct XetBatchResult {
+    pub files: Vec<XetUploadedFile>,
+    /// Logical content bytes for the batch (pre-dedup).
+    pub total_bytes: u64,
+    /// Bytes actually transferred to CAS (post-dedup).
+    pub transfer_bytes: u64,
+    /// total_bytes - transfer_bytes.
+    pub dedup_bytes_saved: u64,
+}
+
 /// Shared xet upload flow for both repositories and buckets.
 ///
 /// Callers build the xet write-token URL with the appropriate variant
@@ -193,7 +221,7 @@ async fn xet_upload_inner(
     not_found_ctx: crate::error::NotFoundContext,
     owner_kind: &'static str,
     progress: &Option<Progress>,
-) -> HFResult<Vec<XetFileInfo>> {
+) -> HFResult<XetUploadOutcome> {
     tracing::info!(owner_kind, owner = owner_id, "fetching xet write token");
     let conn = fetch_xet_connection_info(hf_client, &token_url, Some(owner_id), not_found_ctx).await?;
     tracing::info!(endpoint = conn.endpoint.as_str(), "xet write token obtained, building session");
@@ -340,7 +368,11 @@ async fn xet_upload_inner(
         xet_file_infos.push(metadata.xet_info.clone());
     }
 
-    Ok(xet_file_infos)
+    Ok(XetUploadOutcome {
+        infos: xet_file_infos,
+        total_bytes: results.progress.total_bytes_completed,
+        transfer_bytes: results.progress.total_transfer_bytes_completed,
+    })
 }
 
 impl<T: RepoType> HFRepository<T> {
@@ -640,7 +672,7 @@ impl<T: RepoType> HFRepository<T> {
     ) -> HFResult<Vec<XetFileInfo>> {
         let repo_path = self.repo_path();
         let token_url = repo_xet_token_url(&self.hf_client, "write", &repo_path, self.repo_type.plural(), revision);
-        xet_upload_inner(
+        Ok(xet_upload_inner(
             &self.hf_client,
             files,
             token_url,
@@ -649,7 +681,57 @@ impl<T: RepoType> HFRepository<T> {
             "repo",
             progress,
         )
-        .await
+        .await?
+        .infos)
+    }
+
+    /// Upload a batch of files through xet for `upload_large_folder`. Returns each
+    /// file's git-sha256 oid (computed during the xet clean pass) and size, plus
+    /// the batch's dedup metrics. Reuses the shared `XetSession` so dedup spans
+    /// across batches.
+    pub(crate) async fn xet_upload_batch(
+        &self,
+        files_in: &[(String, AddSource)],
+        revision: &str,
+        progress: &Option<Progress>,
+    ) -> HFResult<XetBatchResult> {
+        let token_url =
+            repo_xet_token_url(&self.hf_client, "write", &self.repo_path(), self.repo_type.plural(), revision);
+        let outcome = xet_upload_inner(
+            &self.hf_client,
+            files_in,
+            token_url,
+            &self.repo_path(),
+            crate::error::NotFoundContext::Repo,
+            "repo",
+            progress,
+        )
+        .await?;
+
+        let mut files = Vec::with_capacity(files_in.len());
+        for ((path_in_repo, source), info) in files_in.iter().zip(&outcome.infos) {
+            let oid = info
+                .sha256()
+                .ok_or_else(|| HFError::Other(format!("xet did not return a sha256 for {path_in_repo}")))?
+                .to_string();
+            let size = info.file_size().unwrap_or_else(|| match source {
+                AddSource::Bytes(b) => b.len() as u64,
+                AddSource::File(p) => std::fs::metadata(p).map(|m| m.len()).unwrap_or(0),
+            });
+            files.push(XetUploadedFile {
+                path_in_repo: path_in_repo.clone(),
+                oid,
+                size,
+            });
+        }
+
+        let dedup_bytes_saved = outcome.total_bytes.saturating_sub(outcome.transfer_bytes);
+        Ok(XetBatchResult {
+            files,
+            total_bytes: outcome.total_bytes,
+            transfer_bytes: outcome.transfer_bytes,
+            dedup_bytes_saved,
+        })
     }
 }
 
@@ -661,7 +743,7 @@ impl crate::buckets::HFBucket {
     ) -> HFResult<Vec<XetFileInfo>> {
         let bucket_id = self.bucket_id();
         let token_url = bucket_xet_token_url(&self.hf_client, "write", &bucket_id);
-        xet_upload_inner(
+        Ok(xet_upload_inner(
             &self.hf_client,
             files,
             token_url,
@@ -670,7 +752,8 @@ impl crate::buckets::HFBucket {
             "bucket",
             progress,
         )
-        .await
+        .await?
+        .infos)
     }
 
     pub(crate) async fn xet_download_batch(&self, files: &[XetBatchFile], progress: &Option<Progress>) -> HFResult<()> {

--- a/hf-hub/src/xet.rs
+++ b/hf-hub/src/xet.rs
@@ -199,11 +199,9 @@ pub(crate) struct XetUploadedFile {
 
 pub(crate) struct XetBatchResult {
     pub files: Vec<XetUploadedFile>,
-    /// Logical content bytes for the batch (pre-dedup).
-    pub total_bytes: u64,
     /// Bytes actually transferred to CAS (post-dedup).
     pub transfer_bytes: u64,
-    /// total_bytes - transfer_bytes.
+    /// Logical content bytes minus transfer_bytes.
     pub dedup_bytes_saved: u64,
 }
 
@@ -728,7 +726,6 @@ impl<T: RepoType> HFRepository<T> {
         let dedup_bytes_saved = outcome.total_bytes.saturating_sub(outcome.transfer_bytes);
         Ok(XetBatchResult {
             files,
-            total_bytes: outcome.total_bytes,
             transfer_bytes: outcome.transfer_bytes,
             dedup_bytes_saved,
         })

--- a/hfrs/src/cli.rs
+++ b/hfrs/src/cli.rs
@@ -53,6 +53,9 @@ pub enum Command {
     Spaces(crate::commands::spaces::Args),
     /// Upload a file or folder to the Hub
     Upload(crate::commands::upload::Args),
+    /// Upload a large folder to the Hub (resumable, batched commits)
+    #[command(name = "upload-large-folder")]
+    UploadLargeFolder(crate::commands::upload_large_folder::Args),
     /// Print information about the environment
     Env(crate::commands::env::Args),
     /// Print the hfrs version

--- a/hfrs/src/commands/mod.rs
+++ b/hfrs/src/commands/mod.rs
@@ -8,4 +8,5 @@ pub mod models;
 pub mod repos;
 pub mod spaces;
 pub mod upload;
+pub mod upload_large_folder;
 pub mod version;

--- a/hfrs/src/commands/upload_large_folder.rs
+++ b/hfrs/src/commands/upload_large_folder.rs
@@ -1,0 +1,83 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args as ClapArgs;
+use hf_hub::progress::Progress;
+use hf_hub::{HFClient, RepoTypeAny};
+
+use crate::cli::RepoTypeArg;
+use crate::output::CommandResult;
+use crate::progress::LargeFolderProgressHandler;
+
+/// Upload a large folder to the Hub as resumable, batched commits
+#[derive(ClapArgs)]
+pub struct Args {
+    /// Repository ID (e.g., username/my-model)
+    pub repo_id: String,
+
+    /// Local folder to upload
+    pub local_path: PathBuf,
+
+    /// Repository type
+    #[arg(long, visible_alias = "repo-type", value_enum, default_value = "model")]
+    pub r#type: RepoTypeArg,
+
+    /// Git revision (branch, tag, or commit SHA)
+    #[arg(long)]
+    pub revision: Option<String>,
+
+    /// Create the repo as private if it does not exist yet
+    #[arg(long)]
+    pub private: bool,
+
+    /// Include only files matching these glob patterns (repeatable)
+    #[arg(long)]
+    pub include: Vec<String>,
+
+    /// Exclude files matching these glob patterns (repeatable)
+    #[arg(long)]
+    pub exclude: Vec<String>,
+
+    /// Number of concurrent workers (classify + xet upload). Defaults to the library's heuristic.
+    #[arg(long)]
+    pub num_workers: Option<usize>,
+
+    /// Disable the periodic status report
+    #[arg(long)]
+    pub no_report: bool,
+}
+
+pub async fn execute(client: &HFClient, args: Args, multi: Option<indicatif::MultiProgress>) -> Result<CommandResult> {
+    let (owner, name) = match args.repo_id.split_once('/') {
+        Some(parts) => parts,
+        None => ("", args.repo_id.as_str()),
+    };
+    let repo = client.repository::<RepoTypeAny>(args.r#type.into(), owner, name);
+
+    let handler: Option<Progress> = match multi {
+        Some(multi) if !args.no_report => Some(LargeFolderProgressHandler::new(multi).into()),
+        _ => None,
+    };
+
+    let allow_patterns = (!args.include.is_empty()).then_some(args.include);
+    let ignore_patterns = (!args.exclude.is_empty()).then_some(args.exclude);
+
+    let report = repo
+        .upload_large_folder()
+        .folder_path(args.local_path)
+        .maybe_revision(args.revision)
+        .maybe_private(if args.private { Some(true) } else { None })
+        .maybe_allow_patterns(allow_patterns)
+        .maybe_ignore_patterns(ignore_patterns)
+        .maybe_num_workers(args.num_workers)
+        .maybe_progress(handler)
+        .send()
+        .await?;
+
+    let url = report
+        .commits
+        .last()
+        .and_then(|c| c.commit_url.clone().or_else(|| c.pr_url.clone()))
+        .unwrap_or_default();
+    Ok(CommandResult::Raw(url))
+}

--- a/hfrs/src/main.rs
+++ b/hfrs/src/main.rs
@@ -64,6 +64,7 @@ async fn main() -> ExitCode {
         Command::Repos(args) => commands::repos::execute(&client, args).await,
         Command::Spaces(args) => commands::spaces::execute(&client, args).await,
         Command::Upload(args) => commands::upload::execute(&client, args, multi.clone()).await,
+        Command::UploadLargeFolder(args) => commands::upload_large_folder::execute(&client, args, multi.clone()).await,
         Command::Env(args) => commands::env::execute(args).await,
         Command::Version(args) => commands::version::execute(args).await,
     };

--- a/hfrs/src/progress.rs
+++ b/hfrs/src/progress.rs
@@ -329,6 +329,7 @@ impl CliProgressHandler {
                     self.multi.remove(&spinner);
                 }
             },
+            UploadEvent::LargeFolderStatus { .. } => {},
         }
     }
 

--- a/hfrs/src/progress.rs
+++ b/hfrs/src/progress.rs
@@ -18,13 +18,14 @@ const REPORT_INTERVAL: Duration = Duration::from_secs(60);
 /// Decouples the formatter from the event enum for straightforward unit testing.
 struct LargeFolderStatusView {
     files_total: usize,
-    upload_mode_known: usize,
     committed: usize,
+    skipped: usize,
     ignored: usize,
     lfs_total: usize,
     preuploaded: usize,
     bytes_uploaded: u64,
     dedup_bytes_saved: u64,
+    skipped_bytes: u64,
 }
 
 /// True if a report should print now: the first print (`last` is `None`) or once
@@ -55,15 +56,16 @@ fn format_report_block(elapsed: Duration, status: &LargeFolderStatusView, done: 
         format!("[{}] upload-large-folder", format_elapsed(elapsed))
     };
     format!(
-        "{header}\n  files:  {} total · {} classified · {} committed · {} ignored\n  lfs:    {} files · {} uploaded · {} sent · {} deduped",
+        "{header}\n  files:  {} total · {} committed · {} skipped · {} ignored\n  xet:    {} files · {} uploaded · {} sent · {} deduped · {} skipped",
         status.files_total,
-        status.upload_mode_known,
         status.committed,
+        status.skipped,
         status.ignored,
         status.lfs_total,
         status.preuploaded,
         HumanBytes(status.bytes_uploaded),
         HumanBytes(status.dedup_bytes_saved),
+        HumanBytes(status.skipped_bytes),
     )
 }
 
@@ -520,24 +522,26 @@ impl ProgressHandler for LargeFolderProgressHandler {
         match event {
             UploadEvent::LargeFolderStatus {
                 files_total,
-                upload_mode_known,
                 lfs_total,
                 preuploaded,
                 committed,
                 ignored,
                 bytes_uploaded,
                 dedup_bytes_saved,
+                skipped,
+                skipped_bytes,
                 ..
             } => {
                 let view = LargeFolderStatusView {
                     files_total: *files_total,
-                    upload_mode_known: *upload_mode_known,
                     committed: *committed,
+                    skipped: *skipped,
                     ignored: *ignored,
                     lfs_total: *lfs_total,
                     preuploaded: *preuploaded,
                     bytes_uploaded: *bytes_uploaded,
                     dedup_bytes_saved: *dedup_bytes_saved,
+                    skipped_bytes: *skipped_bytes,
                 };
                 if should_print(state.last_print, now, REPORT_INTERVAL) {
                     self.print_block(now.duration_since(start), &view, false);
@@ -652,23 +656,27 @@ mod tests {
     fn format_report_block_renders_counts_and_bytes() {
         let status = LargeFolderStatusView {
             files_total: 1000,
-            upload_mode_known: 840,
             committed: 83,
+            skipped: 640,
             ignored: 3,
             lfs_total: 300,
             preuploaded: 120,
             bytes_uploaded: 2_100_000_000,
             dedup_bytes_saved: 5_400_000_000,
+            skipped_bytes: 12_300_000_000,
         };
         let block = format_report_block(Duration::from_secs(135), &status, false);
         assert!(block.contains("[+02:15] upload-large-folder"));
         assert!(!block.contains("done"));
+        assert!(!block.contains("classified"));
         assert!(block.contains("1000 total"));
-        assert!(block.contains("840 classified"));
         assert!(block.contains("83 committed"));
+        assert!(block.contains("640 skipped"));
         assert!(block.contains("3 ignored"));
+        assert!(block.contains("xet:"));
         assert!(block.contains("300 files"));
         assert!(block.contains("120 uploaded"));
+        assert!(block.contains("deduped"));
         assert!(block.contains("GB") || block.contains("GiB"), "expected byte unit, got: {block}");
     }
 
@@ -676,13 +684,14 @@ mod tests {
     fn format_report_block_done_marks_header() {
         let status = LargeFolderStatusView {
             files_total: 1,
-            upload_mode_known: 1,
             committed: 1,
+            skipped: 0,
             ignored: 0,
             lfs_total: 0,
             preuploaded: 0,
             bytes_uploaded: 0,
             dedup_bytes_saved: 0,
+            skipped_bytes: 0,
         };
         let block = format_report_block(Duration::from_secs(1), &status, true);
         assert!(block.contains("upload-large-folder · done"), "done block: {block}");

--- a/hfrs/src/progress.rs
+++ b/hfrs/src/progress.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Write;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use hf_hub::progress::{DownloadEvent, FileProgress, FileStatus, ProgressEvent, ProgressHandler, UploadEvent};
 use indicatif::{HumanBytes, HumanDuration, MultiProgress, ProgressBar, ProgressStyle};
@@ -8,6 +9,63 @@ use indicatif::{HumanBytes, HumanDuration, MultiProgress, ProgressBar, ProgressS
 /// Renders indicatif progress bars in the terminal for download and upload operations.
 const MAX_VISIBLE_FILE_BARS: usize = 10;
 const MAX_VISIBLE_UPLOAD_BARS: usize = 10;
+
+/// Reprint the upload-large-folder status report at most this often. Matches the
+/// Python `huggingface_hub` cadence.
+const REPORT_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Plain-data snapshot of the `LargeFolderStatus` fields the report renders.
+/// Decouples the formatter from the event enum for straightforward unit testing.
+struct LargeFolderStatusView {
+    files_total: usize,
+    upload_mode_known: usize,
+    committed: usize,
+    ignored: usize,
+    lfs_total: usize,
+    preuploaded: usize,
+    bytes_uploaded: u64,
+    dedup_bytes_saved: u64,
+}
+
+/// True if a report should print now: the first print (`last` is `None`) or once
+/// at least `interval` has elapsed since the previous print.
+fn should_print(last: Option<Instant>, now: Instant, interval: Duration) -> bool {
+    match last {
+        None => true,
+        Some(prev) => now.duration_since(prev) >= interval,
+    }
+}
+
+/// Format an elapsed duration as `+mm:ss`, or `+h:mm:ss` once past an hour.
+fn format_elapsed(elapsed: Duration) -> String {
+    let secs = elapsed.as_secs();
+    let (h, m, s) = (secs / 3600, (secs % 3600) / 60, secs % 60);
+    if h > 0 {
+        format!("+{h}:{m:02}:{s:02}")
+    } else {
+        format!("+{m:02}:{s:02}")
+    }
+}
+
+/// Render the three-line status block for one report.
+fn format_report_block(elapsed: Duration, status: &LargeFolderStatusView, done: bool) -> String {
+    let header = if done {
+        format!("[{}] upload-large-folder · done", format_elapsed(elapsed))
+    } else {
+        format!("[{}] upload-large-folder", format_elapsed(elapsed))
+    };
+    format!(
+        "{header}\n  files:  {} total · {} classified · {} committed · {} ignored\n  lfs:    {} files · {} uploaded · {} sent · {} deduped",
+        status.files_total,
+        status.upload_mode_known,
+        status.committed,
+        status.ignored,
+        status.lfs_total,
+        status.preuploaded,
+        HumanBytes(status.bytes_uploaded),
+        HumanBytes(status.dedup_bytes_saved),
+    )
+}
 
 pub struct CliProgressHandler {
     multi: MultiProgress,
@@ -419,6 +477,84 @@ pub fn progress_disabled_by_env() -> bool {
     std::env::var("HF_HUB_DISABLE_PROGRESS_BARS").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
 }
 
+struct ReportState {
+    start: Option<Instant>,
+    last_print: Option<Instant>,
+    latest: Option<LargeFolderStatusView>,
+}
+
+/// Renders `upload_large_folder`'s coarse `LargeFolderStatus` events as a
+/// periodically reprinted text block (no progress bars), throttled to once per
+/// [`REPORT_INTERVAL`]. The latest snapshot always prints on `Complete` so the
+/// final numbers are never lost to throttling.
+pub struct LargeFolderProgressHandler {
+    multi: MultiProgress,
+    state: Mutex<ReportState>,
+}
+
+impl LargeFolderProgressHandler {
+    pub fn new(multi: MultiProgress) -> Self {
+        Self {
+            multi,
+            state: Mutex::new(ReportState {
+                start: None,
+                last_print: None,
+                latest: None,
+            }),
+        }
+    }
+
+    fn print_block(&self, elapsed: Duration, status: &LargeFolderStatusView, done: bool) {
+        let _ = self.multi.println(format_report_block(elapsed, status, done));
+    }
+}
+
+impl ProgressHandler for LargeFolderProgressHandler {
+    fn on_progress(&self, event: &ProgressEvent) {
+        let ProgressEvent::Upload(event) = event else {
+            return;
+        };
+        let now = Instant::now();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let start = *state.start.get_or_insert(now);
+        match event {
+            UploadEvent::LargeFolderStatus {
+                files_total,
+                upload_mode_known,
+                lfs_total,
+                preuploaded,
+                committed,
+                ignored,
+                bytes_uploaded,
+                dedup_bytes_saved,
+                ..
+            } => {
+                let view = LargeFolderStatusView {
+                    files_total: *files_total,
+                    upload_mode_known: *upload_mode_known,
+                    committed: *committed,
+                    ignored: *ignored,
+                    lfs_total: *lfs_total,
+                    preuploaded: *preuploaded,
+                    bytes_uploaded: *bytes_uploaded,
+                    dedup_bytes_saved: *dedup_bytes_saved,
+                };
+                if should_print(state.last_print, now, REPORT_INTERVAL) {
+                    self.print_block(now.duration_since(start), &view, false);
+                    state.last_print = Some(now);
+                }
+                state.latest = Some(view);
+            },
+            UploadEvent::Complete => {
+                if let Some(view) = state.latest.take() {
+                    self.print_block(now.duration_since(start), &view, true);
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -474,6 +610,82 @@ mod tests {
     fn format_eta_caps_absurd_values() {
         let s = format_eta(1_000_000_000_000_000, Some(1.0));
         assert_eq!(s, "--");
+    }
+
+    #[test]
+    fn should_print_first_time_is_true() {
+        let now = Instant::now();
+        assert!(should_print(None, now, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn should_print_within_interval_is_false() {
+        let now = Instant::now();
+        let last = now - Duration::from_secs(10);
+        assert!(!should_print(Some(last), now, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn should_print_after_interval_is_true() {
+        let now = Instant::now();
+        let last = now - Duration::from_secs(61);
+        assert!(should_print(Some(last), now, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn format_elapsed_under_a_minute() {
+        assert_eq!(format_elapsed(Duration::from_secs(0)), "+00:00");
+        assert_eq!(format_elapsed(Duration::from_secs(7)), "+00:07");
+    }
+
+    #[test]
+    fn format_elapsed_minutes_seconds() {
+        assert_eq!(format_elapsed(Duration::from_secs(135)), "+02:15");
+    }
+
+    #[test]
+    fn format_elapsed_past_an_hour() {
+        assert_eq!(format_elapsed(Duration::from_secs(3735)), "+1:02:15");
+    }
+
+    #[test]
+    fn format_report_block_renders_counts_and_bytes() {
+        let status = LargeFolderStatusView {
+            files_total: 1000,
+            upload_mode_known: 840,
+            committed: 83,
+            ignored: 3,
+            lfs_total: 300,
+            preuploaded: 120,
+            bytes_uploaded: 2_100_000_000,
+            dedup_bytes_saved: 5_400_000_000,
+        };
+        let block = format_report_block(Duration::from_secs(135), &status, false);
+        assert!(block.contains("[+02:15] upload-large-folder"));
+        assert!(!block.contains("done"));
+        assert!(block.contains("1000 total"));
+        assert!(block.contains("840 classified"));
+        assert!(block.contains("83 committed"));
+        assert!(block.contains("3 ignored"));
+        assert!(block.contains("300 files"));
+        assert!(block.contains("120 uploaded"));
+        assert!(block.contains("GB") || block.contains("GiB"), "expected byte unit, got: {block}");
+    }
+
+    #[test]
+    fn format_report_block_done_marks_header() {
+        let status = LargeFolderStatusView {
+            files_total: 1,
+            upload_mode_known: 1,
+            committed: 1,
+            ignored: 0,
+            lfs_total: 0,
+            preuploaded: 0,
+            bytes_uploaded: 0,
+            dedup_bytes_saved: 0,
+        };
+        let block = format_report_block(Duration::from_secs(1), &status, true);
+        assert!(block.contains("upload-large-folder · done"), "done block: {block}");
     }
 }
 

--- a/hfrs/tests/cli_comparison.rs
+++ b/hfrs/tests/cli_comparison.rs
@@ -67,7 +67,17 @@ fn help_shows_all_commands() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     for cmd in &[
-        "auth", "cache", "datasets", "download", "models", "repos", "spaces", "upload", "env", "version",
+        "auth",
+        "cache",
+        "datasets",
+        "download",
+        "models",
+        "repos",
+        "spaces",
+        "upload",
+        "upload-large-folder",
+        "env",
+        "version",
     ] {
         assert!(stdout.contains(cmd), "help output should contain command '{cmd}'");
     }
@@ -96,6 +106,41 @@ fn repos_help_shows_subcommands() {
     for cmd in &["create", "delete", "move", "settings", "delete-files", "branch", "tag"] {
         assert!(stdout.contains(cmd), "repos help should contain subcommand '{cmd}'");
     }
+}
+
+#[test]
+fn upload_large_folder_help_lists_flags() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_hfrs"))
+        .args(["upload-large-folder", "--help"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    for flag in &[
+        "--type",
+        "--revision",
+        "--private",
+        "--include",
+        "--exclude",
+        "--num-workers",
+        "--no-report",
+    ] {
+        assert!(stdout.contains(flag), "upload-large-folder help should list '{flag}'");
+    }
+}
+
+#[test]
+fn upload_large_folder_requires_positionals() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_hfrs"))
+        .arg("upload-large-folder")
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "missing positionals should fail");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("required") || stderr.contains("Usage") || stderr.contains("usage"),
+        "should show usage/required-arg error, got: {stderr}"
+    );
 }
 
 // --- Models comparison tests ---
@@ -1999,6 +2044,30 @@ fn write_upload_special_chars() {
     let _ = hfrs.run_raw(&["repos", "delete", &full_repo]);
 
     assert!(result.is_ok(), "upload with special chars in filename should succeed: {:?}", result.err());
+}
+
+#[test]
+fn write_upload_large_folder() {
+    require_token();
+    require_write();
+    let hfrs = CliRunner::hfrs_ci();
+
+    let repo_name = unique_repo_name("hfrs-ulf");
+    let full_repo = full_repo(&repo_name);
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "alpha").unwrap();
+    std::fs::write(tmp.path().join("b.txt"), "beta").unwrap();
+    let sub = tmp.path().join("sub");
+    std::fs::create_dir(&sub).unwrap();
+    std::fs::write(sub.join("c.txt"), "gamma").unwrap();
+
+    let result = hfrs.run_raw(&["upload-large-folder", &full_repo, tmp.path().to_str().unwrap()]);
+    let _ = hfrs.run_raw(&["repos", "delete", &full_repo]);
+
+    assert!(result.is_ok(), "upload-large-folder should succeed: {:?}", result.err());
+    let output = result.unwrap();
+    assert!(output.contains("http"), "output should contain a commit URL, got: {output}");
 }
 
 // =============================================================================

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -432,3 +432,26 @@ fn test_sync_branch_operations() {
 
     delete_test_repo(&client, &repo_id);
 }
+
+#[test]
+fn test_sync_upload_large_folder_smoke() {
+    let Some(client) = ci_sync_api() else { return };
+    if !write_enabled() {
+        return;
+    }
+    let repo_id = create_test_repo(&client);
+    let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
+    let test_repo = client.model(parts[0], parts[1]);
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("small.txt"), b"blocking hello").unwrap();
+
+    let report = test_repo
+        .upload_large_folder()
+        .folder_path(dir.path().to_path_buf())
+        .send()
+        .expect("blocking upload_large_folder failed");
+    assert_eq!(report.total_files, 1);
+
+    delete_test_repo(&client, &repo_id);
+}

--- a/integration-tests/tests/upload_large_folder_test.rs
+++ b/integration-tests/tests/upload_large_folder_test.rs
@@ -1,0 +1,146 @@
+//! Integration tests for `HFRepository::upload_large_folder`.
+//!
+//! Tests upload, resume (no second commit), dedup savings, and cross-tool
+//! resume from a Python-written cache file.
+//!
+//! Requires:
+//!   - HF_TOKEN (local) or HF_CI_TOKEN (CI) environment variable
+//!   - HF_TEST_WRITE=1 (creates and deletes repos)
+//!
+//! Run: HF_TOKEN=hf_xxx HF_TEST_WRITE=1 cargo test -p integration-tests upload_large_folder -- --nocapture
+
+use hf_hub::{HFClient, RepoTypeDataset};
+use integration_tests::test_utils::{
+    HF_CI_TOKEN, HF_TOKEN, HUB_CI_ENDPOINT, is_ci, resolve_hub_ci_token, write_enabled,
+};
+
+fn unique_repo_name(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}-{nanos}")
+}
+
+fn make_client() -> Option<HFClient> {
+    if is_ci() {
+        let token = std::env::var(HF_CI_TOKEN).ok()?;
+        Some(
+            HFClient::builder()
+                .token(token)
+                .endpoint(HUB_CI_ENDPOINT)
+                .build()
+                .expect("failed to create HFClient"),
+        )
+    } else {
+        let token = std::env::var(HF_TOKEN).ok()?;
+        Some(HFClient::builder().token(token).build().expect("failed to create HFClient"))
+    }
+}
+
+/// Upload a folder, verify report fields, then re-upload and verify no new commits are created.
+#[tokio::test]
+async fn upload_large_folder_uploads_and_resumes() {
+    let Some(_token) = resolve_hub_ci_token() else {
+        eprintln!("skipping: no token");
+        return;
+    };
+    if !write_enabled() {
+        eprintln!("skipping: HF_TEST_WRITE not set");
+        return;
+    }
+    let Some(client) = make_client() else {
+        eprintln!("skipping: no token");
+        return;
+    };
+
+    let owner = client.whoami().send().await.unwrap().username;
+    let name = unique_repo_name("rs-ulf-test");
+    let repo = client.dataset(&owner, &name);
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("readme.md"), b"hello world").unwrap();
+    std::fs::create_dir_all(dir.path().join("data")).unwrap();
+    let big: Vec<u8> = (0..(8 * 1024 * 1024)).map(|i| (i % 251) as u8).collect();
+    std::fs::write(dir.path().join("data/a.bin"), &big).unwrap();
+    let mut dup = big.clone();
+    dup.extend_from_slice(b"tail");
+    std::fs::write(dir.path().join("data/b.bin"), &dup).unwrap();
+
+    let report = repo
+        .upload_large_folder()
+        .folder_path(dir.path().to_path_buf())
+        .send()
+        .await
+        .expect("upload_large_folder failed");
+
+    assert_eq!(report.total_files, 3);
+    assert!(report.files_uploaded_lfs >= 2, "expected the two big files via lfs");
+    assert!(!report.commits.is_empty());
+    assert!(report.dedup_bytes_saved > 0, "expected dedup savings from b.bin duplicating a.bin");
+
+    let meta = std::fs::read_to_string(dir.path().join(".cache/huggingface/upload/data/a.bin.metadata")).unwrap();
+    let committed_line = meta.split('\n').nth(7).unwrap();
+    assert_eq!(committed_line, "1", "a.bin should be marked committed");
+
+    // Resume: no new commits expected since everything is already committed.
+    let report2 = repo
+        .upload_large_folder()
+        .folder_path(dir.path().to_path_buf())
+        .send()
+        .await
+        .expect("resume upload_large_folder failed");
+    assert_eq!(report2.total_files, 3);
+    assert!(report2.commits.is_empty(), "resume should create no new commits");
+
+    let _ = client
+        .delete_repository()
+        .repo_id(format!("{owner}/{name}"))
+        .repo_type(RepoTypeDataset)
+        .send()
+        .await;
+}
+
+/// Pre-seed a Python-style metadata file marking a file as already committed;
+/// the Rust implementation should respect it and produce no new commits.
+#[tokio::test]
+async fn resumes_python_written_cache() {
+    let Some(_token) = resolve_hub_ci_token() else {
+        return;
+    };
+    if !write_enabled() {
+        return;
+    }
+    let Some(client) = make_client() else {
+        return;
+    };
+
+    let owner = client.whoami().send().await.unwrap().username;
+    let name = unique_repo_name("rs-ulf-resume");
+    let repo = client.dataset(&owner, &name);
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("x.txt"), b"abc").unwrap();
+
+    // Pre-seed a Python-style metadata file marking x.txt as already committed.
+    let upload_dir = dir.path().join(".cache/huggingface/upload");
+    std::fs::create_dir_all(&upload_dir).unwrap();
+    // 8-line format: timestamp, size, should_ignore, sha256, upload_mode, remote_oid, is_uploaded, is_committed
+    std::fs::write(upload_dir.join("x.txt.metadata"), "99999999999.0\n3\n0\n\nregular\n\n0\n1\n").unwrap();
+
+    let report = repo
+        .upload_large_folder()
+        .folder_path(dir.path().to_path_buf())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(report.total_files, 1);
+    assert!(report.commits.is_empty(), "expected no commit for an already-committed file");
+
+    let _ = client
+        .delete_repository()
+        .repo_id(format!("{owner}/{name}"))
+        .repo_type(RepoTypeDataset)
+        .send()
+        .await;
+}

--- a/integration-tests/tests/upload_large_folder_test.rs
+++ b/integration-tests/tests/upload_large_folder_test.rs
@@ -144,3 +144,60 @@ async fn resumes_python_written_cache() {
         .send()
         .await;
 }
+
+/// Many small (regular) files plus explicit num_workers. Exercises parallel
+/// classify, the committer's batching, and produces ≥1 commit with all files.
+#[tokio::test]
+async fn upload_large_folder_many_small_files_with_workers() {
+    let Some(_token) = resolve_hub_ci_token() else {
+        eprintln!("skipping: no token");
+        return;
+    };
+    if !write_enabled() {
+        eprintln!("skipping: HF_TEST_WRITE not set");
+        return;
+    }
+    let Some(client) = make_client() else {
+        eprintln!("skipping: no token");
+        return;
+    };
+
+    let owner = client.whoami().send().await.unwrap().username;
+    let name = unique_repo_name("rs-ulf-small");
+    let repo = client.dataset(&owner, &name);
+
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..25 {
+        std::fs::write(dir.path().join(format!("f{i}.txt")), format!("content {i}")).unwrap();
+    }
+
+    let report = repo
+        .upload_large_folder()
+        .folder_path(dir.path().to_path_buf())
+        .num_workers(3)
+        .send()
+        .await
+        .expect("upload_large_folder failed");
+
+    assert_eq!(report.total_files, 25);
+    assert_eq!(report.files_committed_inline, 25);
+    assert_eq!(report.files_uploaded_lfs, 0);
+    assert!(!report.commits.is_empty());
+
+    // Resume: nothing new to commit.
+    let report2 = repo
+        .upload_large_folder()
+        .folder_path(dir.path().to_path_buf())
+        .num_workers(1)
+        .send()
+        .await
+        .expect("resume failed");
+    assert!(report2.commits.is_empty(), "resume should create no new commits");
+
+    let _ = client
+        .delete_repository()
+        .repo_id(format!("{owner}/{name}"))
+        .repo_type(RepoTypeDataset)
+        .send()
+        .await;
+}


### PR DESCRIPTION
## Summary

Adds `HFRepository<T>::upload_large_folder` (plus the mandatory blocking counterpart) — the Rust equivalent of Python `huggingface_hub.upload_large_folder`: a resumable, xet-optimized uploader for large local folders, committed in adaptively-sized batches.

- **Byte-compatible resume cache.** Per-file `.cache/huggingface/upload/<path>.metadata` matches Python's exact 8-line format (incl. blank-for-None, `0/1` booleans, 20h S3-GC reset, mtime-staleness re-hash) plus flock locks (`fs2`, compatible with Python's `WeakFileLock`). A folder partially uploaded by either tool resumes in the other.
- **Rust/xet improvements over Python.** One shared `XetSession` across batched `UploadCommit`s for global chunk dedup; single-pass SHA-256 via `Sha256Policy::Compute` (the xet clean pass yields the LFS oid — no separate hashing read); aggregate progress via a new `UploadEvent::LargeFolderStatus` (no per-file spam).
- **Ergonomics beyond Python's entry point.** Allows `path_in_repo`, custom commit message/description, and `create_pr`; ensures the repo exists (create-if-missing, honoring `private`); honors the Hub's `shouldIgnore` flag from `/preupload` (ignored files are recorded in the cache and never uploaded/committed); returns a rich `UploadLargeFolderReport` (per-batch commits + counts + bytes + dedup savings) instead of `None`.

## Implementation

- New module `repository/upload_large_folder/{mod,local_folder,pipeline}.rs` (orchestration + 3-stage pipeline: classify → xet-upload → adaptive commit, driven by a resume-aware stage seeder and `COMMIT_SIZE_SCALE` sizer).
- `upload.rs`: extracted a pure `build_commit_ndjson` and a `commit_resolved_operations` path (commit pre-resolved ops without re-running preupload/xet) — behavior-preserving refactor of `create_commit_impl`. `fetch_upload_modes` now returns `PreuploadInfo` (upload mode + should-ignore).
- `xet.rs`: `xet_upload_batch` surfaces per-file sha256 oids + dedup metrics; `xet_upload_inner` now returns an outcome struct (existing callers unchanged).
- New dependency: `fs2 = "0.4"`.
- Example (`examples/upload_large_folder.rs`) and docs/project-layout updated.

## Test plan

- [x] `cargo clippy -p hf-hub --all-features -- -D warnings` clean; `cargo clippy -p hfrs -- -D warnings` clean
- [x] `cargo test -p hf-hub` — unit + doctests pass (cache round-trip + Python-fixture parse, GC/staleness/corruption, adaptive sizing, stage seeding, NDJSON builder, discovery/glob filtering, preupload shouldIgnore parsing)
- [x] **Live** integration tests against hub-ci (`HF_TEST_WRITE=1`): `upload_large_folder_uploads_and_resumes` (incl. `dedup_bytes_saved > 0` and resume-creates-no-commits) and the blocking smoke test passed
- [x] All crates build (`hf-hub --all-features`, `hfrs`, `examples`, `integration-tests --tests`)

## Known limitations (follow-ups, not blockers)

- **Sequential v1 / `num_workers` reserved.** Stages run sequentially; xet manages its own upload parallelism. Overlapping a batch's Hub commit with the next batch's CAS upload (single committer behind an `mpsc`) is a planned follow-up; `num_workers` is accepted but currently a no-op.
- **Per-invocation report counters.** `bytes_uploaded` / `dedup_bytes_saved` count only the current run's transfers (a resumed run skips already-uploaded files, so they aren't re-counted). `files_uploaded_lfs` counts all lfs-classified files in the set. Doc comments make this explicit.