### PR TITLE
fix: run blocking API on a dedicated runtime thread so Sync handles are safe in async contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ browser tests and runtime build flags live under `wasm/`.
 
 | Feature | Default? | Notes |
 |---------|----------|-------|
-| `blocking` | off | Synchronous `*Sync` wrappers in `blocking.rs`. Pulls in `tokio/rt`. Native only. |
+| `blocking` | off | Synchronous `*Sync` wrappers in `blocking.rs`. Pulls in `tokio/rt` + `tokio/sync`. Native only. |
 | `rustls-tls` | off | Force the rustls TLS backend on reqwest's native build. No effect on wasm. |
 | `default` | (empty) | No features by default. |
 
@@ -124,7 +124,9 @@ helper that already has the field as an `Option<T>` local).
 
 Every async method MUST have a manually-written blocking counterpart on the corresponding
 `*Sync` struct under `#[cfg(feature = "blocking")]`. Mirror the same `#[builder]` parameter list
-verbatim. The body calls the inner async builder and blocks on the runtime:
+verbatim. The body clones the inner handle into a `'static + Send` future and hands it to the
+client's dedicated runtime thread via `run_future` — never call `Runtime::block_on` on a caller
+thread, since that panics when the caller is already inside a tokio runtime:
 
 ```rust
 #[cfg(feature = "blocking")]
@@ -136,21 +138,16 @@ impl crate::blocking::HFRepositorySync {
         #[builder(into)] name: String,
         revision: Option<String>,
     ) -> HFResult<MyOutput> {
-        self.runtime.block_on(
-            self.inner
-                .my_method()
-                .name(name)
-                .maybe_revision(revision)
-                .send(),
-        )
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.my_method().name(name).maybe_revision(revision).send().await })
     }
 }
 ```
 
-For stream-returning methods, the sync counterpart collects into `Vec<T>`: pin the stream and
-drain with `while let Some` (see existing examples in `repository/listing.rs` and
-`repository/mod.rs`). On `HFSpaceSync`, the runtime is reached via `&self.repo_sync.runtime`
-because the struct has no direct `runtime` field. Do NOT reintroduce the legacy `sync_api!` /
+For stream-returning methods, the sync counterpart collects into `Vec<T>` inside the future
+handed to `run_future`: pin the stream and drain with `while let Some` (see existing examples in
+`repository/listing.rs` and `repository/mod.rs`). Do NOT reintroduce the legacy `sync_api!` /
 `sync_api_stream!` / `sync_api_async_stream!` macros — they were removed deliberately when the
 crate moved to bon.
 

--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -34,7 +34,7 @@ sha2 = "0.11"
 
 [features]
 default = []
-blocking = ["tokio/rt"]
+blocking = ["tokio/rt", "tokio/sync"]
 rustls-tls = ["reqwest/rustls"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -1,35 +1,122 @@
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+
+use futures::FutureExt;
 
 use crate::client::HFClient;
 use crate::error::{HFError, HFResult};
 use crate::repository::{HFRepository, RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};
 
-fn build_runtime() -> HFResult<Arc<tokio::runtime::Runtime>> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map(Arc::new)
-        .map_err(|e| HFError::Other(format!("Failed to create tokio runtime: {e}")))
+/// A dedicated background thread that owns a single-threaded tokio runtime,
+/// modeled on `reqwest::blocking`.
+///
+/// The runtime is created on — and never leaves — the background thread, so
+/// no caller thread ever calls `Runtime::block_on` or drops the runtime.
+/// Both operations panic when performed from inside another tokio runtime,
+/// which is exactly the situation a blocking API embedded in an async
+/// application ends up in. Instead, sync wrapper methods hand a
+/// `'static + Send` future over via [`RuntimeThread::run_future`] and park
+/// on a std channel until the result comes back, which merely blocks the
+/// calling thread.
+///
+/// Shutdown: the background thread sits in
+/// `runtime.block_on(shutdown_rx)`. When the last handle sharing this
+/// `RuntimeThread` drops, the `_shutdown` sender drops with it, the
+/// receiver resolves, `block_on` returns, and the runtime is dropped on its
+/// own thread. The thread is detached rather than joined so that dropping
+/// the last handle never blocks the caller (reqwest-style).
+pub(crate) struct RuntimeThread {
+    handle: tokio::runtime::Handle,
+    _shutdown: tokio::sync::oneshot::Sender<()>,
+}
+
+impl RuntimeThread {
+    /// Spawns the background thread and waits for its runtime to come up.
+    fn spawn() -> HFResult<Arc<Self>> {
+        let (handle_tx, handle_rx) = std::sync::mpsc::channel();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        std::thread::Builder::new()
+            .name("hf-hub-blocking-runtime".to_string())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                    Ok(runtime) => runtime,
+                    Err(e) => {
+                        let _ = handle_tx.send(Err(e));
+                        return;
+                    },
+                };
+                let _ = handle_tx.send(Ok(runtime.handle().clone()));
+                runtime.block_on(async {
+                    let _ = shutdown_rx.await;
+                });
+            })
+            .map_err(|e| HFError::Other(format!("Failed to spawn tokio runtime thread: {e}")))?;
+        let handle = handle_rx
+            .recv()
+            .map_err(|_| HFError::Other("tokio runtime thread exited before initializing".to_string()))?
+            .map_err(|e| HFError::Other(format!("Failed to create tokio runtime: {e}")))?;
+        Ok(Arc::new(Self {
+            handle,
+            _shutdown: shutdown_tx,
+        }))
+    }
+
+    /// Runs `future` on the background runtime and blocks the calling thread
+    /// until it completes.
+    ///
+    /// Safe to call from inside another tokio runtime: the future executes on
+    /// the dedicated thread while the caller parks on a std channel, so no
+    /// runtime is ever entered re-entrantly. If the future panics, the panic
+    /// is resumed on the calling thread, matching the semantics the previous
+    /// `Runtime::block_on`-based implementation had for panicking tasks.
+    pub(crate) fn run_future<F, T>(&self, future: F) -> HFResult<T>
+    where
+        F: Future<Output = HFResult<T>> + Send + 'static,
+        T: Send + 'static,
+    {
+        let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+        self.handle.spawn(async move {
+            let result = AssertUnwindSafe(future).catch_unwind().await;
+            let _ = result_tx.send(result);
+        });
+        match result_rx.recv() {
+            Ok(Ok(result)) => result,
+            Ok(Err(panic)) => std::panic::resume_unwind(panic),
+            Err(_) => Err(HFError::Other("hf-hub blocking runtime thread stopped unexpectedly".to_string())),
+        }
+    }
+}
+
+impl std::fmt::Debug for RuntimeThread {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuntimeThread").finish()
+    }
 }
 
 /// Synchronous/blocking counterpart to [`HFClient`].
 ///
