### PR TITLE
feat: make hf-xet optional behind a `xet` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Clippy (all features)
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+      - name: Clippy (no default features — xet disabled)
+        run: cargo clippy -p hf-hub --all-targets --no-default-features -- -D warnings
+
+      - name: Clippy (blocking without xet)
+        run: cargo clippy -p hf-hub --all-targets --no-default-features --features blocking -- -D warnings
+
   build-and-test:
     name: Build & Test
     runs-on: ${{ matrix.runs-on }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,12 @@ browser tests and runtime build flags live under `wasm/`.
 
 | Feature | Default? | Notes |
 |---------|----------|-------|
+| `xet` | **on** | Enables Xet high-performance transfers via the optional `hf-xet` dependency. Gates `src/xet.rs`, `HFClient::xet_session`/`xet_state`, and every xet call site. With it off, xet-backed transfers fail with `HFError::XetFeatureDisabled` (no silent HTTP fallback), the `hf-xet` dep is dropped, and upload negotiation advertises only `basic`/`multipart`. Consumers that need to avoid `hf-xet` (e.g. to escape its `tokio` floor) build with `default-features = false`. |
 | `blocking` | off | Synchronous `*Sync` wrappers in `blocking.rs`. Pulls in `tokio/rt`. Native only. |
 | `rustls-tls` | off | Force the rustls TLS backend on reqwest's native build. No effect on wasm. |
-| `default` | (empty) | No features by default. |
+| `default` | `["xet"]` | Xet on by default so upgrading from 1.0 is non-breaking. |
+
+When adding code that dispatches into `src/xet.rs`, gate the seam with `#[cfg(feature = "xet")]` and add a `#[cfg(not(feature = "xet"))]` arm returning `HFError::xet_feature_disabled(XetOperation::…)`. Any tokio runtime feature relied on by non-xet code must be declared directly in `hf-hub/Cargo.toml` (it must not be assumed to leak in transitively via `hf-xet`).
 
 ### Method builders (bon)
 
@@ -200,9 +203,10 @@ hf-hub/
 │   │   │                           #   runtime/hardware/secrets/variables/duplicate
 │   │   ├── users.rs                # Users component: User/Organization/OrgMembership, whoami,
 │   │   │                           #   user+org lookup, followers/following
-│   │   ├── xet.rs                  # Xet component (pub(crate)): XetConnectionInfo + xet transfer
-│   │   │                           #   plumbing. Most methods are native-only (cached session, fs);
-│   │   │                           #   the wasm `xet_download_stream` builds a fresh session per call
+│   │   ├── xet.rs                  # Xet component (pub(crate), gated on `feature = "xet"`):
+│   │   │                           #   XetConnectionInfo + xet transfer plumbing. Most methods are
+│   │   │                           #   native-only (cached session, fs); the wasm `xet_download_stream`
+│   │   │                           #   builds a fresh session per call
 │   │   ├── buckets/
 │   │   │   ├── mod.rs              # HFBucket handle, bucket types, create/list/tree/batch/download
 │   │   │   └── sync.rs             # BucketSync* types, HFBucket::sync — plan computation and execution

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Both an **async** interface (`HFClient`, on by default) and a **synchronous** in
 - **User and organization info** — whoami, user profiles, organization details, followers
 - **Streaming pagination** — async list endpoints return `impl Stream<Item = Result<T>>` for lazy, memory-efficient iteration; blocking counterparts collect into `Vec<T>`
 - **Bucket operations** — create, delete, list, and move buckets; upload, download, and delete files within buckets
-- **Xet high-performance transfers** — support for Hugging Face's Xet storage backend
+- **Xet high-performance transfers** — support for Hugging Face's Xet storage backend (via the default-on `xet` feature)
 - **Async or blocking** — use `HFClient` with your own tokio runtime, or `HFClientSync` for synchronous callers (requires the `blocking` feature)
 
 ## Installation
@@ -33,6 +33,28 @@ To use the synchronous interface, enable the `blocking` feature:
 [dependencies]
 hf-hub = { version = "1.0.0", features = ["blocking"] }
 ```
+
+### Cargo features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `xet` | ✅ | [Xet](https://huggingface.co/docs/hub/storage-backends) high-performance, chunk-deduplicated transfers via the `hf-xet` dependency. |
+| `blocking` | | Synchronous `*Sync` handles backed by an internal tokio runtime. |
+| `rustls-tls` | | Force the rustls TLS backend for reqwest's native build. |
+
+The `xet` feature is on by default. If you only download metadata or small,
+git-stored files (e.g. `config.json`, `tokenizer.json`), you can drop the
+`hf-xet` dependency — and its heavier transitive requirements — by disabling
+default features:
+
+```toml
+[dependencies]
+hf-hub = { version = "1.0.0", default-features = false }
+```
+
+With `xet` disabled, any transfer that would use Xet fails with
+`HFError::XetFeatureDisabled` rather than silently falling back to a slower
+path; non-xet-backed files continue to download over plain HTTP.
 
 ## CLI Installation
 

--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -16,7 +16,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 bytes = "1"
 reqwest = { version = "0.13", features = ["json", "stream", "multipart", "query"] }
 hyper = "1"
-tokio = { version = "1", features = ["io-util"] }
+# `time` (retry backoff sleeps) and `macros` (`try_join!` in the snapshot
+# download path) are needed on all targets. `rt` (spawn_blocking in the
+# upload/cache paths) is native-only — see the per-target table below. These
+# were previously pulled in transitively via `hf-xet`; declare them directly so
+# the crate still builds with the `xet` feature disabled.
+tokio = { version = "1", features = ["io-util", "time", "macros"] }
 tokio-retry = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -29,13 +34,23 @@ base64 = "0.22"
 pathdiff = "0.2"
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"
-hf-xet = { git = "https://github.com/huggingface/xet-core", branch = "main" }
+hf-xet = { git = "https://github.com/huggingface/xet-core", branch = "main", optional = true }
 sha2 = "0.11"
 
 [features]
-default = []
+# `xet` is on by default so upgrading from 1.0 is a no-op for existing users.
+# Consumers that need to avoid the `hf-xet` dependency (and its transitive
+# tokio floor) opt out with `default-features = false`; xet-backed transfers
+# then fail with a descriptive `HFError::XetFeatureDisabled` at runtime.
+default = ["xet"]
 blocking = ["tokio/rt"]
 rustls-tls = ["reqwest/rustls"]
+xet = ["dep:hf-xet"]
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+# `spawn_blocking` in the upload and cache paths requires the multi-threaded-
+# capable runtime feature. Native only — wasm has no `spawn_blocking`.
+tokio = { version = "1", features = ["rt"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 # `tokio-retry` -> `rand` 0.8 -> `rand_core` 0.6 -> `getrandom` 0.2 transitively

--- a/hf-hub/src/buckets/mod.rs
+++ b/hf-hub/src/buckets/mod.rs
@@ -26,7 +26,9 @@ use url::Url;
 
 use crate::client::HFClient;
 use crate::error::{HFError, HFResult, NotFoundContext};
-use crate::progress::{DownloadEvent, EmitEvent, Progress, UploadEvent};
+#[cfg(feature = "xet")]
+use crate::progress::UploadEvent;
+use crate::progress::{DownloadEvent, EmitEvent, Progress};
 use crate::repository::download::{HFByteStream, wrap_stream_with_progress};
 use crate::retry;
 
@@ -256,16 +258,21 @@ impl HFBucket {
             })?;
 
         if !xet_hash.is_empty() {
-            let stream = self.xet_download_stream(&xet_hash, file_size).await?;
-            progress.emit(DownloadEvent::Start {
-                total_files: 1,
-                total_bytes: file_size,
-            });
-            let boxed: HFByteStream = Box::new(Box::pin(stream));
-            let wrapped = wrap_stream_with_progress(boxed, progress, remote_path, file_size);
-            #[cfg(target_family = "wasm")]
-            let wrapped = crate::repository::download::buffer_wasm_stream(wrapped);
-            return Ok((Some(file_size), wrapped));
+            #[cfg(not(feature = "xet"))]
+            return Err(HFError::xet_feature_disabled(crate::error::XetOperation::StreamDownload));
+            #[cfg(feature = "xet")]
+            {
+                let stream = self.xet_download_stream(&xet_hash, file_size).await?;
+                progress.emit(DownloadEvent::Start {
+                    total_files: 1,
+                    total_bytes: file_size,
+                });
+                let boxed: HFByteStream = Box::new(Box::pin(stream));
+                let wrapped = wrap_stream_with_progress(boxed, progress, remote_path, file_size);
+                #[cfg(target_family = "wasm")]
+                let wrapped = crate::repository::download::buffer_wasm_stream(wrapped);
+                return Ok((Some(file_size), wrapped));
+            }
         }
 
         let mut url = Url::parse(&format!("{}/buckets/{}/resolve", self.hf_client.endpoint(), bucket_id))?;
@@ -545,53 +552,66 @@ impl HFBucket {
         #[builder(into)]
         progress: Option<Progress>,
     ) -> HFResult<()> {
-        if files.is_empty() {
-            return Ok(());
+        #[cfg(not(feature = "xet"))]
+        {
+            let _ = &progress;
+            if files.is_empty() {
+                Ok(())
+            } else {
+                Err(HFError::xet_feature_disabled(crate::error::XetOperation::Upload))
+            }
         }
 
-        let total_bytes: u64 = files
-            .iter()
-            .filter_map(|f| std::fs::metadata(&f.local).ok())
-            .map(|m| m.len())
-            .sum();
-        progress.emit(UploadEvent::Start {
-            total_files: files.len(),
-            total_bytes,
-        });
+        #[cfg(feature = "xet")]
+        {
+            if files.is_empty() {
+                return Ok(());
+            }
 
-        let xet_files: Vec<(String, crate::repository::AddSource)> = files
-            .iter()
-            .map(|f| (f.remote.clone(), crate::repository::AddSource::file(f.local.clone())))
-            .collect();
+            let total_bytes: u64 = files
+                .iter()
+                .filter_map(|f| std::fs::metadata(&f.local).ok())
+                .map(|m| m.len())
+                .sum();
+            progress.emit(UploadEvent::Start {
+                total_files: files.len(),
+                total_bytes,
+            });
 
-        let xet_infos = self.xet_upload(&xet_files, &progress).await?;
+            let xet_files: Vec<(String, crate::repository::AddSource)> = files
+                .iter()
+                .map(|f| (f.remote.clone(), crate::repository::AddSource::file(f.local.clone())))
+                .collect();
 
-        let add_files: Vec<BucketAddFile> = files
-            .iter()
-            .zip(xet_infos.iter())
-            .map(|(f, xet_info)| {
-                let metadata = std::fs::metadata(&f.local).ok();
-                let size = metadata.as_ref().map(|m| m.len()).or(xet_info.file_size).unwrap_or(0);
-                let mtime = metadata
-                    .as_ref()
-                    .and_then(|m| m.modified().ok())
-                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                    .map(|d| d.as_secs());
+            let xet_infos = self.xet_upload(&xet_files, &progress).await?;
 
-                BucketAddFile {
-                    path: f.remote.clone(),
-                    xet_hash: xet_info.hash.clone(),
-                    size,
-                    mtime,
-                    content_type: None,
-                }
-            })
-            .collect();
+            let add_files: Vec<BucketAddFile> = files
+                .iter()
+                .zip(xet_infos.iter())
+                .map(|(f, xet_info)| {
+                    let metadata = std::fs::metadata(&f.local).ok();
+                    let size = metadata.as_ref().map(|m| m.len()).or(xet_info.file_size).unwrap_or(0);
+                    let mtime = metadata
+                        .as_ref()
+                        .and_then(|m| m.modified().ok())
+                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                        .map(|d| d.as_secs());
 
-        self.batch_operations().add_files(add_files).send().await?;
+                    BucketAddFile {
+                        path: f.remote.clone(),
+                        xet_hash: xet_info.hash.clone(),
+                        size,
+                        mtime,
+                        content_type: None,
+                    }
+                })
+                .collect();
 
-        progress.emit(UploadEvent::Complete);
-        Ok(())
+            self.batch_operations().add_files(add_files).send().await?;
+
+            progress.emit(UploadEvent::Complete);
+            Ok(())
+        }
     }
 
     /// Download files from the bucket to local paths.
@@ -615,60 +635,73 @@ impl HFBucket {
         #[builder(into)]
         progress: Option<Progress>,
     ) -> HFResult<()> {
-        if files.is_empty() {
-            return Ok(());
-        }
-
-        let remote_paths: Vec<String> = files.iter().map(|f| f.remote.clone()).collect();
-        let entries = self.get_paths_info().paths(remote_paths).send().await?;
-
-        let entry_map: std::collections::HashMap<String, BucketTreeEntry> = entries
-            .into_iter()
-            .map(|e| {
-                let path = match &e {
-                    BucketTreeEntry::File { path, .. } => path.clone(),
-                    BucketTreeEntry::Directory { path, .. } => path.clone(),
-                };
-                (path, e)
-            })
-            .collect();
-
-        let mut xet_batch_files = Vec::new();
-        let mut total_bytes: u64 = 0;
-
-        for f in &files {
-            match entry_map.get(&f.remote) {
-                Some(BucketTreeEntry::File { xet_hash, size, .. }) => {
-                    total_bytes += size;
-                    xet_batch_files.push(crate::xet::XetBatchFile {
-                        hash: xet_hash.clone(),
-                        file_size: *size,
-                        path: f.local.clone(),
-                        filename: f.remote.clone(),
-                    });
-                },
-                Some(BucketTreeEntry::Directory { path, .. }) => {
-                    return Err(HFError::InvalidParameter(format!("Cannot download directory entry: {path}")));
-                },
-                None => {
-                    return Err(HFError::EntryNotFound {
-                        path: f.remote.clone(),
-                        repo_id: self.bucket_id(),
-                        context: None,
-                    });
-                },
+        #[cfg(not(feature = "xet"))]
+        {
+            let _ = &progress;
+            if files.is_empty() {
+                Ok(())
+            } else {
+                Err(HFError::xet_feature_disabled(crate::error::XetOperation::BucketBatchDownload))
             }
         }
 
-        progress.emit(DownloadEvent::Start {
-            total_files: xet_batch_files.len(),
-            total_bytes,
-        });
+        #[cfg(feature = "xet")]
+        {
+            if files.is_empty() {
+                return Ok(());
+            }
 
-        self.xet_download_batch(&xet_batch_files, &progress).await?;
+            let remote_paths: Vec<String> = files.iter().map(|f| f.remote.clone()).collect();
+            let entries = self.get_paths_info().paths(remote_paths).send().await?;
 
-        progress.emit(DownloadEvent::Complete);
-        Ok(())
+            let entry_map: std::collections::HashMap<String, BucketTreeEntry> = entries
+                .into_iter()
+                .map(|e| {
+                    let path = match &e {
+                        BucketTreeEntry::File { path, .. } => path.clone(),
+                        BucketTreeEntry::Directory { path, .. } => path.clone(),
+                    };
+                    (path, e)
+                })
+                .collect();
+
+            let mut xet_batch_files = Vec::new();
+            let mut total_bytes: u64 = 0;
+
+            for f in &files {
+                match entry_map.get(&f.remote) {
+                    Some(BucketTreeEntry::File { xet_hash, size, .. }) => {
+                        total_bytes += size;
+                        xet_batch_files.push(crate::xet::XetBatchFile {
+                            hash: xet_hash.clone(),
+                            file_size: *size,
+                            path: f.local.clone(),
+                            filename: f.remote.clone(),
+                        });
+                    },
+                    Some(BucketTreeEntry::Directory { path, .. }) => {
+                        return Err(HFError::InvalidParameter(format!("Cannot download directory entry: {path}")));
+                    },
+                    None => {
+                        return Err(HFError::EntryNotFound {
+                            path: f.remote.clone(),
+                            repo_id: self.bucket_id(),
+                            context: None,
+                        });
+                    },
+                }
+            }
+
+            progress.emit(DownloadEvent::Start {
+                total_files: xet_batch_files.len(),
+                total_bytes,
+            });
+
+            self.xet_download_batch(&xet_batch_files, &progress).await?;
+
+            progress.emit(DownloadEvent::Complete);
+            Ok(())
+        }
     }
 }
 
@@ -680,42 +713,55 @@ impl HFBucket {
         uploads: Vec<(String, crate::repository::AddSource)>,
         progress: Option<Progress>,
     ) -> HFResult<()> {
-        if uploads.is_empty() {
-            return Ok(());
+        #[cfg(not(feature = "xet"))]
+        {
+            let _ = &progress;
+            if uploads.is_empty() {
+                Ok(())
+            } else {
+                Err(HFError::xet_feature_disabled(crate::error::XetOperation::Upload))
+            }
         }
 
-        let total_bytes: u64 = uploads
-            .iter()
-            .map(|(_, source)| match source {
-                crate::repository::AddSource::Bytes(b) => b.len() as u64,
-                crate::repository::AddSource::Stream(s) => s.size(),
-                #[cfg(not(target_family = "wasm"))]
-                crate::repository::AddSource::File(p) => std::fs::metadata(p).map(|m| m.len()).unwrap_or(0),
-            })
-            .sum();
-        progress.emit(UploadEvent::Start {
-            total_files: uploads.len(),
-            total_bytes,
-        });
+        #[cfg(feature = "xet")]
+        {
+            if uploads.is_empty() {
+                return Ok(());
+            }
 
-        let xet_infos = self.xet_upload(&uploads, &progress).await?;
+            let total_bytes: u64 = uploads
+                .iter()
+                .map(|(_, source)| match source {
+                    crate::repository::AddSource::Bytes(b) => b.len() as u64,
+                    crate::repository::AddSource::Stream(s) => s.size(),
+                    #[cfg(not(target_family = "wasm"))]
+                    crate::repository::AddSource::File(p) => std::fs::metadata(p).map(|m| m.len()).unwrap_or(0),
+                })
+                .sum();
+            progress.emit(UploadEvent::Start {
+                total_files: uploads.len(),
+                total_bytes,
+            });
 
-        let add_files: Vec<BucketAddFile> = uploads
-            .iter()
-            .zip(xet_infos.iter())
-            .map(|((remote, _source), xet_info)| BucketAddFile {
-                path: remote.clone(),
-                xet_hash: xet_info.hash.clone(),
-                size: xet_info.file_size.unwrap_or(0),
-                mtime: None,
-                content_type: None,
-            })
-            .collect();
+            let xet_infos = self.xet_upload(&uploads, &progress).await?;
 
-        self.batch_operations().add_files(add_files).send().await?;
+            let add_files: Vec<BucketAddFile> = uploads
+                .iter()
+                .zip(xet_infos.iter())
+                .map(|((remote, _source), xet_info)| BucketAddFile {
+                    path: remote.clone(),
+                    xet_hash: xet_info.hash.clone(),
+                    size: xet_info.file_size.unwrap_or(0),
+                    mtime: None,
+                    content_type: None,
+                })
+                .collect();
 
-        progress.emit(UploadEvent::Complete);
-        Ok(())
+            self.batch_operations().add_files(add_files).send().await?;
+
+            progress.emit(UploadEvent::Complete);
+            Ok(())
+        }
     }
 }
 

--- a/hf-hub/src/buckets/sync.rs
+++ b/hf-hub/src/buckets/sync.rs
@@ -26,7 +26,9 @@ use globset::{Glob, GlobMatcher};
 
 use crate::buckets::{BucketTreeEntry, BucketUpload, HFBucket};
 use crate::error::{HFError, HFResult};
-use crate::progress::{DownloadEvent, EmitEvent, Progress};
+use crate::progress::Progress;
+#[cfg(feature = "xet")]
+use crate::progress::{DownloadEvent, EmitEvent};
 
 /// Direction for a bucket sync operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,6 +94,8 @@ pub struct BucketSyncPlan {
     pub operations: Vec<BucketSyncOperation>,
     /// Bucket tree entries for download operations, keyed by relative path.
     /// Used internally during execution to avoid re-fetching metadata.
+    /// Only read on the xet download path (bucket downloads require xet).
+    #[cfg_attr(not(feature = "xet"), allow(dead_code))]
     pub(crate) download_entries: HashMap<String, BucketTreeEntry>,
 }
 
@@ -643,48 +647,58 @@ impl HFBucket {
     }
 
     async fn execute_download_plan(&self, plan: &BucketSyncPlan, params: &BucketSyncParams) -> HFResult<()> {
-        let mut xet_batch_files = Vec::new();
-        let mut total_bytes: u64 = 0;
-
-        for op in plan.operations.iter().filter(|op| op.action == BucketSyncAction::Download) {
-            let entry = plan.download_entries.get(&op.path).ok_or_else(|| HFError::EntryNotFound {
-                path: op.path.clone(),
-                repo_id: self.bucket_id(),
-                context: None,
-            })?;
-
-            let local_path = params.local_path.join(&op.path);
-            if let Some(parent) = local_path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-
-            match entry {
-                BucketTreeEntry::File { xet_hash, size, .. } => {
-                    let remote_path = match &params.prefix {
-                        Some(prefix) => format!("{prefix}/{}", op.path),
-                        None => op.path.clone(),
-                    };
-                    total_bytes += size;
-                    xet_batch_files.push(crate::xet::XetBatchFile {
-                        hash: xet_hash.clone(),
-                        file_size: *size,
-                        path: local_path,
-                        filename: remote_path,
-                    });
-                },
-                BucketTreeEntry::Directory { path, .. } => {
-                    return Err(HFError::InvalidParameter(format!("Cannot download directory entry: {path}")));
-                },
+        #[cfg(not(feature = "xet"))]
+        {
+            if plan.operations.iter().any(|op| op.action == BucketSyncAction::Download) {
+                return Err(HFError::xet_feature_disabled(crate::error::XetOperation::BucketBatchDownload));
             }
         }
 
-        if !xet_batch_files.is_empty() {
-            params.progress.emit(DownloadEvent::Start {
-                total_files: xet_batch_files.len(),
-                total_bytes,
-            });
-            self.xet_download_batch(&xet_batch_files, &params.progress).await?;
-            params.progress.emit(DownloadEvent::Complete);
+        #[cfg(feature = "xet")]
+        {
+            let mut xet_batch_files = Vec::new();
+            let mut total_bytes: u64 = 0;
+
+            for op in plan.operations.iter().filter(|op| op.action == BucketSyncAction::Download) {
+                let entry = plan.download_entries.get(&op.path).ok_or_else(|| HFError::EntryNotFound {
+                    path: op.path.clone(),
+                    repo_id: self.bucket_id(),
+                    context: None,
+                })?;
+
+                let local_path = params.local_path.join(&op.path);
+                if let Some(parent) = local_path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+
+                match entry {
+                    BucketTreeEntry::File { xet_hash, size, .. } => {
+                        let remote_path = match &params.prefix {
+                            Some(prefix) => format!("{prefix}/{}", op.path),
+                            None => op.path.clone(),
+                        };
+                        total_bytes += size;
+                        xet_batch_files.push(crate::xet::XetBatchFile {
+                            hash: xet_hash.clone(),
+                            file_size: *size,
+                            path: local_path,
+                            filename: remote_path,
+                        });
+                    },
+                    BucketTreeEntry::Directory { path, .. } => {
+                        return Err(HFError::InvalidParameter(format!("Cannot download directory entry: {path}")));
+                    },
+                }
+            }
+
+            if !xet_batch_files.is_empty() {
+                params.progress.emit(DownloadEvent::Start {
+                    total_files: xet_batch_files.len(),
+                    total_bytes,
+                });
+                self.xet_download_batch(&xet_batch_files, &params.progress).await?;
+                params.progress.emit(DownloadEvent::Complete);
+            }
         }
 
         let delete_paths: Vec<&str> = plan

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -83,6 +83,7 @@ pub(crate) struct HFClientInner {
     pub(crate) token: Option<String>,
     pub(crate) cache_dir: std::path::PathBuf,
     pub(crate) cache_enabled: bool,
+    #[cfg(feature = "xet")]
     pub(crate) xet_state: std::sync::Mutex<crate::xet::XetState>,
 }
 
@@ -236,6 +237,7 @@ impl HFClientBuilder {
                 token,
                 cache_dir,
                 cache_enabled: self.cache_enabled.unwrap_or(true),
+                #[cfg(feature = "xet")]
                 xet_state: std::sync::Mutex::new(crate::xet::XetState::default()),
             }),
         })
@@ -428,6 +430,7 @@ impl HFClient {
     /// [`replace_xet_session`](Self::replace_xet_session) so that only the
     /// caller that observed the error triggers a replacement — concurrent
     /// callers that already got a session won't clobber it.
+    #[cfg(feature = "xet")]
     pub(crate) fn xet_session(&self) -> HFResult<(xet::xet_session::XetSession, u64)> {
         let mut guard = self
             .inner
@@ -462,6 +465,7 @@ impl HFClient {
     /// Called by xet call sites when a factory method returns an error.
     /// The generation check ensures that if another thread already replaced
     /// the session, this call is a no-op rather than discarding the fresh one.
+    #[cfg(feature = "xet")]
     pub(crate) fn replace_xet_session(&self, generation: u64, err: &xet::error::XetError) {
         tracing::warn!(error = %err, generation, "replacing cached XetSession");
         let Ok(mut guard) = self.inner.xet_state.lock() else {
@@ -588,6 +592,7 @@ mod tests {
         assert!(path_str.contains("huggingface") && path_str.ends_with("hub"));
     }
 
+    #[cfg(feature = "xet")]
     #[test]
     fn test_xet_session_lazy_creation() {
         let client = HFClientBuilder::new().build().unwrap();
@@ -596,6 +601,7 @@ mod tests {
         assert!(client.inner.xet_state.lock().unwrap().session.is_some());
     }
 
+    #[cfg(feature = "xet")]
     #[test]
     fn test_xet_session_shared_across_clones() {
         let client = HFClientBuilder::new().build().unwrap();
@@ -604,6 +610,7 @@ mod tests {
         assert!(clone.inner.xet_state.lock().unwrap().session.is_some());
     }
 
+    #[cfg(feature = "xet")]
     #[test]
     fn test_xet_session_recovers_after_abort() {
         let client = HFClientBuilder::new().build().unwrap();
@@ -620,6 +627,7 @@ mod tests {
         assert!(recovered.new_file_download_group().is_ok());
     }
 
+    #[cfg(feature = "xet")]
     #[test]
     fn test_xet_session_recovers_after_sigint_abort() {
         let client = HFClientBuilder::new().build().unwrap();
@@ -637,6 +645,7 @@ mod tests {
     /// 1. Get session + generation, factory call fails
     /// 2. Call replace_xet_session(generation) to drop the bad session
     /// 3. Get a fresh session, factory call succeeds
+    #[cfg(feature = "xet")]
     #[test]
     fn test_replace_and_retry_after_abort() {
         let client = HFClientBuilder::new().build().unwrap();
@@ -662,6 +671,7 @@ mod tests {
     }
 
     /// Verifies that replace_xet_session with a stale generation is a no-op.
+    #[cfg(feature = "xet")]
     #[test]
     fn test_replace_with_stale_generation_is_noop() {
         let client = HFClientBuilder::new().build().unwrap();
@@ -685,6 +695,7 @@ mod tests {
         assert!(still_fresh.new_file_download_group().is_ok());
     }
 
+    #[cfg(feature = "xet")]
     #[test]
     fn test_xet_session_reuse_without_replacement() {
         let client = HFClientBuilder::new().build().unwrap();

--- a/hf-hub/src/error.rs
+++ b/hf-hub/src/error.rs
@@ -224,6 +224,23 @@ pub enum HFError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    /// A transfer required the xet protocol, but this build of `hf-hub` was
+    /// compiled without the `xet` feature.
+    ///
+    /// The [`operation`](Self::XetFeatureDisabled::operation) field identifies
+    /// which xet step was requested. Enable the `xet` feature (on by default) to
+    /// perform xet-backed transfers, or use `default-features = false` builds
+    /// only against repositories/files that are not xet-backed.
+    #[error(
+        "This operation requires xet transfers, but hf-hub was built without the `xet` feature \
+         (operation: {operation}). Rebuild hf-hub with the `xet` feature enabled — it is on by \
+         default; if you set `default-features = false`, add `features = [\"xet\"]`."
+    )]
+    XetFeatureDisabled {
+        /// Which xet operation was requested but is unavailable.
+        operation: XetOperation,
+    },
+
     /// Hub responded with success but the response is missing data the client
     /// needs to proceed (e.g., an `ETag` or `X-Repo-Commit` header that should
     /// always be present, or a `304 Not Modified` without a corresponding
