### PR TITLE
feat: add 'socks' feature flag for SOCKS proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,6 @@ To use the synchronous interface, enable the `blocking` feature:
 hf-hub = { version = "1.0.0", features = ["blocking"] }
 ```
 
-To route traffic through a SOCKS proxy (e.g. via the `HTTPS_PROXY` environment
-variable), enable the `socks` feature, which forwards to reqwest's `socks`
-feature:
-
-```toml
-[dependencies]
-hf-hub = { version = "1.0.0", features = ["socks"] }
-```
-
 ## CLI Installation
 
 The `hfrs` command-line tool provides a terminal interface to the Hub. Install it with:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ To use the synchronous interface, enable the `blocking` feature:
 hf-hub = { version = "1.0.0", features = ["blocking"] }
 ```
 
+To route traffic through a SOCKS proxy (e.g. via the `HTTPS_PROXY` environment
+variable), enable the `socks` feature, which forwards to reqwest's `socks`
+feature:
+
+```toml
+[dependencies]
+hf-hub = { version = "1.0.0", features = ["socks"] }
+```
+
 ## CLI Installation
 
 The `hfrs` command-line tool provides a terminal interface to the Hub. Install it with:

--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -36,6 +36,7 @@ sha2 = "0.11"
 default = []
 blocking = ["tokio/rt"]
 rustls-tls = ["reqwest/rustls"]
+socks = ["reqwest/socks"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -185,6 +185,7 @@
 //! ## Cargo features
 //!
 //! - `blocking` — enables the synchronous `*Sync` handles.
+//! - `socks` — enables SOCKS proxy support in the underlying HTTP client (forwards to `reqwest/socks`).
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 


### PR DESCRIPTION
Closes #177

Adds a `socks` cargo feature that forwards to `reqwest/socks`, so users can enable SOCKS proxy support (e.g. `HTTPS_PROXY=socks5://...`) without depending on reqwest directly at the exact version hf-hub pins.

Note: in reqwest 0.13 SOCKS support is implemented in-tree (cfg-gated, no extra dependency), so enabling the feature only compiles in the proxy handling code.

- `hf-hub/Cargo.toml`: `socks = ["reqwest/socks"]`
- Documented in the crate-level "Cargo features" doc list