-/// Wraps an [`HFClient`] together with a dedicated single-threaded tokio
-/// runtime so the async API can be used from synchronous code.
+/// Wraps an [`HFClient`] together with a dedicated background thread that
+/// owns a single-threaded tokio runtime, so the async API can be used from
+/// synchronous code. Because the runtime lives on its own thread (the
+/// `reqwest::blocking` model), the blocking methods are also safe to call
+/// from inside an async runtime: the call blocks the current thread while
+/// the work runs on the background thread, instead of panicking on tokio's
+/// nested-runtime guard.
 ///
 /// Xet uploads and downloads do not run on this runtime: hf-xet requires a
 /// multi-threaded runtime with the IO and time drivers enabled, so the
 /// single-threaded runtime here does not meet its requirements. When a Xet
 /// transfer is triggered through any blocking handle, hf-xet spins up its
 /// own multi-threaded thread pool to back the `XetSession`, separate from
-/// the runtime owned by `HFClientSync`.
+/// the runtime on the background thread owned by `HFClientSync`.
 ///
 /// See [`HFClient`] for configuration and API semantics.
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 #[derive(Clone)]
 pub struct HFClientSync {
     pub(crate) inner: HFClient,
-    pub(crate) runtime: Arc<tokio::runtime::Runtime>,
+    pub(crate) runtime: Arc<RuntimeThread>,
 }
 
 /// Synchronous/blocking counterpart to [`HFRepository`], parameterized by the repo kind via `T`.
@@ -40,7 +127,7 @@ pub struct HFClientSync {
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub struct HFRepositorySync<T: RepoType> {
     pub(crate) inner: Arc<HFRepository<T>>,
-    pub(crate) runtime: Arc<tokio::runtime::Runtime>,
+    pub(crate) runtime: Arc<RuntimeThread>,
 }
 
 impl<T: RepoType> Clone for HFRepositorySync<T> {
@@ -62,7 +149,7 @@ impl<T: RepoType> Clone for HFRepositorySync<T> {
 #[derive(Clone)]
 pub struct HFBucketSync {
     pub(crate) inner: Arc<crate::buckets::HFBucket>,
-    pub(crate) runtime: Arc<tokio::runtime::Runtime>,
+    pub(crate) runtime: Arc<RuntimeThread>,
 }
 
 impl std::fmt::Debug for HFClientSync {
@@ -94,7 +181,7 @@ impl HFClientSync {
     pub fn new() -> HFResult<Self> {
         Ok(Self {
             inner: HFClient::new()?,
-            runtime: build_runtime()?,
+            runtime: RuntimeThread::spawn()?,
         })
     }
 
@@ -106,7 +193,7 @@ impl HFClientSync {
     pub fn from_inner(inner: HFClient) -> HFResult<Self> {
         Ok(Self {
             inner,
-            runtime: build_runtime()?,
+            runtime: RuntimeThread::spawn()?,
         })
     }
 
@@ -233,5 +320,80 @@ mod tests {
         assert_eq!(repo.name(), "gpt2");
         assert_eq!(repo.repo_type().singular(), "model");
         assert_eq!(space.repo_type().singular(), "space");
+    }
+
+    /// Endpoint that refuses connections: bind an ephemeral port, then free it.
+    fn unreachable_endpoint() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        format!("http://127.0.0.1:{port}")
+    }
+
+    fn client_with_unreachable_endpoint() -> HFClientSync {
+        let inner = HFClient::builder()
+            .endpoint(unreachable_endpoint())
+            .retry_max_attempts(0)
+            .build()
+            .unwrap();
+        HFClientSync::from_inner(inner).unwrap()
+    }
+
+    /// Regression test: with the runtime owned by the caller-side handle, this
+    /// panicked on tokio's nested-runtime guard ("Cannot start a runtime from
+    /// within a runtime"). The connection error is expected; the point is
+    /// completing without a panic.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sync_call_inside_multi_thread_runtime_does_not_panic() {
+        let client = client_with_unreachable_endpoint();
+        let result = client.model("openai-community", "gpt2").info().send();
+        assert!(result.is_err());
+    }
+
+    /// Same regression as the multi-thread flavor. The call blocks the only
+    /// runtime thread while the work runs on the dedicated background thread,
+    /// so it still completes.
+    #[tokio::test]
+    async fn sync_call_inside_current_thread_runtime_does_not_panic() {
+        let client = client_with_unreachable_endpoint();
+        let result = client.model("openai-community", "gpt2").info().send();
+        assert!(result.is_err());
+    }
+
+    /// Regression test: dropping the handle (and with it the old caller-side
+    /// `Runtime`) from async context also panicked before the runtime moved
+    /// to its own thread.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn construct_and_drop_inside_async_context_does_not_panic() {
+        let client = HFClientSync::from_inner(HFClient::builder().build().unwrap()).unwrap();
+        drop(client);
+    }
+
+    #[test]
+    fn clones_share_runtime_thread_and_survive_staggered_drops() {
+        let client = client_with_unreachable_endpoint();
+        let clone = client.clone();
+        let repo = client.model("openai-community", "gpt2");
+        assert!(Arc::ptr_eq(&client.runtime, &clone.runtime));
+        assert!(Arc::ptr_eq(&client.runtime, &repo.runtime));
+
+        drop(client);
+        drop(clone);
+        let result = repo.exists().send();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn run_future_resumes_task_panics_on_the_caller() {
+        let runtime = RuntimeThread::spawn().unwrap();
+        let caught = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            runtime.run_future(async {
+                panic!("boom");
+                #[allow(unreachable_code)]
+                Ok::<(), HFError>(())
+            })
+        }));
+        let panic = caught.unwrap_err();
+        assert_eq!(panic.downcast_ref::<&str>(), Some(&"boom"));
     }
 }