@@ -303,6 +320,14 @@ impl HFError {
             operation,
             source: Box::new(source),
         }
+    }
+
+    /// Construct an [`HFError::XetFeatureDisabled`] for the given operation.
+    ///
+    /// Used at the seams where a xet-backed transfer would otherwise be
+    /// dispatched, when the crate was built without the `xet` feature.
+    pub fn xet_feature_disabled(operation: XetOperation) -> Self {
+        HFError::XetFeatureDisabled { operation }
     }
 
     /// Construct a [`HFError::MalformedResponse`] without a known URL.

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -36,7 +36,7 @@
 //! - **Spaces** — runtime, hardware, secrets, variables, pause/restart.
 //! - **Buckets** — namespaced storage buckets, tree listings, and bucket sync plans.
 //! - **Xet transfers** — high-performance chunk-deduplicated uploads and downloads integrated transparently into the
-//!   file APIs.
+//!   file APIs (behind the default-on `xet` feature).
 //! - **Optional blocking API** — synchronous counterparts to every async handle when the `blocking` feature is enabled.
 //!
 //! ## Creating a client
@@ -184,6 +184,11 @@
 //!
 //! ## Cargo features
 //!
+//! - `xet` — **on by default.** Enables [Xet](https://huggingface.co/docs/hub/storage-backends) high-performance,
+//!   chunk-deduplicated transfers via the `hf-xet` dependency. Disable with `default-features = false` to drop `hf-xet`
+//!   (and its transitive requirements, such as a newer `tokio` floor) when you only touch metadata or non-xet-backed
+//!   files. With the feature off, any transfer that would use xet fails with [`HFError::XetFeatureDisabled`] rather
+//!   than silently falling back to a slower path.
 //! - `blocking` — enables the synchronous `*Sync` handles.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -211,6 +216,7 @@ pub mod progress;
 pub mod repository;
 pub mod spaces;
 pub mod users;
