### PR TITLE
fix: follow relative redirects on metadata HEAD requests (#163)

### DIFF
--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -8,6 +8,33 @@ use crate::constants;
 use crate::error::{HFError, HFResult, HttpErrorContext, NotFoundContext};
 use crate::retry::{self, RetryConfig};
 
+/// Maximum number of relative redirects followed while resolving file metadata, bounding the
+/// loop in [`HFClient::head_following_relative_redirects`] in case an endpoint advertises a
+/// redirect cycle. Matches the implicit cap of `reqwest`'s default redirect policy.
+const MAX_RELATIVE_REDIRECTS: usize = 10;
+
+/// Resolve the next URL for a *relative* redirect, or `None` when the redirect should not be
+/// followed (absolute / cross-host `Location`, or no usable `Location` header — e.g. a `304`).
+///
+/// Mirrors the Python `huggingface_hub` logic
+/// `urlparse(url)._replace(path=urlparse(location).path)`: only the path component of the current
+/// URL is swapped for the redirect target's path, preserving the original scheme and host. A
+/// `Location` with a host (either `scheme://host/…` or the protocol-relative `//host/…`) is
+/// treated as absolute and left unfollowed.
+fn relative_redirect_target(current_url: &str, response: &reqwest::Response) -> Option<String> {
+    let location = response.headers().get(reqwest::header::LOCATION)?.to_str().ok()?;
+
+    let is_absolute = location.starts_with("//") || reqwest::Url::parse(location).is_ok();
+    if is_absolute {
+        return None;
+    }
+
+    let mut next = reqwest::Url::parse(current_url).ok()?;
+    let path = location.split(['?', '#']).next().unwrap_or(location);
+    next.set_path(path);
+    Some(next.into())
+}
+
 /// Async client for the Hugging Face Hub API.
 ///
 /// `HFClient` wraps an `Arc<HFClientInner>` so it is cheap to clone — all clones
@@ -265,6 +292,43 @@ impl HFClient {
 
     pub(crate) fn retry_config(&self) -> &RetryConfig {
         &self.inner.retry_config
+    }
+
+    /// Perform a `HEAD` request that transparently follows *relative* redirects, mirroring the
+    /// Python `huggingface_hub` `_httpx_follow_relative_redirects_with_backoff` helper.
+    ///
+    /// Relative redirects (a `Location` header without a host — used when a repository is renamed
+    /// or by some mirror endpoints such as `hf-mirror.com`) are followed so the final response
+    /// carries the `X-Linked-Etag` / `X-Repo-Commit` metadata headers. Absolute redirects (e.g. a
+    /// `302` to a CDN) are returned *unfollowed* so callers can read those headers off the redirect
+    /// response itself, exactly as the plain hub endpoint serves them.
+    ///
+    /// Each individual hop is retried via [`retry::retry`]. Non-redirect responses (including `304
+    /// Not Modified` and `404 Not Found`) are returned to the caller as-is.
+    pub(crate) async fn head_following_relative_redirects(
+        &self,
+        url: &str,
+        headers: HeaderMap,
+    ) -> HFResult<reqwest::Response> {
+        let mut current_url = url.to_string();
+        for _ in 0..MAX_RELATIVE_REDIRECTS {
+            let response = retry::retry(self.retry_config(), || {
+                self.no_redirect_client().head(&current_url).headers(headers.clone()).send()
+            })
+            .await?;
+
+            if response.status().is_redirection()
+                && let Some(next_url) = relative_redirect_target(&current_url, &response)
+            {
+                current_url = next_url;
+                continue;
+            }
+            return Ok(response);
+        }
+        Err(HFError::malformed_response_at(
+            format!("exceeded the maximum of {MAX_RELATIVE_REDIRECTS} relative redirects"),
+            url.to_string(),
+        ))
     }
 
     /// Hub base URL this client targets, with any trailing slash trimmed.
@@ -738,5 +802,109 @@ mod tests {
             let client = HFClientBuilder::new().build().unwrap();
             assert!(client.inner.token.is_none());
         }
+    }
+}
+
+#[cfg(test)]
+mod redirect_tests {
+    use reqwest::header::HeaderMap;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::HFClient;
+    use crate::constants;
+
+    /// Spawn an HTTP/1.1 server that routes raw responses by request path (one request per
+    /// connection). `respond` maps the request path to a full raw HTTP response string.
+    async fn spawn_server<F>(respond: F) -> std::net::SocketAddr
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = vec![0u8; 4096];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let path = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/")
+                    .to_string();
+                let response = respond(&path);
+                let _ = sock.write_all(response.as_bytes()).await;
+                let _ = sock.flush().await;
+            }
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn follows_relative_redirect_to_reach_etag() {
+        // Mirror-style endpoint: the resolve URL relative-redirects to a versioned path, and only
+        // the final response carries the ETag — the shape that broke downloads via hf-mirror.com.
+        let addr = spawn_server(|path| {
+            if path.contains("/resolve/main/") {
+                "HTTP/1.1 302 Found\r\n\
+                 Location: /org/repo/resolve/abc123/model.bin\r\n\
+                 Content-Length: 0\r\n\
+                 Connection: close\r\n\r\n"
+                    .to_string()
+            } else {
+                "HTTP/1.1 200 OK\r\n\
+                 ETag: \"deadbeefcafe\"\r\n\
+                 X-Repo-Commit: abc123\r\n\
+                 Content-Length: 1024\r\n\
+                 Connection: close\r\n\r\n"
+                    .to_string()
+            }
+        })
+        .await;
+
+        let client = HFClient::builder().endpoint(format!("http://{addr}")).build().unwrap();
+        let url = format!("http://{addr}/org/repo/resolve/main/model.bin");
+
+        let response = client.head_following_relative_redirects(&url, HeaderMap::new()).await.unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(
+            response.headers().get(reqwest::header::ETAG).and_then(|v| v.to_str().ok()),
+            Some("\"deadbeefcafe\"")
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_follow_absolute_redirect() {
+        // Plain hub endpoint: the resolve URL 302-redirects to an absolute CDN URL but carries the
+        // X-Linked-Etag / X-Repo-Commit headers on the redirect itself. The redirect must NOT be
+        // followed, so those headers stay readable on the returned response.
+        let addr = spawn_server(|_path| {
+            "HTTP/1.1 302 Found\r\n\
+             Location: https://cdn.example.com/blob/xyz\r\n\
+             X-Linked-Etag: \"linkedsha256\"\r\n\
+             X-Repo-Commit: commit789\r\n\
+             Content-Length: 0\r\n\
+             Connection: close\r\n\r\n"
+                .to_string()
+        })
+        .await;
+
+        let client = HFClient::builder().endpoint(format!("http://{addr}")).build().unwrap();
+        let url = format!("http://{addr}/org/repo/resolve/main/model.bin");
+
+        let response = client.head_following_relative_redirects(&url, HeaderMap::new()).await.unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+        assert_eq!(
+            response
+                .headers()
+                .get(constants::HEADER_X_LINKED_ETAG)
+                .and_then(|v| v.to_str().ok()),
+            Some("\"linkedsha256\"")
+        );
     }
 }

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::header::{ACCEPT_ENCODING, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use tracing::debug;
 
 use crate::constants;
@@ -305,11 +305,16 @@ impl HFClient {
     ///
     /// Each individual hop is retried via [`retry::retry`]. Non-redirect responses (including `304
     /// Not Modified` and `404 Not Found`) are returned to the caller as-is.
+    ///
+    /// `Accept-Encoding: identity` is forced on every hop so the server cannot apply a transfer
+    /// encoding to the `HEAD`, keeping `Content-Length` equal to the file's real size — mirroring
+    /// what the Python `get_hf_file_metadata` sets before this same resolve `HEAD`.
     pub(crate) async fn head_following_relative_redirects(
         &self,
         url: &str,
-        headers: HeaderMap,
+        mut headers: HeaderMap,
     ) -> HFResult<reqwest::Response> {
+        headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
         let mut current_url = url.to_string();
         for _ in 0..MAX_RELATIVE_REDIRECTS {
             let response = retry::retry(self.retry_config(), || {
@@ -905,6 +910,46 @@ mod redirect_tests {
                 .get(constants::HEADER_X_LINKED_ETAG)
                 .and_then(|v| v.to_str().ok()),
             Some("\"linkedsha256\"")
+        );
+    }
+
+    #[tokio::test]
+    async fn sends_accept_encoding_identity() {
+        // The metadata HEAD must advertise `Accept-Encoding: identity` so the server cannot apply a
+        // transfer encoding that would skew `Content-Length` away from the real file size, matching
+        // the Python client.
+        use std::sync::{Arc, Mutex};
+
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let captured_for_server = Arc::clone(&captured);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = vec![0u8; 4096];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                *captured_for_server.lock().unwrap() = Some(String::from_utf8_lossy(&buf[..n]).to_string());
+                let _ = sock
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\n\
+                          ETag: \"deadbeefcafe\"\r\n\
+                          X-Repo-Commit: abc123\r\n\
+                          Content-Length: 1024\r\n\
+                          Connection: close\r\n\r\n",
+                    )
+                    .await;
+                let _ = sock.flush().await;
+            }
+        });
+
+        let client = HFClient::builder().endpoint(format!("http://{addr}")).build().unwrap();
+        let url = format!("http://{addr}/org/repo/resolve/main/model.bin");
+        client.head_following_relative_redirects(&url, HeaderMap::new()).await.unwrap();
+
+        let request = captured.lock().unwrap().clone().unwrap();
+        assert!(
+            request.to_ascii_lowercase().contains("accept-encoding: identity"),
+            "expected `Accept-Encoding: identity` in request, got:\n{request}"
         );
     }
 }

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -20,7 +20,9 @@ use futures::stream::{Stream, StreamExt};
 use reqwest::header::IF_NONE_MATCH;
 use serde::Deserialize;
 
-use super::files::{extract_commit_hash, extract_etag, extract_file_size, extract_xet_hash, matches_any_glob};
+use super::files::{
+    extract_commit_hash, extract_etag, extract_file_size, extract_location, extract_xet_hash, matches_any_glob,
+};
 use super::{FileMetadataInfo, HFRepository, RepoTreeEntry, RepoType};
 use crate::cache::storage as cache;
 use crate::error::{HFError, HFResult};
@@ -369,14 +371,7 @@ impl<T: RepoType> HFRepository<T> {
             head_headers.insert(IF_NONE_MATCH, hv);
         }
 
-        let head_response = retry::retry(self.hf_client.retry_config(), || {
-            self.hf_client
-                .no_redirect_client()
-                .head(&url)
-                .headers(head_headers.clone())
-                .send()
-        })
-        .await?;
+        let head_response = self.hf_client.head_following_relative_redirects(&url, head_headers).await?;
 
         let status = head_response.status();
 
@@ -599,10 +594,7 @@ impl<T: RepoType> HFRepository<T> {
                 let filename = filename.clone();
                 let repo_folder_ref = &repo_folder;
                 async move {
-                    let resp = retry::retry(self.hf_client.retry_config(), || {
-                        self.hf_client.no_redirect_client().head(&url).headers(auth.clone()).send()
-                    })
-                    .await?;
+                    let resp = self.hf_client.head_following_relative_redirects(&url, auth).await?;
                     // Per-file 404 resilience: write a .no_exist marker and skip
                     // the file rather than aborting the entire snapshot download.
                     // This matches the Python huggingface_hub library behavior.
@@ -631,7 +623,7 @@ impl<T: RepoType> HFRepository<T> {
                         tracing::warn!(file = %filename, "missing or invalid Content-Length/X-Linked-Size header, defaulting file size to 0");
                         0
                     });
-                    let location = Some(resp.url().to_string());
+                    let location = Some(extract_location(&resp));
                     Ok::<_, HFError>(Some(FileMetadataInfo {
                         filename,
                         etag,

--- a/hf-hub/src/repository/files.rs
+++ b/hf-hub/src/repository/files.rs
@@ -276,6 +276,19 @@ pub(crate) fn extract_xet_hash(response: &reqwest::Response) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Resolve the download location of a metadata `HEAD` response, mirroring Python's
+/// `response.headers.get("Location") or response.request.url`: prefer the `Location` header
+/// (present on an unfollowed CDN redirect, where it points at the signed blob URL) and fall back
+/// to the final request URL when the response was served directly.
+pub(super) fn extract_location(response: &reqwest::Response) -> String {
+    response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| response.url().to_string())
+}
+
 /// Check if a path matches any of the given glob patterns using the `globset` crate.
 pub(super) fn matches_any_glob(patterns: &[String], path: &str) -> bool {
     patterns.iter().any(|p| {

--- a/hf-hub/src/repository/listing.rs
+++ b/hf-hub/src/repository/listing.rs
@@ -137,14 +137,23 @@ impl<T: RepoType> HFRepository<T> {
             .download_url(self.repo_type.url_prefix(), &repo_path, revision, &filename);
 
         let headers = self.hf_client.auth_headers();
-        let response = retry::retry(self.hf_client.retry_config(), || {
-            self.hf_client.http_client().head(&url).headers(headers.clone()).send()
-        })
-        .await?;
-        let response = self
-            .hf_client
-            .check_response(response, Some(&repo_path), crate::error::NotFoundContext::Entry { path: filename.clone() })
-            .await?;
+        // Follow relative redirects (renamed repos, mirror endpoints) but stop on the absolute CDN
+        // redirect so the `X-Linked-Etag` / `X-Repo-Commit` headers stay readable, matching the
+        // Python client. A redirect response is therefore expected and must not be treated as an
+        // error by `check_response`.
+        let response = self.hf_client.head_following_relative_redirects(&url, headers).await?;
+        let status = response.status();
+        let response = if status.is_success() || status.is_redirection() {
+            response
+        } else {
+            self.hf_client
+                .check_response(
+                    response,
+                    Some(&repo_path),
+                    crate::error::NotFoundContext::Entry { path: filename.clone() },
+                )
+                .await?
+        };
 
         let etag = extract_etag(&response).ok_or_else(|| {
             HFError::malformed_response_at(format!("missing ETag header for {filename}"), url.to_string())
@@ -160,7 +169,7 @@ impl<T: RepoType> HFRepository<T> {
             );
             0
         });
-        let location = Some(response.url().to_string());
+        let location = Some(super::files::extract_location(&response));
 
         Ok(FileMetadataInfo {
             filename,

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -678,6 +678,40 @@ async fn test_get_file_metadata_bogus_revision() {
     );
 }
 
+// Regression test for https://github.com/huggingface/hf-hub/issues/163: the metadata HEAD on an
+// LFS/Xet-backed file resolves to a CDN redirect carrying `X-Linked-Etag` / `X-Repo-Commit`. The
+// client must read those headers off the (unfollowed) redirect rather than chasing it to the CDN,
+// where they are absent.
+#[tokio::test]
+async fn test_get_file_metadata_lfs_file() {
+    let Some(client) = prod_api() else { return };
+    let r = repo(&client, TEST_MODEL_REPO);
+
+    let stream = r.list_tree().recursive(true).expand(true).send().unwrap();
+    futures::pin_mut!(stream);
+    let mut large_file: Option<String> = None;
+    while let Some(entry) = stream.next().await {
+        if let RepoTreeEntry::File {
+            path, lfs, xet_hash, ..
+        } = entry.unwrap()
+            && (lfs.is_some() || xet_hash.is_some())
+        {
+            large_file = Some(path);
+            break;
+        }
+    }
+    let Some(filepath) = large_file else {
+        eprintln!("skipping: no LFS/xet-backed file found in {TEST_MODEL_REPO}");
+        return;
+    };
+
+    let meta = r.get_file_metadata().filepath(filepath.clone()).send().await.unwrap();
+    assert_eq!(meta.filename, filepath);
+    assert!(!meta.etag.is_empty(), "expected non-empty ETag for {filepath}");
+    assert!(!meta.commit_hash.is_empty(), "expected non-empty commit hash for {filepath}");
+    assert!(meta.file_size > 0, "expected non-zero file size for {filepath}");
+}
+
 // --- Commit and diff tests ---
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #163 — downloads via a mirror endpoint (e.g. `hf-mirror.com`) failed with `missing ETag header`.

When resolving file metadata with a `HEAD` on a repo's `resolve` URL, the client used `no_redirect_client()` and ignored `3xx` responses. The plain hub endpoint serves the metadata headers (`X-Linked-Etag`, `X-Repo-Commit`, `X-Linked-Size`) **on the `302` redirect** to the CDN, so not following it works there. But mirror endpoints — and renamed repos — answer with a redirect that does **not** carry those headers; the metadata only appears on the *final* response after following. `extract_etag` then returned `None`, surfacing as `missing ETag header`.

This mirrors how the Python client behaves. `huggingface_hub`'s `get_hf_file_metadata` uses `_httpx_follow_relative_redirects_with_backoff`, which follows **only relative redirects** (a `Location` without a host — renamed repos / mirror-internal hops) and leaves **absolute** redirects (the CDN `302`) unfollowed so it can read the metadata headers off them.

## Changes

- **`HFClient::head_following_relative_redirects`** (`client.rs`) — a `HEAD` that follows only relative redirects, retrying each hop. Absolute / cross-host `Location`s (including protocol-relative `//host/…`) are returned unfollowed; the path-swap logic matches Python's `urlparse(url)._replace(path=urlparse(location).path)`. Bounded by `MAX_RELATIVE_REDIRECTS`.
- **`repository/download.rs`** — single-file and snapshot download `HEAD`s now use the helper.
- **`repository/listing.rs::get_file_metadata`** — now uses the helper too. Previously it used `http_client()`, which followed **all** redirects and chased the CDN `302`, dropping `X-Repo-Commit` and breaking metadata for LFS/Xet files on the *plain* hub endpoint. A redirect response is now expected and not treated as an error by `check_response`.
- **`extract_location`** (`files.rs`) — resolves the download location as `Location` header → request URL (Python parity), used by `get_file_metadata` and the snapshot path.

## Behavior matrix

| Endpoint / case | `HEAD` result | Followed? | Outcome |
|---|---|---|---|
| Plain hub, LFS file | `302` → absolute CDN, headers on `302` | no | read `X-Linked-Etag` / `X-Repo-Commit` off `302` (unchanged) |
| Renamed repo | `3xx` → relative path | yes | reaches final response carrying metadata |
| Mirror, metadata redirect (relative) | `3xx` → relative, no ETag on it | yes | reaches response carrying ETag — **fixes #163** |
| `304 Not Modified` / `404` | not a usable `Location` | no | returned as-is (cache / not-found logic unchanged) |

## Testing

- **Unit tests** (`client.rs`, local mock server): `follows_relative_redirect_to_reach_etag` (relative redirect chased to the `200` carrying the ETag) and `does_not_follow_absolute_redirect` (absolute CDN `302` left unfollowed, `X-Linked-Etag` stays readable). Written test-first — the first failed (got `302`, want `200`) before the fix.
- **Integration test** `test_get_file_metadata_lfs_file` — resolves metadata for an LFS/Xet-backed file, whose `HEAD` returns a `302` to an absolute CDN URL. This would have failed before the fix (the old `http_client()` chased the CDN and lost `X-Repo-Commit`).
- `cargo test -p hf-hub --all-features` (187 passing), `cargo test -p integration-tests` download/cache/xet/metadata suites all green, `cargo clippy -p hf-hub --all-features -D warnings` clean, `cargo +nightly fmt`.

## Note on reproducing the mirror case

The fix targets exact Python parity (follow relative redirects). From some network vantage points `hf-mirror.com` returns an **absolute** `308` straight to `huggingface.co`, which neither Python nor this change follows; affected users hit an edge that serves a *relative* redirect, which is the path this fix handles. The deterministic mock-server unit tests cover both branches rather than depending on mirror geography.