--- a/hf-hub/src/buckets/mod.rs
+++ b/hf-hub/src/buckets/mod.rs
@@ -1095,16 +1095,18 @@ impl crate::blocking::HFClientSync {
         #[builder(into)] resource_group_id: Option<String>,
         #[builder(default)] exist_ok: bool,
     ) -> HFResult<BucketUrl> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .create_bucket()
                 .namespace(namespace)
                 .name(name)
                 .private(private)
                 .maybe_resource_group_id(resource_group_id)
                 .exist_ok(exist_ok)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFClient::delete_bucket`]. See the async method for parameters
@@ -1115,16 +1117,18 @@ impl crate::blocking::HFClientSync {
         #[builder(into)] bucket_id: String,
         #[builder(default)] missing_ok: bool,
     ) -> HFResult<()> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.delete_bucket().bucket_id(bucket_id).missing_ok(missing_ok).send())
+            .run_future(async move { inner.delete_bucket().bucket_id(bucket_id).missing_ok(missing_ok).send().await })
     }
 
     /// Blocking counterpart of [`HFClient::list_buckets`]. Collects the stream into a
     /// `Vec<BucketInfo>`. See the async method for parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn list_buckets(&self, #[builder(into)] namespace: String) -> HFResult<Vec<BucketInfo>> {
-        self.runtime.block_on(async move {
-            let stream = self.inner.list_buckets().namespace(namespace).send()?;
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner.list_buckets().namespace(namespace).send()?;
             futures::pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(item) = stream.next().await {
@@ -1138,8 +1142,9 @@ impl crate::blocking::HFClientSync {
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn move_bucket(&self, #[builder(into)] from_id: String, #[builder(into)] to_id: String) -> HFResult<()> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.move_bucket().from_id(from_id).to_id(to_id).send())
+            .run_future(async move { inner.move_bucket().from_id(from_id).to_id(to_id).send().await })
     }
 }
 
@@ -1149,7 +1154,8 @@ impl crate::blocking::HFBucketSync {
     /// Blocking counterpart of [`HFBucket::info`].
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn info(&self) -> HFResult<BucketInfo> {
-        self.runtime.block_on(self.inner.info().send())
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move { inner.info().send().await })
     }
 
     /// Blocking counterpart of [`HFBucket::list_tree`]. Collects the stream into a
@@ -1160,8 +1166,9 @@ impl crate::blocking::HFBucketSync {
         #[builder(into)] prefix: Option<String>,
         #[builder(default)] recursive: bool,
     ) -> HFResult<Vec<BucketTreeEntry>> {
-        self.runtime.block_on(async move {
-            let stream = self.inner.list_tree().maybe_prefix(prefix).recursive(recursive).send()?;
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner.list_tree().maybe_prefix(prefix).recursive(recursive).send()?;
             futures::pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(item) = stream.next().await {
@@ -1175,15 +1182,18 @@ impl crate::blocking::HFBucketSync {
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn get_paths_info(&self, paths: Vec<String>) -> HFResult<Vec<BucketTreeEntry>> {
-        self.runtime.block_on(self.inner.get_paths_info().paths(paths).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.get_paths_info().paths(paths).send().await })
     }
 
     /// Blocking counterpart of [`HFBucket::get_file_metadata`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn get_file_metadata(&self, #[builder(into)] remote_path: String) -> HFResult<BucketFileMetadata> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.get_file_metadata().remote_path(remote_path).send())
+            .run_future(async move { inner.get_file_metadata().remote_path(remote_path).send().await })
     }
 
     /// Blocking counterpart of [`HFBucket::batch_operations`]. See the async method for parameters and
@@ -1195,21 +1205,25 @@ impl crate::blocking::HFBucketSync {
         #[builder(default)] delete: Vec<String>,
         #[builder(default)] copy: Vec<BucketCopyFile>,
     ) -> HFResult<()> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .batch_operations()
                 .add_files(add_files)
                 .delete(delete)
                 .copy(copy)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFBucket::delete_files`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn delete_files(&self, paths: Vec<String>) -> HFResult<()> {
-        self.runtime.block_on(self.inner.delete_files().paths(paths).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.delete_files().paths(paths).send().await })
     }
 
     /// Blocking counterpart of [`HFBucket::upload_source_files`]. See the async method for
@@ -1220,16 +1234,18 @@ impl crate::blocking::HFBucketSync {
         files: Vec<(String, crate::repository::AddSource)>,
         #[builder(into)] progress: Option<Progress>,
     ) -> HFResult<()> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.upload_source_files().files(files).maybe_progress(progress).send())