+#[cfg(feature = "xet")]
 pub(crate) mod xet;
 
 #[cfg(all(feature = "blocking", not(target_family = "wasm")))]

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -194,27 +194,39 @@ impl<T: RepoType> HFRepository<T> {
         let (xet_hash, file_size_hint) = self.resolve_xet_hash_and_size(revision, &params.filename).await?;
 
         if let Some(xet_hash) = xet_hash {
-            let file_size: u64 = file_size_hint.unwrap_or_else(|| {
-                tracing::warn!(url = %url, "missing file size for xet file, defaulting to 0");
-                0
-            });
+            #[cfg(not(feature = "xet"))]
+            {
+                let _ = (&xet_hash, &file_size_hint);
+                return Err(HFError::xet_feature_disabled(crate::error::XetOperation::StreamDownload));
+            }
+            #[cfg(feature = "xet")]
+            {
+                let file_size: u64 = file_size_hint.unwrap_or_else(|| {
+                    tracing::warn!(url = %url, "missing file size for xet file, defaulting to 0");
+                    0
+                });
 
-            let content_length = params.range.as_ref().map(|r| r.end.saturating_sub(r.start)).or(Some(file_size));
+                let content_length = params.range.as_ref().map(|r| r.end.saturating_sub(r.start)).or(Some(file_size));
 
-            let stream = self
-                .xet_download_stream(revision, &xet_hash, file_size, params.range.clone())
-                .await?;
+                let stream = self
+                    .xet_download_stream(revision, &xet_hash, file_size, params.range.clone())
+                    .await?;
 
-            let total_bytes = content_length.unwrap_or(0);
-            params.progress.emit(DownloadEvent::Start {
-                total_files: 1,
-                total_bytes,
-            });
-            let wrapped =
-                wrap_stream_with_progress(Box::new(Box::pin(stream)), params.progress, params.filename, total_bytes);
-            #[cfg(target_family = "wasm")]
-            let wrapped = buffer_wasm_stream(wrapped);
-            return Ok((content_length, wrapped));
+                let total_bytes = content_length.unwrap_or(0);
+                params.progress.emit(DownloadEvent::Start {
+                    total_files: 1,
+                    total_bytes,
+                });
+                let wrapped = wrap_stream_with_progress(
+                    Box::new(Box::pin(stream)),
+                    params.progress,
+                    params.filename,
+                    total_bytes,
+                );
+                #[cfg(target_family = "wasm")]
+                let wrapped = buffer_wasm_stream(wrapped);
+                return Ok((content_length, wrapped));
+            }
         }
 
         let range_header = params
@@ -300,10 +312,15 @@ impl<T: RepoType> HFRepository<T> {
         });
 
         if has_xet_hash {
-            let local_dir = params.local_dir.as_ref().unwrap();
-            return self
-                .xet_download_to_local_dir(revision, &params.filename, local_dir, &head_response, &params.progress)
-                .await;
+            #[cfg(not(feature = "xet"))]
+            return Err(HFError::xet_feature_disabled(crate::error::XetOperation::Download));
+            #[cfg(feature = "xet")]
+            {
+                let local_dir = params.local_dir.as_ref().unwrap();
+                return self
+                    .xet_download_to_local_dir(revision, &params.filename, local_dir, &head_response, &params.progress)
+                    .await;
+            }
         }
 
         let response = retry::retry(self.hf_client.retry_config(), || {
@@ -527,20 +544,33 @@ impl<T: RepoType> HFRepository<T> {
         });
 
         if has_xet_hash {
-            let xet_hash =
-                xet_hash.ok_or_else(|| HFError::malformed_response_at("missing X-Xet-Hash header", url.clone()))?;
-            let blob = cache::blob_path(cache_dir, repo_folder, &etag);
-            if !blob.exists() || force_download {
-                if let Some(parent) = blob.parent() {
-                    std::fs::create_dir_all(parent)?;
-                }
-                let _lock = cache::acquire_lock(cache_dir, repo_folder, &etag).await?;
+            #[cfg(not(feature = "xet"))]
+            return Err(HFError::xet_feature_disabled(crate::error::XetOperation::Download));
+            #[cfg(feature = "xet")]
+            {
+                let xet_hash =
+                    xet_hash.ok_or_else(|| HFError::malformed_response_at("missing X-Xet-Hash header", url.clone()))?;
+                let blob = cache::blob_path(cache_dir, repo_folder, &etag);
+                if !blob.exists() || force_download {
+                    if let Some(parent) = blob.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    let _lock = cache::acquire_lock(cache_dir, repo_folder, &etag).await?;
 
-                self.xet_download_to_blob(revision, &params.filename, &xet_hash, file_size, &blob, &params.progress)
+                    self.xet_download_to_blob(
+                        revision,
+                        &params.filename,
+                        &xet_hash,
+                        file_size,
+                        &blob,
+                        &params.progress,
+                    )
                     .await?;
-            }
+                }
 
-            return finalize_cached_file(cache_dir, repo_folder, revision, &commit_hash, &params.filename, &etag).await;
+                return finalize_cached_file(cache_dir, repo_folder, revision, &commit_hash, &params.filename, &etag)
+                    .await;
+            }
         }
 
         let blob = cache::blob_path(cache_dir, repo_folder, &etag);
@@ -800,17 +830,22 @@ impl<T: RepoType> HFRepository<T> {
                 if xet_metas.is_empty() {
                     return Ok::<_, HFError>(());
                 }
-                let batch_files: Vec<crate::xet::XetBatchFile> = xet_metas
-                    .iter()
-                    .map(|m| crate::xet::XetBatchFile {
-                        hash: m.xet_hash.as_ref().unwrap().clone(),
-                        file_size: m.file_size,
-                        path: local_dir.join(&m.filename),
-                        filename: m.filename.clone(),
-                    })
-                    .collect();
-                self.xet_download_batch(&commit_hash, &batch_files, &params.progress).await?;
-                Ok(())
+                #[cfg(not(feature = "xet"))]
+                return Err(HFError::xet_feature_disabled(crate::error::XetOperation::BatchDownload));
+                #[cfg(feature = "xet")]
+                {
+                    let batch_files: Vec<crate::xet::XetBatchFile> = xet_metas
+                        .iter()
+                        .map(|m| crate::xet::XetBatchFile {
+                            hash: m.xet_hash.as_ref().unwrap().clone(),
+                            file_size: m.file_size,
+                            path: local_dir.join(&m.filename),
+                            filename: m.filename.clone(),
+                        })
+                        .collect();
+                    self.xet_download_batch(&commit_hash, &batch_files, &params.progress).await?;
+                    Ok(())
+                }
             };
 
             let non_xet_dl_params = build_download_params(
@@ -860,25 +895,31 @@ impl<T: RepoType> HFRepository<T> {
             if xet_metas.is_empty() {
                 return Ok::<_, HFError>(());
             }
-            let mut locks = Vec::with_capacity(xet_metas.len());
-            for m in &xet_metas {
-                locks.push(cache::acquire_lock(cache_dir, &repo_folder, &m.etag).await?);
+            #[cfg(not(feature = "xet"))]
+            return Err(HFError::xet_feature_disabled(crate::error::XetOperation::BatchDownload));
+            #[cfg(feature = "xet")]
+            {
+                let mut locks = Vec::with_capacity(xet_metas.len());
+                for m in &xet_metas {
+                    locks.push(cache::acquire_lock(cache_dir, &repo_folder, &m.etag).await?);
+                }
+                let batch_files: Vec<crate::xet::XetBatchFile> = xet_metas
+                    .iter()
+                    .map(|m| crate::xet::XetBatchFile {
+                        hash: m.xet_hash.as_ref().unwrap().clone(),
+                        file_size: m.file_size,
+                        path: cache::blob_path(cache_dir, &repo_folder, &m.etag),
+                        filename: m.filename.clone(),
+                    })
+                    .collect();
+                self.xet_download_batch(&commit_hash, &batch_files, &params.progress).await?;
+                for m in &xet_metas {
+                    cache::create_pointer_symlink(cache_dir, &repo_folder, &m.commit_hash, &m.filename, &m.etag)
+                        .await?;
+                }
+                drop(locks);
+                Ok(())
             }
-            let batch_files: Vec<crate::xet::XetBatchFile> = xet_metas
-                .iter()
-                .map(|m| crate::xet::XetBatchFile {
-                    hash: m.xet_hash.as_ref().unwrap().clone(),
-                    file_size: m.file_size,
-                    path: cache::blob_path(cache_dir, &repo_folder, &m.etag),
-                    filename: m.filename.clone(),
-                })
-                .collect();
-            self.xet_download_batch(&commit_hash, &batch_files, &params.progress).await?;
-            for m in &xet_metas {
-                cache::create_pointer_symlink(cache_dir, &repo_folder, &m.commit_hash, &m.filename, &m.etag).await?;
-            }
-            drop(locks);
-            Ok(())
         };
 
         let non_xet_dl_params = build_download_params(

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -38,6 +38,7 @@ pub use files::{
     RepoTreeEntry, SourceByteStream, StreamFactory, StreamSource,
 };
 #[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "xet")]
 pub(crate) use files::{extract_file_size, extract_xet_hash};
 use futures::Stream;
 pub use repo_type::{RepoType, RepoTypeAny, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -467,6 +467,9 @@ impl<T: RepoType> HFRepository<T> {
     }
 
     /// Compute SHA256, negotiate LFS batch transfer, and upload via xet.
+    // `params` (progress) is only consumed on the xet upload path; without the
+    // `xet` feature the function errors before using it.
+    #[cfg_attr(not(feature = "xet"), allow(unused_variables))]
     async fn upload_lfs_files_via_xet(
         &self,
         params: &CreateCommitParams,
@@ -504,19 +507,29 @@ impl<T: RepoType> HFRepository<T> {
             return Ok(HashMap::new());
         }
 
-        let xet_files: Vec<(String, AddSource)> = lfs_with_sha
-            .iter()
-            .map(|(path, _, _, source)| (path.clone(), (*source).clone()))
-            .collect();
+        // The Hub selected the xet transfer. With the `xet` feature off we do not
+        // advertise xet (see `post_lfs_batch_info`), so this only happens when a
+        // repo hard-requires xet — surface it as an explicit error rather than
+        // silently degrading.
+        #[cfg(not(feature = "xet"))]
+        return Err(crate::error::HFError::xet_feature_disabled(crate::error::XetOperation::Upload));
 
-        self.xet_upload(&xet_files, revision, &params.progress).await?;
+        #[cfg(feature = "xet")]
+        {
+            let xet_files: Vec<(String, AddSource)> = lfs_with_sha
+                .iter()
+                .map(|(path, _, _, source)| (path.clone(), (*source).clone()))
+                .collect();
 
-        let result: HashMap<String, (String, u64)> = lfs_with_sha
-            .into_iter()
-            .map(|(path, size, oid, _)| (path, (oid, size)))
-            .collect();
+            self.xet_upload(&xet_files, revision, &params.progress).await?;
 
-        Ok(result)
+            let result: HashMap<String, (String, u64)> = lfs_with_sha
+                .into_iter()
+                .map(|(path, size, oid, _)| (path, (oid, size)))
+                .collect();
+
+            Ok(result)
+        }
     }
 
     /// Call the LFS batch endpoint to negotiate the transfer method.
@@ -540,9 +553,18 @@ impl<T: RepoType> HFRepository<T> {
             })
             .collect();
 
+        // Only advertise the xet transfer when the feature is compiled in. This
+        // steers the Hub's LFS negotiation toward `basic`/`multipart` for
+        // xet-off builds; a repo that still requires xet then has that surfaced
+        // as an explicit error at the upload seam below.
+        #[cfg(feature = "xet")]
+        let transfers = serde_json::json!(["basic", "multipart", "xet"]);
+        #[cfg(not(feature = "xet"))]
+        let transfers = serde_json::json!(["basic", "multipart"]);
+
         let body = serde_json::json!({
             "operation": "upload",
-            "transfers": ["basic", "multipart", "xet"],
+            "transfers": transfers,
             "objects": objects_payload,
             "hash_algo": "sha256",
             "ref": { "name": revision },

--- a/scripts/verify_wasm.sh
+++ b/scripts/verify_wasm.sh
@@ -3,7 +3,10 @@
 #
 # Filesystem-heavy modules (cache, blocking, buckets, snapshot download, etc.)
 # are gated off on wasm. What this script verifies:
-#   1. The whole crate builds against the wasm32 target with no default features.
+#   1. The whole crate builds against the wasm32 target with no default features
+#      (i.e. with the `xet` feature disabled — the metadata/non-xet-file path).
+#   1b. The crate also builds with the `xet` feature enabled on wasm (the
+#      threaded `hf-xet` wasm download path).
 #   2. The `wasm/smoke` crate typechecks against the wasm32 target — it
 #      exercises `HFRepository::download_file_stream` through wasm-bindgen, which
 #      is the same call shape used on native and is backed by `hf-xet`'s xet
@@ -21,8 +24,12 @@ if ! rustup target list --installed | grep -q wasm32-unknown-unknown; then
   rustup target add wasm32-unknown-unknown
 fi
 
-echo "==> cargo check -p hf-hub --target wasm32-unknown-unknown --no-default-features"
+echo "==> cargo check -p hf-hub --target wasm32-unknown-unknown --no-default-features (xet disabled)"
 cargo check -p hf-hub --target wasm32-unknown-unknown --no-default-features
+
+echo
+echo "==> cargo check -p hf-hub --target wasm32-unknown-unknown --no-default-features --features xet (xet enabled)"
+cargo check -p hf-hub --target wasm32-unknown-unknown --no-default-features --features xet
 
 echo
 echo "==> cargo check (wasm/smoke) — exercises HFRepository::download_file_stream through wasm-bindgen"


### PR DESCRIPTION
## What

Makes the `hf-xet` dependency **optional**, gated behind a new `xet` cargo feature (**on by default**). When the feature is disabled, `hf-xet` is dropped from the dependency tree and any transfer that would use xet fails with a descriptive `HFError::XetFeatureDisabled` error — there is **no silent fallback** to plain HTTP.

## Motivation

Consumer validation surfaced real breakage from hf-hub 1.0's unconditional `hf-xet` dependency:

- `hf-xet` (via xet-core) floors **tokio at `^1.49`** (it uses `Handle::id()`, stabilized in tokio 1.49).
- **sglang's router** and **NVIDIA dynamo** both pin `tokio = "=1.48.0"` (dynamo ships this pin in its published crates). Against hf-hub 1.0 this makes cargo resolution *impossible* — no tokio version satisfies both.
- sglang only pulls two small, git-stored JSON files (`tokenizer.json`, `tokenizer_config.json`). These are **not** xet-backed, so xet buys them nothing while forcing the tokio floor and a large transitive tree onto them.

Making `hf-xet` optional lets metadata / small-file / non-xet consumers resolve freely and shrink their dependency tree, while xet stays available (and default-on) for consumers that want fast large-file transfers. This mirrors Python `huggingface_hub`, where `hf_xet` is an optional extra.

## Design decision: fail loudly, no HTTP fallback

Per the agreed design, when the `xet` feature is **off**, xet-requiring transfers **fail with a clear runtime error** rather than degrading. New error variant:

```rust
HFError::XetFeatureDisabled { operation: XetOperation }
```

Where the errors sit (the seams where the xet path would have been taken):

| Path | Seam |
|------|------|
| Download (cache) | `download_file_to_cache_network` — when the metadata HEAD carries `x-xet-hash` |
| Download (local_dir) | `download_file_to_local_dir` — when the HEAD carries `x-xet-hash` |
| Download (stream) | `download_file_stream_impl` — when `paths-info`/HEAD reports a xet hash |
| Snapshot download | the `xet_batch_fut` in both `local_dir` and cache branches — errors if any file in the set is xet-backed |
| Upload | `upload_lfs_files_via_xet` — after LFS batch negotiation |
| Buckets | `download_file_stream`, `download_files`, `upload_files`, `upload_source_files`, and `sync` download plans (buckets are xet-backed, so these error wholesale) |

### Upload: steering the LFS negotiation

Following the "advertise only non-xet transfers" approach: when `xet` is off, the LFS batch request advertises only `["basic", "multipart"]` instead of `["basic", "multipart", "xet"]`. This lets the Hub pick a non-xet transfer where possible, and a repo that *hard-requires* xet then surfaces the error naturally at the upload seam (defensive `#[cfg(not(feature = "xet"))]` guard on the `xet` branch). This steers the protocol rather than only reacting to it.

### Rejected alternative (considered)

**Plain-HTTP fallback for downloads.** Because the Hub's `resolve` URL 302-redirects to a CAS blob that serves the xet-backed bytes over ordinary HTTP, a xet-off build *could* transparently download xet-backed files without xet. We **rejected** this: silent fallback hides that the fast path is unavailable, produces surprising performance cliffs, and diverges from the "opt out explicitly" contract. Non-xet-backed files still download over plain HTTP as before; only genuinely xet-backed transfers error.

> Observation (pre-existing, out of scope): the `local_dir` download HEAD uses the redirect-following client, so in practice it resolves to the CAS response and doesn't observe `x-xet-hash` — the cache path uses the no-redirect client and detects xet reliably. The gate is in place on both paths regardless; aligning the `local_dir` HEAD with the cache path can be a separate change.

## Feature default: on by default (recommended)

Shipped **`default = ["xet"]`**. Tradeoff:

- **default-ON (chosen):** Non-breaking for existing 1.0 users — upgrading is a no-op. sglang and dynamo already use `default-features = false`, so they are unblocked automatically without any change on their side. New consumers keep the fast path by default.
- **default-OFF (rejected):** Would maximally advance the unblocking goal, but silently drops xet for every existing user on upgrade — a surprising behavioral regression for a point release.

Consumers who want to avoid `hf-xet` (and its tokio floor) opt out:

```toml
hf-hub = { version = "1", default-features = false }
```

### tokio features made explicit

Non-xet code (`tokio::time::sleep` in retry, `tokio::try_join!` in snapshot download, `spawn_blocking` in the upload/cache paths) previously relied on tokio runtime features leaking in transitively via `hf-xet`. Those are now declared directly on hf-hub's tokio dependency (`time`, `macros`, and native-only `rt`) so the crate builds cleanly with `xet` off.

## Test matrix (all green)

Build / clippy `-D warnings`:

- `cargo check/clippy -p hf-hub` (default, xet on)
- `--no-default-features` (xet off)
- `--no-default-features --features xet`
- `--all-features`
- `--no-default-features --features blocking` (blocking without xet)
- `--features blocking` (default + blocking)
- `cargo clippy --workspace --all-targets` and `--all-features`

Tests:

- `cargo test -p hf-hub` (xet on): 190 passed
- `cargo test -p hf-hub --no-default-features` (xet off): 180 passed (the 10 xet-only unit tests are feature-gated)

wasm (`./scripts/verify_wasm.sh`, now checks both configs):

- `-p hf-hub --target wasm32 --no-default-features` (xet off)
- `-p hf-hub --target wasm32 --no-default-features --features xet` (xet on)
- `wasm/smoke` and `wasm/tests`

fmt: `cargo +nightly fmt --check` clean.

### Live verification (HF_TOKEN present)

Downloaded a genuinely xet-backed file (`sentence-transformers/all-MiniLM-L6-v2/model.safetensors`, ~90 MB, `x-xet-hash` present) via the cache path:

- **xet on:** downloads successfully (90,868,376 bytes) — no regression.
- **xet off:** returns `HFError::XetFeatureDisabled { operation: Download }` — error fires, no silent HTTP fallback.

## CI

- Added `--no-default-features` and `--no-default-features --features blocking` clippy steps so the xet-off configuration stays green.
- `verify_wasm.sh` now checks both the xet-off and xet-on wasm builds explicitly.

## Docs

Feature tables updated in `AGENTS.md`, crate docs (`lib.rs` "Cargo features"), and `README.md`.
