### PR TITLE
fix: encode revisions as single path segments, follow relative redirects; add split_id helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,6 +1131,7 @@ dependencies = [
  "hf-xet",
  "hyper",
  "pathdiff",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 url = "2"
+percent-encoding = "2"
 futures = "0.3"
 bon = "3"
 globset = "0.4"

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -29,6 +29,19 @@ pub(crate) fn append_path_segments(url: &mut Url, path: &str) -> HFResult<()> {
     Ok(())
 }
 
+/// Percent-encode `value` as a single URL path segment.
+///
+/// Unlike [`append_path_segments`], slashes are escaped rather than treated as
+/// separators, so refs like `refs/pr/21` or `refs/convert/parquet` occupy
+/// exactly one segment (`refs%2Fpr%2F21`) — the Hub 404s on the unescaped
+/// form. Mirrors `huggingface_hub`'s `quote(value, safe="")`. Use for
+/// revisions, branch names, and tag names interpolated into URL paths.
+pub(crate) fn encode_path_segment(value: &str) -> String {
+    let mut url = Url::parse("https://hf.co").expect("static base URL parses");
+    url.path_segments_mut().expect("https URL can be a base").push(value);
+    url.path()[1..].to_string()
+}
+
 /// Async client for the Hugging Face Hub API.
 ///
 /// `HFClient` wraps an `Arc<HFClientInner>` so it is cheap to clone — all clones
@@ -345,7 +358,8 @@ impl HFClient {
     /// `url_prefix` is `""` for models or `"<plural>/"` for the other repo types. Pass
     /// [`crate::repository::RepoType::url_prefix`] for the concrete repo type at the call
     /// site. `filename` is percent-encoded path-segment by path-segment, so values like
-    /// `subdir/file name #1.bin` produce a correctly escaped URL.
+    /// `subdir/file name #1.bin` produce a correctly escaped URL. `revision` is encoded
+    /// as a single segment, so `refs/pr/21` becomes `refs%2Fpr%2F21`.
     pub(crate) fn download_url(
         &self,
         url_prefix: &str,
@@ -353,7 +367,7 @@ impl HFClient {
         revision: &str,
         filename: &str,
     ) -> HFResult<String> {
-        let base = format!("{}/{}{}/resolve/{}", self.endpoint(), url_prefix, repo_id, revision);
+        let base = format!("{}/{}{}/resolve/{}", self.endpoint(), url_prefix, repo_id, encode_path_segment(revision));
         let mut url = Url::parse(&base)?;
         append_path_segments(&mut url, filename)?;
         Ok(url.into())
@@ -519,7 +533,7 @@ mod tests {
     use serial_test::serial;
     use url::Url;
 
-    use super::{HFClientBuilder, append_path_segments};
+    use super::{HFClientBuilder, append_path_segments, encode_path_segment};
 
     #[test]
     fn append_path_segments_encodes_special_chars() {
@@ -570,6 +584,34 @@ mod tests {
         let client = HFClientBuilder::new().endpoint("https://huggingface.co").build().unwrap();
         let url = client.download_url("datasets/", "owner/ds", "v1.0", "data/train.csv").unwrap();
         assert_eq!(url, "https://huggingface.co/datasets/owner/ds/resolve/v1.0/data/train.csv");
+    }
+
+    #[test]
+    fn download_url_encodes_revision_as_single_segment() {
+        let client = HFClientBuilder::new().endpoint("https://huggingface.co").build().unwrap();
+        let url = client
+            .download_url("", "owner/repo", "refs/pr/21", "model.safetensors")
+            .unwrap();
+        assert_eq!(url, "https://huggingface.co/owner/repo/resolve/refs%2Fpr%2F21/model.safetensors");
+    }
+
+    #[test]
+    fn encode_path_segment_escapes_slashes() {
+        assert_eq!(encode_path_segment("refs/pr/21"), "refs%2Fpr%2F21");
+        assert_eq!(encode_path_segment("refs/convert/parquet"), "refs%2Fconvert%2Fparquet");
+    }
+
+    #[test]
+    fn encode_path_segment_plain_revisions_unchanged() {
+        assert_eq!(encode_path_segment("main"), "main");
+        assert_eq!(encode_path_segment("v1.0"), "v1.0");
+        assert_eq!(encode_path_segment("main..feature"), "main..feature");
+    }
+
+    #[test]
+    fn encode_path_segment_escapes_percent_and_special_chars() {
+        assert_eq!(encode_path_segment("a%2Fb"), "a%252Fb");
+        assert_eq!(encode_path_segment("with space#hash?q"), "with%20space%23hash%3Fq");
     }
 
     #[test]

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use tracing::debug;
 use url::Url;
@@ -34,40 +35,28 @@ pub(crate) fn append_path_segments(url: &mut Url, path: &str) -> HFResult<()> {
 /// Unlike [`append_path_segments`], slashes are escaped rather than treated as
 /// separators, so refs like `refs/pr/21` or `refs/convert/parquet` occupy
 /// exactly one segment (`refs%2Fpr%2F21`) — the Hub 404s on the unescaped
-/// form. Mirrors `huggingface_hub`'s `quote(value, safe="")`. Use for
-/// revisions, branch names, and tag names interpolated into URL paths.
+/// form. Every byte outside the RFC 3986 unreserved set (`ALPHA`, `DIGIT`, and
+/// `-._~`) is encoded, mirroring `huggingface_hub`'s `quote(value, safe="")`.
+/// Use for revisions, branch names, and tag names interpolated into URL paths.
 pub(crate) fn encode_path_segment(value: &str) -> String {
-    let mut url = Url::parse("https://hf.co").expect("static base URL parses");
-    url.path_segments_mut().expect("https URL can be a base").push(value);
-    url.path()[1..].to_string()
+    /// `NON_ALPHANUMERIC` minus the four unreserved punctuation characters.
+    const SEGMENT: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
+    utf8_percent_encode(value, SEGMENT).to_string()
 }
 
-/// Split a repo or bucket id into its `(owner, name)` parts.
+/// Split a repo or bucket id into the `(owner, name)` pair taken by
+/// [`HFClient::model`], [`HFClient::dataset`], [`HFClient::space`], and
+/// [`HFClient::repository`].
 ///
-/// A fully-qualified id (`"owner/name"`) splits on the first `/`. A short-form
-/// id with no owner (`"gpt2"`) yields an empty owner, matching the `owner, name`
-/// argument pair taken by [`HFClient::model`], [`HFClient::dataset`],
-/// [`HFClient::space`], and [`HFClient::repository`]. Only the first `/` is a
-/// separator, so nested names (`"owner/sub/name"`) keep their tail intact
-/// (`("owner", "sub/name")`).
+/// Splits on the first `/` only, so nested names keep their tail. A short-form
+/// id with no owner yields an empty owner.
 ///
 /// ```
 /// use hf_hub::split_id;
 ///
 /// assert_eq!(split_id("openai-community/gpt2"), ("openai-community", "gpt2"));
 /// assert_eq!(split_id("gpt2"), ("", "gpt2"));
-/// ```
-///
-/// Handy for turning a user-supplied id straight into a repo handle:
-///
-/// ```no_run
-/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
-/// use hf_hub::{HFClient, split_id};
-///
-/// let client = HFClient::new()?;
-/// let (owner, name) = split_id("openai-community/gpt2");
-/// let info = client.model(owner, name).info().send().await?;
-/// # let _ = info; Ok(()) }
+/// assert_eq!(split_id("owner/sub/name"), ("owner", "sub/name"));
 /// ```
 pub fn split_id(id: &str) -> (&str, &str) {
     match id.split_once('/') {
@@ -187,16 +176,12 @@ impl HFClientBuilder {
         self
     }
 
-    /// Builds an unauthenticated client, ignoring any ambient credentials.
+    /// Builds an unauthenticated client, skipping the ambient `HF_TOKEN` and
+    /// cached token files so requests carry no `Authorization` header even on a
+    /// logged-in machine. Per-client equivalent of `HF_HUB_DISABLE_IMPLICIT_TOKEN`.
     ///
-    /// The ambient `HF_TOKEN` env var and cached token files (`HF_TOKEN_PATH`,
-    /// `$HF_HOME/token`) are skipped, so requests are sent without an
-    /// `Authorization` header even on a machine that is logged in. This is the
-    /// per-client equivalent of setting the `HF_HUB_DISABLE_IMPLICIT_TOKEN`
-    /// env var.
-    ///
-    /// Setting both [`token`](Self::token) and `anonymous` is contradictory and
-    /// makes [`build`](Self::build) fail with [`HFError::InvalidParameter`].
+    /// Setting both [`token`](Self::token) and `anonymous` makes
+    /// [`build`](Self::build) fail with [`HFError::InvalidParameter`].
     ///
     /// ```rust,no_run
     /// use hf_hub::HFClient;
@@ -453,15 +438,13 @@ impl HFClient {
         format!("{}/api/buckets/{}", self.endpoint(), bucket_id)
     }
 
-    /// Issue a HEAD request via the no-redirect client, manually following
-    /// *relative* redirects (Location without a host).
+    /// Issue a HEAD request, manually following *relative* redirects (a
+    /// `Location` without a host).
     ///
-    /// The Hub 307s to the canonical repo path when a repo id differs in
-    /// casing (e.g. `snowflake/…` → `Snowflake/…`); that response carries no
-    /// ETag, so metadata extraction must happen after following it. Absolute
-    /// redirects (e.g. to the CDN) are returned as-is — their headers already
-    /// carry the linked metadata. Mirrors `huggingface_hub`'s
-    /// `follow_relative_redirects` behavior.
+    /// The Hub 307s to the canonically-cased repo path (e.g. `snowflake/…` →
+    /// `Snowflake/…`) with no ETag, so metadata must be read after following.
+    /// Absolute redirects (e.g. to the CDN) are returned as-is. Mirrors
+    /// `huggingface_hub`'s `follow_relative_redirects`.
     #[cfg(not(target_family = "wasm"))]
     pub(crate) async fn head_with_relative_redirects(
         &self,

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -42,6 +42,40 @@ pub(crate) fn encode_path_segment(value: &str) -> String {
     url.path()[1..].to_string()
 }
 
+/// Split a repo or bucket id into its `(owner, name)` parts.
+///
+/// A fully-qualified id (`"owner/name"`) splits on the first `/`. A short-form
+/// id with no owner (`"gpt2"`) yields an empty owner, matching the `owner, name`
+/// argument pair taken by [`HFClient::model`], [`HFClient::dataset`],
+/// [`HFClient::space`], and [`HFClient::repository`]. Only the first `/` is a
+/// separator, so nested names (`"owner/sub/name"`) keep their tail intact
+/// (`("owner", "sub/name")`).
+///
+/// ```
+/// use hf_hub::split_id;
+///
+/// assert_eq!(split_id("openai-community/gpt2"), ("openai-community", "gpt2"));
+/// assert_eq!(split_id("gpt2"), ("", "gpt2"));
+/// ```
+///
+/// Handy for turning a user-supplied id straight into a repo handle:
+///
+/// ```no_run
+/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+/// use hf_hub::{HFClient, split_id};
+///
+/// let client = HFClient::new()?;
+/// let (owner, name) = split_id("openai-community/gpt2");
+/// let info = client.model(owner, name).info().send().await?;
+/// # let _ = info; Ok(()) }
+/// ```
+pub fn split_id(id: &str) -> (&str, &str) {
+    match id.split_once('/') {
+        Some((owner, name)) => (owner, name),
+        None => ("", id),
+    }
+}
+
 /// Whether a `Location` header value is a relative reference (no scheme, no
 /// host), like `/Snowflake/repo/resolve/main/config.json`. Protocol-relative
 /// URLs (`//host/path`) carry a host and are treated as absolute.
@@ -575,7 +609,7 @@ mod tests {
     use serial_test::serial;
     use url::Url;
 
-    use super::{HFClientBuilder, append_path_segments, encode_path_segment, is_relative_location};
+    use super::{HFClientBuilder, append_path_segments, encode_path_segment, is_relative_location, split_id};
 
     #[test]
     fn append_path_segments_encodes_special_chars() {
@@ -648,6 +682,29 @@ mod tests {
         assert_eq!(encode_path_segment("main"), "main");
         assert_eq!(encode_path_segment("v1.0"), "v1.0");
         assert_eq!(encode_path_segment("main..feature"), "main..feature");
+    }
+
+    #[test]
+    fn split_id_splits_owner_and_name() {
+        assert_eq!(split_id("openai-community/gpt2"), ("openai-community", "gpt2"));
+        assert_eq!(split_id("HuggingFaceFW/fineweb"), ("HuggingFaceFW", "fineweb"));
+    }
+
+    #[test]
+    fn split_id_ownerless_short_form() {
+        assert_eq!(split_id("gpt2"), ("", "gpt2"));
+        assert_eq!(split_id(""), ("", ""));
+    }
+
+    #[test]
+    fn split_id_only_splits_first_slash() {
+        assert_eq!(split_id("owner/sub/name"), ("owner", "sub/name"));
+    }
+
+    #[test]
+    fn split_id_empty_owner_or_name() {
+        assert_eq!(split_id("/name"), ("", "name"));
+        assert_eq!(split_id("owner/"), ("owner", ""));
     }
 
     #[test]

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -147,6 +147,7 @@ pub(crate) struct HFClientInner {
 pub struct HFClientBuilder {
     endpoint: Option<String>,
     token: Option<String>,
+    anonymous: bool,
     user_agent: Option<String>,
     headers: Option<HeaderMap>,
     client: Option<reqwest::Client>,
@@ -162,6 +163,7 @@ impl HFClientBuilder {
         Self {
             endpoint: None,
             token: None,
+            anonymous: false,
             user_agent: None,
             headers: None,
             client: None,
@@ -182,6 +184,28 @@ impl HFClientBuilder {
     /// var and the cached token file written by `huggingface-cli login`.
     pub fn token(mut self, token: impl Into<String>) -> Self {
         self.token = Some(token.into());
+        self
+    }
+
+    /// Builds an unauthenticated client, ignoring any ambient credentials.
+    ///
+    /// The ambient `HF_TOKEN` env var and cached token files (`HF_TOKEN_PATH`,
+    /// `$HF_HOME/token`) are skipped, so requests are sent without an
+    /// `Authorization` header even on a machine that is logged in. This is the
+    /// per-client equivalent of setting the `HF_HUB_DISABLE_IMPLICIT_TOKEN`
+    /// env var.
+    ///
+    /// Setting both [`token`](Self::token) and `anonymous` is contradictory and
+    /// makes [`build`](Self::build) fail with [`HFError::InvalidParameter`].
+    ///
+    /// ```rust,no_run
+    /// use hf_hub::HFClient;
+    ///
+    /// let client = HFClient::builder().anonymous().build()?;
+    /// # Ok::<(), hf_hub::HFError>(())
+    /// ```
+    pub fn anonymous(mut self) -> Self {
+        self.anonymous = true;
         self
     }
 
@@ -235,8 +259,9 @@ impl HFClientBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if the endpoint URL is not a valid URL or if the `reqwest` client
-    /// cannot be constructed (e.g., an invalid `User-Agent` string was provided).
+    /// Returns an error if the endpoint URL is not a valid URL, if the `reqwest` client
+    /// cannot be constructed (e.g., an invalid `User-Agent` string was provided), or if
+    /// both [`token`](Self::token) and [`anonymous`](Self::anonymous) were set.
     pub fn build(self) -> HFResult<HFClient> {
         let endpoint = self
             .endpoint
@@ -245,7 +270,16 @@ impl HFClientBuilder {
 
         let _ = url::Url::parse(&endpoint)?;
 
-        let token = self.token.or_else(resolve_token);
+        let token = if self.anonymous {
+            if self.token.is_some() {
+                return Err(HFError::InvalidParameter(
+                    "both token(...) and anonymous() were set on HFClientBuilder — pick one".to_string(),
+                ));
+            }
+            None
+        } else {
+            self.token.or_else(resolve_token)
+        };
 
         let cache_dir = self.cache_dir.unwrap_or_else(constants::resolve_cache_dir);
 
@@ -977,6 +1011,38 @@ mod tests {
 
             let client = HFClientBuilder::new().token("explicit-token").build().unwrap();
             assert_eq!(client.inner.token.as_deref(), Some("explicit-token"));
+        }
+
+        #[test]
+        #[serial]
+        fn test_anonymous_ignores_env_token() {
+            let _g = EnvGuard::new();
+            unsafe { std::env::set_var(HF_TOKEN, "env-token") };
+
+            let client = HFClientBuilder::new().anonymous().build().unwrap();
+            assert!(client.inner.token.is_none());
+        }
+
+        #[test]
+        #[serial]
+        fn test_anonymous_ignores_token_path_file() {
+            let g = EnvGuard::new();
+            let dir = tempfile::tempdir().unwrap();
+            let token_file = write_token_file(dir.path(), "tok", "file-token");
+            unsafe { std::env::set_var(HF_TOKEN_PATH, &token_file) };
+
+            let client = HFClientBuilder::new().anonymous().build().unwrap();
+            assert!(client.inner.token.is_none());
+            drop(g);
+        }
+
+        #[test]
+        #[serial]
+        fn test_anonymous_conflicts_with_explicit_token() {
+            let _g = EnvGuard::new();
+
+            let err = HFClientBuilder::new().token("explicit-token").anonymous().build().unwrap_err();
+            assert!(matches!(err, crate::HFError::InvalidParameter(_)), "unexpected error: {err:?}");
         }
 
         #[test]

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -42,6 +42,13 @@ pub(crate) fn encode_path_segment(value: &str) -> String {
     url.path()[1..].to_string()
 }
 
+/// Whether a `Location` header value is a relative reference (no scheme, no
+/// host), like `/Snowflake/repo/resolve/main/config.json`. Protocol-relative
+/// URLs (`//host/path`) carry a host and are treated as absolute.
+fn is_relative_location(location: &str) -> bool {
+    Url::parse(location) == Err(url::ParseError::RelativeUrlWithoutBase) && !location.starts_with("//")
+}
+
 /// Async client for the Hugging Face Hub API.
 ///
 /// `HFClient` wraps an `Arc<HFClientInner>` so it is cheap to clone — all clones
@@ -378,6 +385,41 @@ impl HFClient {
         format!("{}/api/buckets/{}", self.endpoint(), bucket_id)
     }
 
+    /// Issue a HEAD request via the no-redirect client, manually following
+    /// *relative* redirects (Location without a host).
+    ///
+    /// The Hub 307s to the canonical repo path when a repo id differs in
+    /// casing (e.g. `snowflake/…` → `Snowflake/…`); that response carries no
+    /// ETag, so metadata extraction must happen after following it. Absolute
+    /// redirects (e.g. to the CDN) are returned as-is — their headers already
+    /// carry the linked metadata. Mirrors `huggingface_hub`'s
+    /// `follow_relative_redirects` behavior.
+    #[cfg(not(target_family = "wasm"))]
+    pub(crate) async fn head_with_relative_redirects(
+        &self,
+        url: &str,
+        headers: &HeaderMap,
+    ) -> HFResult<reqwest::Response> {
+        const MAX_RELATIVE_REDIRECTS: usize = 10;
+        let mut url = Url::parse(url)?;
+        for _ in 0..=MAX_RELATIVE_REDIRECTS {
+            let response = retry::retry(self.retry_config(), || {
+                self.no_redirect_client().head(url.clone()).headers(headers.clone()).send()
+            })
+            .await?;
+            if response.status().is_redirection()
+                && let Some(location) = response.headers().get(reqwest::header::LOCATION)
+                && let Ok(location) = location.to_str()
+                && is_relative_location(location)
+            {
+                url = url.join(location)?;
+                continue;
+            }
+            return Ok(response);
+        }
+        Err(HFError::malformed_response_at("too many relative redirects", url.to_string()))
+    }
+
     /// Check an HTTP response and map error status codes to HFError variants.
     /// Returns the response on success (2xx).
     ///
@@ -533,7 +575,7 @@ mod tests {
     use serial_test::serial;
     use url::Url;
 
-    use super::{HFClientBuilder, append_path_segments, encode_path_segment};
+    use super::{HFClientBuilder, append_path_segments, encode_path_segment, is_relative_location};
 
     #[test]
     fn append_path_segments_encodes_special_chars() {
@@ -606,6 +648,14 @@ mod tests {
         assert_eq!(encode_path_segment("main"), "main");
         assert_eq!(encode_path_segment("v1.0"), "v1.0");
         assert_eq!(encode_path_segment("main..feature"), "main..feature");
+    }
+
+    #[test]
+    fn is_relative_location_classification() {
+        assert!(is_relative_location("/Snowflake/repo/resolve/main/config.json"));
+        assert!(is_relative_location("relative/path"));
+        assert!(!is_relative_location("https://cdn-lfs.huggingface.co/repos/x"));
+        assert!(!is_relative_location("//cdn-lfs.huggingface.co/repos/x"));
     }
 
     #[test]

--- a/hf-hub/src/error.rs
+++ b/hf-hub/src/error.rs
@@ -321,6 +321,49 @@ impl HFError {
         }
     }
 
+    /// Returns the HTTP status code the server actually returned, when this
+    /// error carries one.
+    ///
+    /// Covers every variant holding an [`HttpErrorContext`] ([`Http`](Self::Http),
+    /// [`AuthRequired`](Self::AuthRequired), [`Forbidden`](Self::Forbidden),
+    /// [`Conflict`](Self::Conflict), [`RateLimited`](Self::RateLimited), and the
+    /// not-found family when their optional context was captured) plus
+    /// [`Request`](Self::Request) errors whose underlying `reqwest` error knows
+    /// a status. No status is ever synthesized: a
+    /// [`RepoNotFound`](Self::RepoNotFound) constructed without a response
+    /// context returns `None` rather than a canonical 404, and purely local
+    /// errors (I/O, JSON, cache) always return `None`.
+    ///
+    /// ```no_run
+    /// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+    /// use reqwest::StatusCode;
+    ///
+    /// let repo = hf_hub::HFClient::new()?.model("openai-community", "gpt2");
+    /// if let Err(err) = repo.info().send().await {
+    ///     match err.status_code() {
+    ///         Some(StatusCode::TOO_MANY_REQUESTS) => println!("back off and retry"),
+    ///         Some(status) => println!("hub returned {status}"),
+    ///         None => println!("no HTTP response involved: {err}"),
+    ///     }
+    /// }
+    /// # Ok(()) }
+    /// ```
+    pub fn status_code(&self) -> Option<reqwest::StatusCode> {
+        match self {
+            HFError::Http { context }
+            | HFError::AuthRequired { context }
+            | HFError::Forbidden { context }
+            | HFError::Conflict { context }
+            | HFError::RateLimited { context, .. } => Some(context.status),
+            HFError::RepoNotFound { context, .. }
+            | HFError::RevisionNotFound { context, .. }
+            | HFError::EntryNotFound { context, .. }
+            | HFError::BucketNotFound { context, .. } => context.as_ref().map(|c| c.status),
+            HFError::Request { source, .. } => source.status(),
+            _ => None,
+        }
+    }
+
     /// Returns true for errors that indicate transient network/server issues
     /// where falling back to a cached version is appropriate.
     pub(crate) fn is_transient(&self) -> bool {
@@ -441,6 +484,71 @@ mod tests {
                 "{s} should not be transient"
             );
         }
+    }
+
+    #[test]
+    fn status_code_from_context_variants() {
+        let err = HFError::Http {
+            context: Box::new(ctx(500)),
+        };
+        assert_eq!(err.status_code(), Some(StatusCode::INTERNAL_SERVER_ERROR));
+
+        let err = HFError::AuthRequired {
+            context: Box::new(ctx(401)),
+        };
+        assert_eq!(err.status_code(), Some(StatusCode::UNAUTHORIZED));
+
+        let err = HFError::Forbidden {
+            context: Box::new(ctx(403)),
+        };
+        assert_eq!(err.status_code(), Some(StatusCode::FORBIDDEN));
+
+        let err = HFError::Conflict {
+            context: Box::new(ctx(409)),
+        };
+        assert_eq!(err.status_code(), Some(StatusCode::CONFLICT));
+
+        let err = HFError::RateLimited {
+            retry_after: None,
+            context: Box::new(ctx(429)),
+        };
+        assert_eq!(err.status_code(), Some(StatusCode::TOO_MANY_REQUESTS));
+    }
+
+    #[test]
+    fn status_code_from_not_found_family_only_when_context_present() {
+        let err = HFError::RepoNotFound {
+            repo_id: "owner/name".to_string(),
+            context: Some(Box::new(ctx(404))),
+        };
+        assert_eq!(err.status_code(), Some(StatusCode::NOT_FOUND));
+
+        let err = HFError::RepoNotFound {
+            repo_id: "owner/name".to_string(),
+            context: None,
+        };
+        assert_eq!(err.status_code(), None);
+
+        let err = HFError::EntryNotFound {
+            path: "config.json".to_string(),
+            repo_id: "owner/name".to_string(),
+            context: Some(Box::new(ctx(404))),
+        };
+        assert_eq!(err.status_code(), Some(StatusCode::NOT_FOUND));
+    }
+
+    #[test]
+    fn status_code_none_for_local_errors() {
+        let err = HFError::LocalEntryNotFound {
+            path: "config.json".to_string(),
+        };
+        assert_eq!(err.status_code(), None);
+
+        let err = HFError::InvalidParameter("bad".to_string());
+        assert_eq!(err.status_code(), None);
+
+        let err = HFError::Io(std::io::Error::other("disk"));
+        assert_eq!(err.status_code(), None);
     }
 
     #[test]

--- a/hf-hub/src/error.rs
+++ b/hf-hub/src/error.rs
@@ -321,18 +321,12 @@ impl HFError {
         }
     }
 
-    /// Returns the HTTP status code the server actually returned, when this
-    /// error carries one.
+    /// Returns the HTTP status the server actually returned, when this error
+    /// carries one.
     ///
-    /// Covers every variant holding an [`HttpErrorContext`] ([`Http`](Self::Http),
-    /// [`AuthRequired`](Self::AuthRequired), [`Forbidden`](Self::Forbidden),
-    /// [`Conflict`](Self::Conflict), [`RateLimited`](Self::RateLimited), and the
-    /// not-found family when their optional context was captured) plus
-    /// [`Request`](Self::Request) errors whose underlying `reqwest` error knows
-    /// a status. No status is ever synthesized: a
-    /// [`RepoNotFound`](Self::RepoNotFound) constructed without a response
+    /// Nothing is synthesized: a not-found variant built without a response
     /// context returns `None` rather than a canonical 404, and purely local
-    /// errors (I/O, JSON, cache) always return `None`.
+    /// errors (I/O, JSON, cache) return `None`.
     ///
     /// ```no_run
     /// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -65,9 +65,8 @@
 //! # Ok::<(), hf_hub::HFError>(())
 //! ```
 //!
-//! To send requests unauthenticated even on a machine that is logged in (i.e.,
-//! ignoring the ambient `HF_TOKEN` and token files), build an anonymous client —
-//! the per-client equivalent of `HF_HUB_DISABLE_IMPLICIT_TOKEN`:
+//! To send requests unauthenticated even on a logged-in machine (ignoring the
+//! ambient `HF_TOKEN` and token files), build an anonymous client:
 //!
 //! ```rust,no_run
 //! use hf_hub::HFClient;

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -196,7 +196,9 @@
 //! [`EntryNotFound`][HFError::EntryNotFound], [`RevisionNotFound`][HFError::RevisionNotFound],
 //! [`AuthRequired`][HFError::AuthRequired], [`Forbidden`][HFError::Forbidden], and
 //! [`RateLimited`][HFError::RateLimited] — so you can match on them directly without
-//! parsing HTTP status codes or response bodies.
+//! parsing HTTP status codes or response bodies. When you do want the raw status the
+//! server returned, [`HFError::status_code`] extracts it from any variant that
+//! carries one.
 //!
 //! ## Caching
 //!

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -92,6 +92,20 @@
 //! Space-specific methods like `runtime`, `add_secret`, and `pause` live as `impl`
 //! blocks on `HFRepository<RepoTypeSpace>` — there is no separate `HFSpace` wrapper.
 //!
+//! When you start from a single `"owner/name"` string, [`split_id`] turns it into
+//! the `(owner, name)` pair these constructors take (short-form ids like `"gpt2"`
+//! yield an empty owner):
+//!
+//! ```rust,no_run
+//! use hf_hub::{HFClient, split_id};
+//!
+//! # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+//! let client = HFClient::new()?;
+//! let (owner, name) = split_id("openai-community/gpt2");
+//! let model = client.model(owner, name);
+//! # let _ = model; Ok(()) }
+//! ```
+//!
 //! ## File operations
 //!
 //! File APIs live on the repository handle. Downloads go through the local cache
@@ -218,7 +232,7 @@ pub(crate) mod xet;
 pub use blocking::{HFBucketSync, HFClientSync, HFRepositorySync};
 #[doc(inline)]
 pub use buckets::HFBucket;
-pub use client::{HFClient, HFClientBuilder};
+pub use client::{HFClient, HFClientBuilder, split_id};
 #[doc(hidden)]
 pub use constants::{hf_home, resolve_cache_dir};
 pub use error::{HFError, HFResult, XetOperation};

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -65,6 +65,17 @@
 //! # Ok::<(), hf_hub::HFError>(())
 //! ```
 //!
+//! To send requests unauthenticated even on a machine that is logged in (i.e.,
+//! ignoring the ambient `HF_TOKEN` and token files), build an anonymous client —
+//! the per-client equivalent of `HF_HUB_DISABLE_IMPLICIT_TOKEN`:
+//!
+//! ```rust,no_run
+//! use hf_hub::HFClient;
+//!
+//! let client = HFClient::builder().anonymous().build()?;
+//! # Ok::<(), hf_hub::HFError>(())
+//! ```
+//!
 //! [`HFClient`] wraps an `Arc<…>` internally, so cloning it is cheap and all clones
 //! share the same connection pool, token, and cache configuration.
 //!

--- a/hf-hub/src/repository/commits.rs
+++ b/hf-hub/src/repository/commits.rs
@@ -130,8 +130,11 @@ impl<T: RepoType> HFRepository<T> {
         limit: Option<usize>,
     ) -> HFResult<impl Stream<Item = HFResult<GitCommitInfo>> + '_> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url_str =
-            format!("{}/commits/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), revision);
+        let url_str = format!(
+            "{}/commits/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(revision)
+        );
         let url = Url::parse(&url_str)?;
         Ok(self.hf_client.paginate(url, vec![], limit))
     }
@@ -201,7 +204,11 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         compare: String,
     ) -> HFResult<String> {
-        let url = format!("{}/compare/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), compare);
+        let url = format!(
+            "{}/compare/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(&compare)
+        );
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -242,7 +249,11 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         compare: String,
     ) -> HFResult<String> {
-        let url = format!("{}/compare/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), compare);
+        let url = format!(
+            "{}/compare/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(&compare)
+        );
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -287,7 +298,11 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         compare: String,
     ) -> HFResult<impl Stream<Item = HFResult<HFFileDiff>> + '_> {
-        let url = format!("{}/compare/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), compare);
+        let url = format!(
+            "{}/compare/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(&compare)
+        );
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -327,7 +342,11 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         revision: Option<String>,
     ) -> HFResult<()> {
-        let url = format!("{}/branch/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), branch);
+        let url = format!(
+            "{}/branch/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(&branch)
+        );
 
         let mut body = serde_json::Map::new();
         if let Some(ref rev) = revision {
@@ -366,7 +385,11 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         branch: String,
     ) -> HFResult<()> {
-        let url = format!("{}/branch/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), branch);
+        let url = format!(
+            "{}/branch/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(&branch)
+        );
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -404,7 +427,11 @@ impl<T: RepoType> HFRepository<T> {
         message: Option<String>,
     ) -> HFResult<()> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!("{}/tag/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), revision);
+        let url = format!(
+            "{}/tag/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(revision)
+        );
 
         let mut body = serde_json::json!({ "tag": tag });
         if let Some(ref m) = message {
@@ -443,7 +470,11 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         tag: String,
     ) -> HFResult<()> {
-        let url = format!("{}/tag/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), tag);
+        let url = format!(
+            "{}/tag/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(&tag)
+        );
 
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -1103,6 +1103,29 @@ impl<T: RepoType> HFRepository<T> {
     /// [`HFRepository::download_file_to_bytes`] when you do not want to write to
     /// disk.
     ///
+    /// # Offline / cache-only lookups
+    ///
+    /// Set `.local_files_only(true)` to resolve strictly from the local cache
+    /// without any network request — this is the replacement for the 0.x
+    /// `Cache::get` API. A cache miss returns
+    /// [`HFError::LocalEntryNotFound`](crate::HFError::LocalEntryNotFound), which
+    /// is distinct from a real failure: match it to tell "not cached" apart from
+    /// a genuinely missing file ([`HFError::EntryNotFound`](crate::HFError::EntryNotFound))
+    /// or any transport error.
+    ///
+    /// ```no_run
+    /// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+    /// use hf_hub::HFError;
+    ///
+    /// let repo = hf_hub::HFClient::new()?.model("openai-community", "gpt2");
+    /// match repo.download_file().filename("config.json").local_files_only(true).send().await {
+    ///     Ok(path) => println!("cached at {}", path.display()),
+    ///     Err(HFError::LocalEntryNotFound { .. }) => println!("not in cache"),
+    ///     Err(e) => return Err(e),
+    /// }
+    /// # Ok(()) }
+    /// ```
+    ///
     /// Endpoint: `GET {endpoint}/{prefix}{repo_id}/resolve/{revision}/{filename}`.
     ///
     /// # Parameters

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -459,14 +459,7 @@ impl<T: RepoType> HFRepository<T> {
             head_headers.insert(IF_NONE_MATCH, hv);
         }
 
-        let head_response = retry::retry(self.hf_client.retry_config(), || {
-            self.hf_client
-                .no_redirect_client()
-                .head(&url)
-                .headers(head_headers.clone())
-                .send()
-        })
-        .await?;
+        let head_response = self.hf_client.head_with_relative_redirects(&url, &head_headers).await?;
 
         let status = head_response.status();
 
@@ -694,10 +687,7 @@ impl<T: RepoType> HFRepository<T> {
                     let url = self
                         .hf_client
                         .download_url(self.repo_type.url_prefix(), repo_path_ref, commit_hash_ref, &filename)?;
-                    let resp = retry::retry(self.hf_client.retry_config(), || {
-                        self.hf_client.no_redirect_client().head(&url).headers(auth.clone()).send()
-                    })
-                    .await?;
+                    let resp = self.hf_client.head_with_relative_redirects(&url, &auth).await?;
                     // Per-file 404 resilience: write a .no_exist marker and skip
                     // the file rather than aborting the entire snapshot download.
                     // This matches the Python huggingface_hub library behavior.

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -1106,12 +1106,10 @@ impl<T: RepoType> HFRepository<T> {
     /// # Offline / cache-only lookups
     ///
     /// Set `.local_files_only(true)` to resolve strictly from the local cache
-    /// without any network request — this is the replacement for the 0.x
-    /// `Cache::get` API. A cache miss returns
-    /// [`HFError::LocalEntryNotFound`](crate::HFError::LocalEntryNotFound), which
-    /// is distinct from a real failure: match it to tell "not cached" apart from
-    /// a genuinely missing file ([`HFError::EntryNotFound`](crate::HFError::EntryNotFound))
-    /// or any transport error.
+    /// with no network request (the replacement for the 0.x `Cache::get`). A
+    /// cache miss returns [`HFError::LocalEntryNotFound`](crate::HFError::LocalEntryNotFound),
+    /// distinct from a genuinely missing file
+    /// ([`HFError::EntryNotFound`](crate::HFError::EntryNotFound)) or a transport error.
     ///
     /// ```no_run
     /// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {

--- a/hf-hub/src/repository/listing.rs
+++ b/hf-hub/src/repository/listing.rs
@@ -55,8 +55,11 @@ impl<T: RepoType> HFRepository<T> {
         limit: Option<usize>,
     ) -> HFResult<impl Stream<Item = HFResult<RepoTreeEntry>> + '_> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url_str =
-            format!("{}/tree/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), revision);
+        let url_str = format!(
+            "{}/tree/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(revision)
+        );
         let mut url = Url::parse(&url_str)?;
         if let Some(path) = path_in_repo.as_deref() {
             crate::client::append_path_segments(&mut url, path)?;
@@ -94,8 +97,11 @@ impl<T: RepoType> HFRepository<T> {
         revision: Option<String>,
     ) -> HFResult<Vec<RepoTreeEntry>> {
         let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url =
-            format!("{}/paths-info/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), revision);
+        let url = format!(
+            "{}/paths-info/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(revision)
+        );
 
         let body = serde_json::json!({ "paths": paths });
 

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -263,6 +263,21 @@ pub struct EvalResultSource {
 /// Returned by [`HFClient::list_models`] and by
 /// [`HFRepository::info`] when the repo is a model.
 /// Most fields are optional because they depend on the `expand` parameter and the repo's state.
+///
+/// Because fields like `siblings` and `sha` are `Option`, treat "absent" as
+/// empty rather than unwrapping. Iterate files with `.iter().flatten()` and take
+/// an owned list with `.unwrap_or_default()`:
+///
+/// ```no_run
+/// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {
+/// # let info = hf_hub::HFClient::new()?.model("openai-community", "gpt2").info().send().await?;
+/// for sibling in info.siblings.iter().flatten() {
+///     println!("{}", sibling.rfilename);
+/// }
+/// let files = info.siblings.clone().unwrap_or_default();
+/// let sha = info.sha.as_deref().unwrap_or("main");
+/// # let _ = (files, sha); Ok(()) }
+/// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ModelInfo {

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -1118,7 +1118,7 @@ impl<T: RepoType> HFRepository<T> {
     ) -> HFResult<I> {
         let mut url = self.hf_client.api_url(self.repo_type.plural(), &self.repo_path());
         if let Some(ref revision) = revision {
-            url = format!("{url}/revision/{revision}");
+            url = format!("{url}/revision/{}", crate::client::encode_path_segment(revision));
         }
         let headers = self.hf_client.auth_headers();
         let expand_params: Option<Vec<(&str, &str)>> =
@@ -1181,8 +1181,11 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         revision: String,
     ) -> HFResult<bool> {
-        let url =
-            format!("{}/revision/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), revision);
+        let url = format!(
+            "{}/revision/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(&revision)
+        );
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
             self.hf_client.http_client().get(&url).headers(headers.clone()).send()

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -264,9 +264,9 @@ pub struct EvalResultSource {
 /// [`HFRepository::info`] when the repo is a model.
 /// Most fields are optional because they depend on the `expand` parameter and the repo's state.
 ///
-/// Because fields like `siblings` and `sha` are `Option`, treat "absent" as
-/// empty rather than unwrapping. Iterate files with `.iter().flatten()` and take
-/// an owned list with `.unwrap_or_default()`:
+/// `siblings` and `sha` are `Option` — treat "absent" as empty rather than
+/// unwrapping. Iterate files with `.iter().flatten()`, or take an owned list
+/// with `.unwrap_or_default()`:
 ///
 /// ```no_run
 /// # #[tokio::main] async fn main() -> hf_hub::HFResult<()> {

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -90,7 +90,11 @@ struct DeleteFolderParams {
 impl<T: RepoType> HFRepository<T> {
     async fn create_commit_impl(&self, params: CreateCommitParams) -> HFResult<CommitInfo> {
         let revision = params.revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
-        let url = format!("{}/commit/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), revision);
+        let url = format!(
+            "{}/commit/{}",
+            self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()),
+            crate::client::encode_path_segment(revision)
+        );
 
         let add_ops_count = params
             .operations
@@ -430,7 +434,11 @@ impl<T: RepoType> HFRepository<T> {
         revision: &str,
         files: &[(&str, u64, &[u8])],
     ) -> HFResult<HashMap<String, String>> {
-        let url = format!("{}/preupload/{}", self.hf_client.api_url(api_segment, repo_id), revision);
+        let url = format!(
+            "{}/preupload/{}",
+            self.hf_client.api_url(api_segment, repo_id),
+            crate::client::encode_path_segment(revision)
+        );
 
         let files_payload: Vec<serde_json::Value> = files
             .iter()

--- a/hf-hub/src/xet.rs
+++ b/hf-hub/src/xet.rs
@@ -74,7 +74,14 @@ async fn fetch_xet_connection_info(
 }
 
 fn repo_xet_token_url(client: &HFClient, token_type: &str, repo_id: &str, api_segment: &str, revision: &str) -> String {
-    format!("{}/api/{}/{}/xet-{}-token/{}", client.endpoint(), api_segment, repo_id, token_type, revision)
+    format!(
+        "{}/api/{}/{}/xet-{}-token/{}",
+        client.endpoint(),
+        api_segment,
+        repo_id,
+        token_type,
+        crate::client::encode_path_segment(revision)
+    )
 }
 
 pub(crate) fn bucket_xet_token_url(client: &HFClient, token_type: &str, bucket_id: &str) -> String {

--- a/hfrs/src/commands/datasets/info.rs
+++ b/hfrs/src/commands/datasets/info.rs
@@ -22,10 +22,7 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let (owner, name) = match args.dataset_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.dataset_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.dataset_id);
     let repo = client.dataset(owner, name);
     let info = repo.info().maybe_revision(args.revision).send().await?;
     let json_value = json!({

--- a/hfrs/src/commands/download.rs
+++ b/hfrs/src/commands/download.rs
@@ -58,10 +58,7 @@ pub async fn execute(client: &HFClient, args: Args, multi: Option<indicatif::Mul
         multi.map(|multi| CliProgressHandler::new(multi).into())
     };
 
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     let path = if args.filenames.len() == 1 && args.include.is_empty() && args.exclude.is_empty() {
         repo.download_file()

--- a/hfrs/src/commands/models/info.rs
+++ b/hfrs/src/commands/models/info.rs
@@ -22,10 +22,7 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let (owner, name) = match args.model_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.model_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.model_id);
     let repo = client.model(owner, name);
     let info = repo.info().maybe_revision(args.revision).send().await?;
     let json_value = json!({

--- a/hfrs/src/commands/repos/branch.rs
+++ b/hfrs/src/commands/repos/branch.rs
@@ -61,10 +61,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
 }
 
 async fn create(client: &HFClient, args: BranchCreateArgs) -> Result<CommandResult> {
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     repo.create_branch()
         .branch(args.branch)
@@ -75,10 +72,7 @@ async fn create(client: &HFClient, args: BranchCreateArgs) -> Result<CommandResu
 }
 
 async fn delete(client: &HFClient, args: BranchDeleteArgs) -> Result<CommandResult> {
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     repo.delete_branch().branch(args.branch).send().await?;
     Ok(CommandResult::Silent)

--- a/hfrs/src/commands/repos/delete_files.rs
+++ b/hfrs/src/commands/repos/delete_files.rs
@@ -46,10 +46,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         .filter_map(|p| Glob::new(p).ok().map(|g| g.compile_matcher()))
         .collect();
 
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     let stream = repo.list_tree().maybe_revision(args.revision.clone()).recursive(true).send()?;
     futures::pin_mut!(stream);

--- a/hfrs/src/commands/repos/file_metadata.rs
+++ b/hfrs/src/commands/repos/file_metadata.rs
@@ -29,10 +29,7 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     let metadata = repo
         .get_file_metadata()

--- a/hfrs/src/commands/repos/settings.rs
+++ b/hfrs/src/commands/repos/settings.rs
@@ -52,10 +52,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
         (None, None) => None,
     };
 
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     repo.update_settings()
         .maybe_private(args.private)

--- a/hfrs/src/commands/repos/tag.rs
+++ b/hfrs/src/commands/repos/tag.rs
@@ -84,10 +84,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
 }
 
 async fn create(client: &HFClient, args: TagCreateArgs) -> Result<CommandResult> {
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     repo.create_tag()
         .tag(args.tag)
@@ -99,20 +96,14 @@ async fn create(client: &HFClient, args: TagCreateArgs) -> Result<CommandResult>
 }
 
 async fn delete(client: &HFClient, args: TagDeleteArgs) -> Result<CommandResult> {
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     repo.delete_tag().tag(args.tag).send().await?;
     Ok(CommandResult::Silent)
 }
 
 async fn list(client: &HFClient, args: TagListArgs) -> Result<CommandResult> {
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     let refs = repo.list_refs().include_pull_requests(false).send().await?;
 

--- a/hfrs/src/commands/spaces/info.rs
+++ b/hfrs/src/commands/spaces/info.rs
@@ -22,10 +22,7 @@ pub struct Args {
 }
 
 pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
-    let (owner, name) = match args.space_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.space_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.space_id);
     let repo = client.space(owner, name);
     let info = repo.info().maybe_revision(args.revision).send().await?;
     let json_value = json!({

--- a/hfrs/src/commands/upload.rs
+++ b/hfrs/src/commands/upload.rs
@@ -73,10 +73,7 @@ pub async fn execute(client: &HFClient, args: Args, multi: Option<indicatif::Mul
         multi.map(|multi| CliProgressHandler::new(multi).into())
     };
 
-    let (owner, name) = match args.repo_id.split_once('/') {
-        Some(parts) => parts,
-        None => ("", args.repo_id.as_str()),
-    };
+    let (owner, name) = hf_hub::split_id(&args.repo_id);
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     let url = do_upload(client, repo, args, local_path, handler).await?;
     Ok(CommandResult::Raw(url))


### PR DESCRIPTION
Quality-of-life batch surfaced while migrating downstream consumers onto `hf-hub`. Two bug fixes, three ergonomic additions (`split_id`, anonymous clients, `HFError::status_code`), and doc notes.

## Bug fixes

### 1. Encode revisions as single URL path segments
Slash-containing revisions (`refs/pr/N`, `refs/convert/parquet`) were interpolated raw into resolve/api URLs, so the Hub read them as extra path segments and returned **404** for every request against them.

New `encode_path_segment()` in `client.rs` percent-encodes a value as exactly one path segment (`refs/pr/21` -> `refs%2Fpr%2F21`), mirroring `huggingface_hub`'s `quote(revision, safe="")`. Applied at all 16 revision/branch/tag/compare interpolation sites: `download_url`, `revision`, `tree`, `paths-info`, `commits`, `compare`, `branch`, `tag`, `commit`, `preupload`, and the xet-token URLs.

**Repro / evidence:** surfaced by candle's `hub::tests::test_dataset` (resolves `refs/convert/parquet`) during consumer validation; verified live via `hfrs download --revision refs/pr/21`.

### 2. Follow relative redirects on metadata HEAD requests
File-metadata resolution HEADs via the no-redirect client. When a repo id differs only in casing (`snowflake/snowflake-arctic-embed-xs` vs canonical `Snowflake/...`), the Hub 307s to the canonical repo path with **no ETag**, so the old code surfaced a misleading "missing ETag header" error.

New `head_with_relative_redirects()` + `is_relative_location()` in `client.rs`, used at both HEAD sites in `repository/download.rs`. Only relative redirects (Location without a host) are followed; absolute/CDN redirects are returned as-is since their headers already carry the linked-file metadata. Mirrors `huggingface_hub`'s `follow_relative_redirects`.

**Repro / evidence:** surfaced by fastembed's test suite (non-canonical casing); verified live via `hfrs download snowflake/snowflake-arctic-embed-xs`.

## New helper: `split_id()`
`hf_hub::split_id(id) -> (owner, name)` splits a repo/bucket id on its first `/`, yielding an empty owner for short-form ids (`"gpt2"` -> `("", "gpt2")`) — feeds straight into `client.model(owner, name)` and the other handle constructors.

Rationale: every migrated consumer (tokenizers, candle, TEI, vLLM, sglang, fastembed, modelexpress, dynamo) hand-wrote the same `split_once('/')` match, and hfrs carried ~13 copies. Refactored those copies in `commands/{download,upload}`, `repos/{branch,delete_files,file_metadata,tag,settings}`, and `{models,datasets,spaces}/info` to use the helper. `parse_bucket_id` deliberately keeps its own logic (it validates and errors on a missing slash rather than defaulting to an empty owner).

## Anonymous client support
`HFClient::builder().anonymous().build()` builds a client that sends requests unauthenticated even when ambient credentials exist (`HF_TOKEN` env var, `HF_TOKEN_PATH`, cached `$HF_HOME/token`) — the per-client equivalent of the process-wide `HF_HUB_DISABLE_IMPLICIT_TOKEN` env var, which was previously the only escape hatch (mistral.rs friction).

Semantics: `.anonymous()` wins over all implicit token sources (that's its whole point); setting both `.token(...)` and `.anonymous()` is contradictory and fails `build()`/`build_sync()` with `HFError::InvalidParameter` rather than silently picking one. Documented on the builder and in the crate-level client docs.

## `HFError::status_code()`
`err.status_code() -> Option<reqwest::StatusCode>` extracts the HTTP status the server actually returned, replacing manual digging through `HttpErrorContext` (mistral.rs friction). `StatusCode` was already public surface via `HttpErrorContext::status`.

Covers the context-bearing variants (`Http`, `AuthRequired`, `Forbidden`, `Conflict`, `RateLimited`), the not-found family when their optional response context was captured, and `Request` errors whose `reqwest` source knows a status. No status is ever synthesized — a `RepoNotFound` built without a response context returns `None` rather than a canonical 404, and purely local errors (I/O, JSON, cache) always return `None`.

## Doc notes
- `ModelInfo`/`RepoInfo` optional `siblings`/`sha`: show the `.iter().flatten()` / `.unwrap_or_default()` idiom.
- `download_file().local_files_only(true)` as the replacement for 0.x `Cache::get`, and matching `HFError::LocalEntryNotFound` to distinguish "not cached" from a real `EntryNotFound`/transport error.

## Verification
- `cargo test -p hf-hub`: 213 unit + 27 doc tests pass (216 with `--all-features`); includes new tests for `split_id`, `encode_path_segment`/`is_relative_location`, builder token resolution with `anonymous()` + `HF_TOKEN`/token-file in env, and `status_code()` across variant families
- `cargo test -p hfrs`: 73 pass; 24 remaining failures are all `HF_TEST_WRITE=1`-gated write/xet tests (environmental, unchanged by this PR)
- `cargo clippy --all-features -- -D warnings`: clean on hf-hub and hfrs
- `cargo +nightly fmt`: clean
- `./scripts/verify_wasm.sh`: green