+            .run_future(async move { inner.upload_source_files().files(files).maybe_progress(progress).send().await })
     }
 
     /// Blocking counterpart of [`HFBucket::upload_files`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn upload_files(&self, files: Vec<BucketUpload>, #[builder(into)] progress: Option<Progress>) -> HFResult<()> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.upload_files().files(files).maybe_progress(progress).send())
+            .run_future(async move { inner.upload_files().files(files).maybe_progress(progress).send().await })
     }
 
     /// Blocking counterpart of [`HFBucket::download_files`]. See the async method for parameters
@@ -1240,8 +1256,9 @@ impl crate::blocking::HFBucketSync {
         files: Vec<BucketDownload>,
         #[builder(into)] progress: Option<Progress>,
     ) -> HFResult<()> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.download_files().files(files).maybe_progress(progress).send())
+            .run_future(async move { inner.download_files().files(files).maybe_progress(progress).send().await })
     }
 }
 

--- a/hf-hub/src/buckets/sync.rs
+++ b/hf-hub/src/buckets/sync.rs
@@ -882,8 +882,9 @@ impl crate::blocking::HFBucketSync {
         #[builder(default)] verbose: bool,
         #[builder(into)] progress: Option<Progress>,
     ) -> HFResult<BucketSyncPlan> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .sync()
                 .local_path(local_path)
                 .direction(direction)
@@ -897,8 +898,9 @@ impl crate::blocking::HFBucketSync {
                 .exclude(exclude)
                 .verbose(verbose)
                 .maybe_progress(progress)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 }
 

--- a/hf-hub/src/cache/mod.rs
+++ b/hf-hub/src/cache/mod.rs
@@ -129,6 +129,7 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::scan_cache`].
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn scan_cache(&self) -> HFResult<HFCacheInfo> {
-        self.runtime.block_on(self.inner.scan_cache().send())
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move { inner.scan_cache().send().await })
     }
 }

--- a/hf-hub/src/repository/commits.rs
+++ b/hf-hub/src/repository/commits.rs
@@ -470,8 +470,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(into)] revision: Option<String>,
         limit: Option<usize>,
     ) -> HFResult<Vec<GitCommitInfo>> {
-        self.runtime.block_on(async move {
-            let stream = self.inner.list_commits().maybe_revision(revision).maybe_limit(limit).send()?;
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner.list_commits().maybe_revision(revision).maybe_limit(limit).send()?;
             futures::pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(item) = stream.next().await {
@@ -485,30 +486,36 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn list_refs(&self, #[builder(default)] include_pull_requests: bool) -> HFResult<GitRefs> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.list_refs().include_pull_requests(include_pull_requests).send())
+            .run_future(async move { inner.list_refs().include_pull_requests(include_pull_requests).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::get_commit_diff`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn get_commit_diff(&self, #[builder(into)] compare: String) -> HFResult<String> {
-        self.runtime.block_on(self.inner.get_commit_diff().compare(compare).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.get_commit_diff().compare(compare).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::get_raw_diff`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn get_raw_diff(&self, #[builder(into)] compare: String) -> HFResult<String> {
-        self.runtime.block_on(self.inner.get_raw_diff().compare(compare).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.get_raw_diff().compare(compare).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::get_raw_diff_stream`]. Collects the parsed stream
     /// into a `Vec<HFFileDiff>`. See the async method for parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn get_raw_diff_stream(&self, #[builder(into)] compare: String) -> HFResult<Vec<HFFileDiff>> {
-        self.runtime.block_on(async move {
-            let stream = self.inner.get_raw_diff_stream().compare(compare).send().await?;
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner.get_raw_diff_stream().compare(compare).send().await?;
             futures::pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(item) = stream.next().await {
@@ -526,15 +533,18 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(into)] branch: String,
         #[builder(into)] revision: Option<String>,
     ) -> HFResult<()> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.create_branch().branch(branch).maybe_revision(revision).send())
+            .run_future(async move { inner.create_branch().branch(branch).maybe_revision(revision).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::delete_branch`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn delete_branch(&self, #[builder(into)] branch: String) -> HFResult<()> {
-        self.runtime.block_on(self.inner.delete_branch().branch(branch).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.delete_branch().branch(branch).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::create_tag`]. See the async method for parameters
@@ -546,21 +556,24 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(into)] revision: Option<String>,
         #[builder(into)] message: Option<String>,
     ) -> HFResult<()> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .create_tag()
                 .tag(tag)
                 .maybe_revision(revision)
                 .maybe_message(message)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::delete_tag`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn delete_tag(&self, #[builder(into)] tag: String) -> HFResult<()> {
-        self.runtime.block_on(self.inner.delete_tag().tag(tag).send())
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move { inner.delete_tag().tag(tag).send().await })
     }
 }
 

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -686,7 +686,11 @@ impl<T: RepoType> HFRepository<T> {
         let repo_path = self.repo_path();
         let repo_path_ref = &repo_path;
         let commit_hash_ref = &commit_hash;
-        let head_futs = filenames.iter().map(|filename| {
+        // Collected eagerly: keeping the borrowing closure inside a lazy
+        // `stream::iter(iter.map(..))` makes the enclosing future fail the
+        // `Send + 'static` bound required by the blocking wrappers with
+        // "implementation of `FnOnce` is not general enough".
+        let head_futs: Vec<_> = filenames.iter().map(|filename| {
                 let auth = self.hf_client.auth_headers();
                 let filename = filename.clone();
                 let repo_folder_ref = &repo_folder;
@@ -736,7 +740,7 @@ impl<T: RepoType> HFRepository<T> {
                         location,
                     }))
                 }
-            });
+            }).collect();
 
         let file_metas: Vec<FileMetadataInfo> = futures::stream::iter(head_futs)
             .buffer_unordered(max_workers)
@@ -975,7 +979,11 @@ async fn download_concurrently<T: RepoType>(
     params: &[DownloadFileParams],
     max_workers: usize,
 ) -> HFResult<Vec<PathBuf>> {
-    futures::stream::iter(params.iter().map(|p| api.download_file_inner(p)))
+    // Collected eagerly for the same reason as `head_futs` in
+    // `snapshot_download_impl`: a lazy borrowing closure inside the stream
+    // breaks the `Send + 'static` bound required by the blocking wrappers.
+    let download_futs: Vec<_> = params.iter().map(|p| api.download_file_inner(p)).collect();
+    futures::stream::iter(download_futs)
         .buffer_unordered(max_workers)
         .try_collect()
         .await
@@ -1325,8 +1333,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(default)] local_files_only: bool,
         #[builder(into)] progress: Option<Progress>,
     ) -> HFResult<PathBuf> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .download_file()
                 .filename(filename)
                 .maybe_local_dir(local_dir)
@@ -1334,8 +1343,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
                 .force_download(force_download)
                 .local_files_only(local_files_only)
                 .maybe_progress(progress)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::download_file_to_bytes`]. See the async method for
@@ -1348,15 +1358,17 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         range: Option<std::ops::Range<u64>>,
         #[builder(into)] progress: Option<Progress>,
     ) -> HFResult<bytes::Bytes> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .download_file_to_bytes()
                 .filename(filename)
                 .maybe_revision(revision)
                 .maybe_range(range)
                 .maybe_progress(progress)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::snapshot_download`]. See the async method for
@@ -1373,8 +1385,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         max_workers: Option<usize>,
         #[builder(into)] progress: Option<Progress>,
     ) -> HFResult<PathBuf> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .snapshot_download()
                 .maybe_revision(revision)
                 .maybe_allow_patterns(allow_patterns)
@@ -1384,7 +1397,8 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
                 .local_files_only(local_files_only)
                 .maybe_max_workers(max_workers)
                 .maybe_progress(progress)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 }

--- a/hf-hub/src/repository/listing.rs
+++ b/hf-hub/src/repository/listing.rs
@@ -200,9 +200,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(default)] expand: bool,
         limit: Option<usize>,
     ) -> HFResult<Vec<RepoTreeEntry>> {
-        self.runtime.block_on(async move {
-            let stream = self
-                .inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner
                 .list_tree()
                 .maybe_revision(revision)
                 .maybe_path_in_repo(path_in_repo)
@@ -227,8 +227,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         paths: Vec<String>,
         #[builder(into)] revision: Option<String>,
     ) -> HFResult<Vec<RepoTreeEntry>> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.get_paths_info().paths(paths).maybe_revision(revision).send())
+            .run_future(async move { inner.get_paths_info().paths(paths).maybe_revision(revision).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::get_file_metadata`]. See the async method for
@@ -239,12 +240,14 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(into)] filepath: String,
         #[builder(into)] revision: Option<String>,
     ) -> HFResult<FileMetadataInfo> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .get_file_metadata()
                 .filepath(filepath)
                 .maybe_revision(revision)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 }

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -1444,9 +1444,9 @@ impl crate::blocking::HFClientSync {
         limit: Option<usize>,
     ) -> HFResult<Vec<ModelInfo>> {
         use futures::StreamExt;
-        self.runtime.block_on(async move {
-            let stream = self
-                .inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner
                 .list_models()
                 .maybe_search(search)
                 .maybe_author(author)
@@ -1480,9 +1480,9 @@ impl crate::blocking::HFClientSync {
         limit: Option<usize>,
     ) -> HFResult<Vec<DatasetInfo>> {
         use futures::StreamExt;
-        self.runtime.block_on(async move {
-            let stream = self
-                .inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner
                 .list_datasets()
                 .maybe_search(search)
                 .maybe_author(author)
@@ -1513,9 +1513,9 @@ impl crate::blocking::HFClientSync {
         limit: Option<usize>,
     ) -> HFResult<Vec<SpaceInfo>> {
         use futures::StreamExt;
-        self.runtime.block_on(async move {
-            let stream = self
-                .inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner
                 .list_spaces()
                 .maybe_search(search)
                 .maybe_author(author)
@@ -1544,16 +1544,18 @@ impl crate::blocking::HFClientSync {
         #[builder(default)] exist_ok: bool,
         #[builder(into)] space_sdk: Option<String>,
     ) -> HFResult<RepoUrl> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .create_repository()
                 .repo_id(repo_id)
                 .repo_type(repo_type)
                 .maybe_private(private)
                 .exist_ok(exist_ok)
                 .maybe_space_sdk(space_sdk)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFClient::delete_repository`]. See the async method for parameters and
@@ -1565,14 +1567,16 @@ impl crate::blocking::HFClientSync {
         repo_type: impl RepoType,
         #[builder(default)] missing_ok: bool,
     ) -> HFResult<()> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .delete_repository()
                 .repo_id(repo_id)
                 .repo_type(repo_type)
                 .missing_ok(missing_ok)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFClient::move_repository`]. See the async method for parameters and
@@ -1584,14 +1588,16 @@ impl crate::blocking::HFClientSync {
         #[builder(into)] to_id: String,
         repo_type: impl RepoType,
     ) -> HFResult<RepoUrl> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .move_repository()
                 .from_id(from_id)
                 .to_id(to_id)
                 .repo_type(repo_type)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 }
 
@@ -1601,14 +1607,17 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::exists`].
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn exists(&self) -> HFResult<bool> {
-        self.runtime.block_on(self.inner.exists().send())
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move { inner.exists().send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::revision_exists`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn revision_exists(&self, #[builder(into)] revision: String) -> HFResult<bool> {
-        self.runtime.block_on(self.inner.revision_exists().revision(revision).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.revision_exists().revision(revision).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::file_exists`]. See the async method for parameters
@@ -1619,8 +1628,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(into)] filename: String,
         #[builder(into)] revision: Option<String>,
     ) -> HFResult<bool> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.file_exists().filename(filename).maybe_revision(revision).send())
+            .run_future(async move { inner.file_exists().filename(filename).maybe_revision(revision).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::update_settings`]. See the async method for
@@ -1634,16 +1644,18 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         discussions_disabled: Option<bool>,
         gated_notifications: Option<GatedNotifications>,
     ) -> HFResult<()> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .update_settings()
                 .maybe_private(private)
                 .maybe_gated(gated)
                 .maybe_description(description)
                 .maybe_discussions_disabled(discussions_disabled)
                 .maybe_gated_notifications(gated_notifications)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 }
 
@@ -1664,8 +1676,9 @@ impl crate::blocking::HFRepositorySync<RepoTypeModel> {
         derive(Debug, Clone),
     )]
     pub fn info(&self, #[builder(into)] revision: Option<String>, expand: Option<Vec<String>>) -> HFResult<ModelInfo> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
+            .run_future(async move { inner.info().maybe_revision(revision).maybe_expand(expand).send().await })
     }
 }
 
@@ -1684,8 +1697,9 @@ impl crate::blocking::HFRepositorySync<RepoTypeDataset> {
         #[builder(into)] revision: Option<String>,
         expand: Option<Vec<String>>,
     ) -> HFResult<DatasetInfo> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
+            .run_future(async move { inner.info().maybe_revision(revision).maybe_expand(expand).send().await })
     }
 }
 
@@ -1700,8 +1714,9 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
         derive(Debug, Clone),
     )]
     pub fn info(&self, #[builder(into)] revision: Option<String>, expand: Option<Vec<String>>) -> HFResult<SpaceInfo> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
+            .run_future(async move { inner.info().maybe_revision(revision).maybe_expand(expand).send().await })
     }
 }
 
@@ -1716,8 +1731,9 @@ impl crate::blocking::HFRepositorySync<RepoTypeKernel> {
         derive(Debug, Clone),
     )]
     pub fn info(&self, #[builder(into)] revision: Option<String>, expand: Option<Vec<String>>) -> HFResult<KernelInfo> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
+            .run_future(async move { inner.info().maybe_revision(revision).maybe_expand(expand).send().await })
     }
 }
 

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -982,8 +982,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(into)] parent_commit: Option<String>,
         #[builder(into)] progress: Option<Progress>,
     ) -> HFResult<CommitInfo> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .create_commit()
                 .operations(operations)
                 .commit_message(commit_message)
@@ -992,8 +993,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
                 .create_pr(create_pr)
                 .maybe_parent_commit(parent_commit)
                 .maybe_progress(progress)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::upload_file`]. See the async method for parameters
@@ -1010,8 +1012,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(into)] parent_commit: Option<String>,
         #[builder(into)] progress: Option<Progress>,
     ) -> HFResult<CommitInfo> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .upload_file()
                 .source(source)
                 .path_in_repo(path_in_repo)
@@ -1021,8 +1024,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
                 .create_pr(create_pr)
                 .maybe_parent_commit(parent_commit)
                 .maybe_progress(progress)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::upload_folder`]. See the async method for
@@ -1042,8 +1046,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         delete_patterns: Option<Vec<String>>,
         #[builder(into)] progress: Option<Progress>,
     ) -> HFResult<CommitInfo> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .upload_folder()
                 .folder_path(folder_path)
                 .maybe_path_in_repo(path_in_repo)
@@ -1055,8 +1060,9 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
                 .maybe_ignore_patterns(ignore_patterns)
                 .maybe_delete_patterns(delete_patterns)
                 .maybe_progress(progress)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::delete_file`]. See the async method for parameters
@@ -1069,15 +1075,17 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(into)] commit_message: Option<String>,
         #[builder(default)] create_pr: bool,
     ) -> HFResult<CommitInfo> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .delete_file()
                 .path_in_repo(path_in_repo)
                 .maybe_revision(revision)
                 .maybe_commit_message(commit_message)
                 .create_pr(create_pr)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::delete_folder`]. See the async method for
@@ -1090,14 +1098,16 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
         #[builder(into)] commit_message: Option<String>,
         #[builder(default)] create_pr: bool,
     ) -> HFResult<CommitInfo> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .delete_folder()
                 .path_in_repo(path_in_repo)
                 .maybe_revision(revision)
                 .maybe_commit_message(commit_message)
                 .create_pr(create_pr)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 }

--- a/hf-hub/src/spaces.rs
+++ b/hf-hub/src/spaces.rs
@@ -509,7 +509,8 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn runtime(&self) -> HFResult<SpaceRuntime> {
-        self.runtime.block_on(self.inner.runtime().send())
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move { inner.runtime().send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::request_hardware`]. See the async method for parameters
@@ -520,34 +521,40 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
         #[builder(into)] hardware: String,
         sleep_time: Option<u64>,
     ) -> HFResult<SpaceRuntime> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .request_hardware()
                 .hardware(hardware)
                 .maybe_sleep_time(sleep_time)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::set_sleep_time`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn set_sleep_time(&self, sleep_time: u64) -> HFResult<()> {
-        self.runtime.block_on(self.inner.set_sleep_time().sleep_time(sleep_time).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.set_sleep_time().sleep_time(sleep_time).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::pause`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn pause(&self) -> HFResult<SpaceRuntime> {
-        self.runtime.block_on(self.inner.pause().send())
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move { inner.pause().send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::restart`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn restart(&self) -> HFResult<SpaceRuntime> {
-        self.runtime.block_on(self.inner.restart().send())
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move { inner.restart().send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::add_secret`]. See the async method for parameters and
@@ -559,21 +566,25 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
         #[builder(into)] value: String,
         #[builder(into)] description: Option<String>,
     ) -> HFResult<()> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .add_secret()
                 .key(key)
                 .value(value)
                 .maybe_description(description)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::delete_secret`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn delete_secret(&self, #[builder(into)] key: String) -> HFResult<()> {
-        self.runtime.block_on(self.inner.delete_secret().key(key).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.delete_secret().key(key).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::add_variable`]. See the async method for parameters and
@@ -585,21 +596,25 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
         #[builder(into)] value: String,
         #[builder(into)] description: Option<String>,
     ) -> HFResult<()> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .add_variable()
                 .key(key)
                 .value(value)
                 .maybe_description(description)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 
     /// Blocking counterpart of [`HFRepository::delete_variable`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn delete_variable(&self, #[builder(into)] key: String) -> HFResult<()> {
-        self.runtime.block_on(self.inner.delete_variable().key(key).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.delete_variable().key(key).send().await })
     }
 
     /// Blocking counterpart of [`HFRepository::duplicate`]. See the async method for parameters and
@@ -615,8 +630,9 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
         secrets: Option<Vec<serde_json::Value>>,
         variables: Option<Vec<serde_json::Value>>,
     ) -> HFResult<RepoUrl> {
-        self.runtime.block_on(
-            self.inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            inner
                 .duplicate()
                 .maybe_to_id(to_id)
                 .maybe_private(private)
@@ -625,8 +641,9 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
                 .maybe_sleep_time(sleep_time)
                 .maybe_secrets(secrets)
                 .maybe_variables(variables)
-                .send(),
-        )
+                .send()
+                .await
+        })
     }
 }
 

--- a/hf-hub/src/users.rs
+++ b/hf-hub/src/users.rs
@@ -268,22 +268,26 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::whoami`].
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn whoami(&self) -> HFResult<User> {
-        self.runtime.block_on(self.inner.whoami().send())
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move { inner.whoami().send().await })
     }
 
     /// Blocking counterpart of [`HFClient::user_overview`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn user_overview(&self, #[builder(into)] username: String) -> HFResult<User> {
-        self.runtime.block_on(self.inner.user_overview().username(username).send())
+        let inner = self.inner.clone();
+        self.runtime
+            .run_future(async move { inner.user_overview().username(username).send().await })
     }
 
     /// Blocking counterpart of [`HFClient::organization_overview`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn organization_overview(&self, #[builder(into)] organization: String) -> HFResult<Organization> {
+        let inner = self.inner.clone();
         self.runtime
-            .block_on(self.inner.organization_overview().organization(organization).send())
+            .run_future(async move { inner.organization_overview().organization(organization).send().await })
     }
 
     /// Blocking counterpart of [`HFClient::list_user_followers`]. Collects the stream into a
@@ -291,8 +295,9 @@ impl crate::blocking::HFClientSync {
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn list_user_followers(&self, #[builder(into)] username: String, limit: Option<usize>) -> HFResult<Vec<User>> {
         use futures::StreamExt;
-        self.runtime.block_on(async move {
-            let stream = self.inner.list_user_followers().username(username).maybe_limit(limit).send()?;
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner.list_user_followers().username(username).maybe_limit(limit).send()?;
             futures::pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(item) = stream.next().await {
@@ -307,8 +312,9 @@ impl crate::blocking::HFClientSync {
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn list_user_following(&self, #[builder(into)] username: String, limit: Option<usize>) -> HFResult<Vec<User>> {
         use futures::StreamExt;
-        self.runtime.block_on(async move {
-            let stream = self.inner.list_user_following().username(username).maybe_limit(limit).send()?;
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner.list_user_following().username(username).maybe_limit(limit).send()?;
             futures::pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(item) = stream.next().await {
@@ -327,9 +333,9 @@ impl crate::blocking::HFClientSync {
         limit: Option<usize>,
     ) -> HFResult<Vec<User>> {
         use futures::StreamExt;
-        self.runtime.block_on(async move {
-            let stream = self
-                .inner
+        let inner = self.inner.clone();
+        self.runtime.run_future(async move {
+            let stream = inner
                 .list_organization_members()
                 .organization(organization)
                 .maybe_limit(limit)

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -432,3 +432,47 @@ fn test_sync_branch_operations() {
 
     delete_test_repo(&client, &repo_id);
 }
+
+// --- Async-context safety ---
+//
+// Regression tests for the dedicated-runtime-thread execution model: every
+// call below used to panic on tokio's nested-runtime guard ("Cannot start a
+// runtime from within a runtime") when the sync API was invoked from inside
+// an async application, and dropping the client from async context panicked
+// during unwind as well.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sync_info_and_download_inside_async_context() {
+    let Some(client) = prod_sync_api() else { return };
+    let repo = repo_handle(&client, TEST_MODEL_REPO);
+
+    let info = repo.info().send().unwrap();
+    assert_eq!(info.id, TEST_MODEL_REPO);
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = repo
+        .download_file()
+        .filename("config.json")
+        .local_dir(dir.path().to_path_buf())
+        .send()
+        .unwrap();
+    assert!(path.exists());
+}
+
+#[tokio::test]
+async fn test_sync_call_inside_current_thread_runtime() {
+    let Some(client) = prod_sync_api() else { return };
+    let repo = repo_handle(&client, TEST_MODEL_REPO);
+    assert!(repo.exists().send().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sync_client_clone_and_staggered_drop_inside_async_context() {
+    let Some(client) = prod_sync_api() else { return };
+    let clone = client.clone();
+    let repo = repo_handle(&client, TEST_MODEL_REPO);
+    drop(client);
+    drop(clone);
+    assert!(repo.exists().send().unwrap());
+    drop(repo);
+}


### PR DESCRIPTION
## Problem

The 1.0 `*Sync` handles each own a current-thread `tokio::runtime::Runtime`, and every wrapper method is `self.runtime.block_on(...)` (~65 sites across `blocking.rs` and the sync mirrors in `repository/*.rs`, `buckets/*.rs`, `spaces.rs`, `users.rs`, `cache/mod.rs`). Tokio's enter-guard makes `Runtime::block_on` panic when the calling thread is already inside a runtime, and dropping the runtime from async context panics too. So from async code:

- constructing an `HFClientSync` works,
- any method call panics ("Cannot start a runtime from within a runtime"),
- and even dropping the client panics during unwind.

This is a migration trap. hf-hub 0.4's sync API was ureq-backed (no runtime), so calling it inside async handlers was rude but worked. A mechanical ureq-to-blocking migration keeps compiling, passes plain-thread tests, then panics in production only on paths that run inside a runtime. Consumer validation found real exposure: mistral.rs (sync API threaded through ~22 files, used from the async mistralrs-server), fastembed (sync lib consumed by async frameworks rig/swiftide), and the sglang router (`HFClientSync` in an async server). It also violates our own AGENTS.md rule: never panic.

## Fix: the `reqwest::blocking` model

The runtime moves onto a dedicated background thread owned by the client. Blocking calls from async contexts then block a worker thread — the same rudeness as 0.4's ureq — but they work, and both panic modes disappear.

**Thread ownership.** A private `RuntimeThread` (in `blocking.rs`) spawns a `hf-hub-blocking-runtime` thread that builds a current-thread runtime, sends its `Handle` back, and parks in `runtime.block_on(shutdown_rx)` so foreign threads can spawn onto it. The runtime is created on — and never leaves — that thread, so no caller thread ever enters or drops it (that kills the Drop panic).

**One helper, no per-site boilerplate.** All wrapper methods go through `RuntimeThread::run_future`: they clone their inner `Arc`'d handle into a `'static + Send` future, `handle.spawn` it, and park on a `std::sync::mpsc` channel for the result. A std channel deliberately — tokio's `blocking_recv` has its own enter-guard panic. Stream-collecting methods (`list_*` etc.) run the whole pin-and-drain collection inside the spawned future.

**Panic propagation.** The spawned task is wrapped in `catch_unwind` and the payload is resumed on the caller (`resume_unwind`), matching the semantics `Runtime::block_on` had for panicking tasks. If the runtime thread is ever gone, `run_future` returns `HFError::Other` instead of panicking.

**Clone/shutdown semantics.** `*Sync` handles clone freely and share one background thread (`Arc<RuntimeThread>`). When the last handle drops, the shutdown oneshot sender drops, the receiver resolves, `block_on` returns, and the runtime is dropped on its own thread. The thread is detached rather than joined, so dropping the last handle never blocks the caller (reqwest-style; documented on `RuntimeThread`).

**Public API unchanged.** All bon builder signatures, `HFClientSync::new()`/`from_inner()` (thread-spawn failure maps onto the existing `HFResult` error path), and the xet doc note (xet still spins up its own pool, separate from this runtime — wording updated) are intact. The AGENTS.md blocking-counterpart template now shows the `run_future` pattern.

One incidental change in `repository/download.rs`: two lazy borrowing-closure streams in `snapshot_download` (`head_futs` and `download_concurrently`) are collected eagerly into `Vec`s. Leaving them lazy makes the enclosing future fail the `Send + 'static` bound with rustc's "implementation of `FnOnce` is not general enough" HRTB limitation. (#180's boxing addresses the same spot; if #180 merges first this hunk may partially collapse in the rebase.)

## Alternatives considered

- **Doc-only** ("don't call the sync API from async"): keeps the trap armed; the failing consumers above show it gets hit in practice.
- **`Handle::try_current()` guard returning a typed error**: rejected in favor of making the call work; also false-positives on `tokio::task::block_in_place` blocks (multi-thread runtimes), where `try_current` succeeds but `block_on` would have been legal, so the guard can't be made precise.

## Tests

New regression tests (all panicked before this change, verified by running the same shape against the base commit — panics at the `block_on` site in `repository/mod.rs`):

- unit (`blocking.rs`, network-free via a connection-refused local endpoint): sync `info()` call inside `#[tokio::test]` multi-thread and current-thread runtimes; construct-and-drop of `HFClientSync` inside async context; clones share the runtime thread (`Arc::ptr_eq`) and survive staggered drops; `run_future` resumes task panics on the caller.
- integration (`blocking_test.rs`, HF_TOKEN-gated): `info()` + small `download_file()` from inside a multi-thread `#[tokio::test]` (the exact consumer shape that used to panic), a current-thread-runtime call, and clone/staggered-drop in async context.

Verification:

- `cargo test -p hf-hub --features blocking` / `--all-features`: 198 passed
- `cargo test -p integration-tests --test blocking_test` (live, HF_TOKEN): 25 passed, including the 3 new async-context tests
- `cargo clippy -p hf-hub --all-features -- -D warnings`: clean
- `cargo +nightly fmt --check`: clean
- `./scripts/verify_wasm.sh`: green (blocking stays native-only)

## Stacking

Based on `assaf/wasm-xet-deps`, same as #178/#179/#180/#181, and touches the same sync-mirror files — expect conflicts with all four. Suggest merging this after #180 (its future-boxing overlaps with the `snapshot_download` hunk here and the rebase is easiest in that order).
