### PR TITLE
feat: allow passing params by ref

### DIFF
--- a/examples/blocking_spaces.rs
+++ b/examples/blocking_spaces.rs
@@ -26,7 +26,7 @@ fn main() -> hf_hub::HFResult<()> {
     client
         .create_repository()
         .repo_type(RepoTypeSpace)
-        .repo_id(space.repo_path())
+        .repo_id(&space.repo_path())
         .private(true)
         .space_sdk("static")
         .exist_ok(true)
@@ -54,7 +54,7 @@ fn main() -> hf_hub::HFResult<()> {
     client
         .delete_repository()
         .repo_type(RepoTypeSpace)
-        .repo_id(space.repo_path())
+        .repo_id(&space.repo_path())
         .missing_ok(true)
         .send()?;
     println!("Cleaned up test space");

--- a/examples/blocking_write.rs
+++ b/examples/blocking_write.rs
@@ -19,7 +19,7 @@ fn main() -> hf_hub::HFResult<()> {
     let repo_url = client
         .create_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .private(true)
         .exist_ok(true)
         .send()?;
@@ -110,7 +110,7 @@ fn main() -> hf_hub::HFResult<()> {
     client
         .delete_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .missing_ok(true)
         .send()?;
     println!("Deleted repo");

--- a/examples/commits.rs
+++ b/examples/commits.rs
@@ -58,7 +58,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .create_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .private(true)
         .exist_ok(true)
         .send()
@@ -80,7 +80,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .delete_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .missing_ok(true)
         .send()
         .await?;

--- a/examples/download_upload.rs
+++ b/examples/download_upload.rs
@@ -109,7 +109,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .create_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .private(true)
         .exist_ok(true)
         .send()
@@ -158,7 +158,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .delete_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .missing_ok(true)
         .send()
         .await?;

--- a/examples/files.rs
+++ b/examples/files.rs
@@ -62,7 +62,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .create_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .private(true)
         .exist_ok(true)
         .send()
@@ -112,7 +112,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .delete_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .missing_ok(true)
         .send()
         .await?;

--- a/examples/progress_logger.rs
+++ b/examples/progress_logger.rs
@@ -92,7 +92,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .create_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .private(true)
         .exist_ok(true)
         .send()
@@ -112,7 +112,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .delete_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .missing_ok(true)
         .send()
         .await?;

--- a/examples/repository.rs
+++ b/examples/repository.rs
@@ -78,7 +78,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let repo_url = client
         .create_repository()
         .repo_type(RepoTypeModel)
-        .repo_id(repo.repo_path())
+        .repo_id(&repo.repo_path())
         .private(true)
         .exist_ok(true)
         .send()
@@ -92,7 +92,7 @@ async fn main() -> hf_hub::HFResult<()> {
     let moved = client
         .move_repository()
         .repo_type(RepoTypeModel)
-        .from_id(repo.repo_path())
+        .from_id(&repo.repo_path())
         .to_id(&new_name)
         .send()
         .await?;

--- a/examples/spaces.rs
+++ b/examples/spaces.rs
@@ -24,7 +24,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .create_repository()
         .repo_type(RepoTypeSpace)
-        .repo_id(space.repo_path())
+        .repo_id(&space.repo_path())
         .private(true)
         .space_sdk("static")
         .exist_ok(true)
@@ -53,7 +53,7 @@ async fn main() -> hf_hub::HFResult<()> {
     client
         .delete_repository()
         .repo_type(RepoTypeSpace)
-        .repo_id(space.repo_path())
+        .repo_id(&space.repo_path())
         .missing_ok(true)
         .send()
         .await?;

--- a/hf-hub/src/buckets/mod.rs
+++ b/hf-hub/src/buckets/mod.rs
@@ -236,13 +236,7 @@ impl HFBucket {
 
         let response = self
             .hf_client
-            .check_response(
-                response,
-                Some(&bucket_id),
-                NotFoundContext::Entry {
-                    path: remote_path.to_string(),
-                },
-            )
+            .check_response(response, Some(&bucket_id), NotFoundContext::Entry { path: remote_path })
             .await?;
 
         let size = response
@@ -767,11 +761,9 @@ impl HFClient {
     pub async fn create_bucket(
         &self,
         /// Namespace (user or organization) that owns the bucket.
-        #[builder(into)]
-        namespace: String,
+        namespace: &str,
         /// Bucket name within the namespace.
-        #[builder(into)]
-        name: String,
+        name: &str,
         /// Whether the bucket should be private.
         #[builder(default)]
         private: bool,
@@ -788,8 +780,8 @@ impl HFClient {
         if private {
             body["private"] = serde_json::Value::Bool(true);
         }
-        if let Some(ref rg) = resource_group_id {
-            body["resourceGroupId"] = serde_json::Value::String(rg.clone());
+        if let Some(rg) = resource_group_id {
+            body["resourceGroupId"] = serde_json::Value::String(rg);
         }
 
         let headers = self.auth_headers();
@@ -822,13 +814,12 @@ impl HFClient {
     pub async fn delete_bucket(
         &self,
         /// Bucket ID in `"owner/name"` format.
-        #[builder(into)]
-        bucket_id: String,
+        bucket_id: &str,
         /// If `true`, do not error when the bucket does not exist.
         #[builder(default)]
         missing_ok: bool,
     ) -> HFResult<()> {
-        let url = self.bucket_api_url(&bucket_id);
+        let url = self.bucket_api_url(bucket_id);
 
         let headers = self.auth_headers();
         let response =
@@ -839,7 +830,7 @@ impl HFClient {
             return Ok(());
         }
 
-        self.check_response(response, Some(&bucket_id), NotFoundContext::Bucket).await?;
+        self.check_response(response, Some(bucket_id), NotFoundContext::Bucket).await?;
         Ok(())
     }
 
@@ -875,11 +866,9 @@ impl HFClient {
     pub async fn move_bucket(
         &self,
         /// Current bucket ID in `"owner/name"` format.
-        #[builder(into)]
-        from_id: String,
+        from_id: &str,
         /// New bucket ID in `"owner/name"` format.
-        #[builder(into)]
-        to_id: String,
+        to_id: &str,
     ) -> HFResult<()> {
         let url = format!("{}/api/repos/move", self.endpoint());
         let body = serde_json::json!({
@@ -907,8 +896,8 @@ impl crate::blocking::HFClientSync {
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn create_bucket(
         &self,
-        #[builder(into)] namespace: String,
-        #[builder(into)] name: String,
+        namespace: &str,
+        name: &str,
         #[builder(default)] private: bool,
         #[builder(into)] resource_group_id: Option<String>,
         #[builder(default)] exist_ok: bool,
@@ -928,11 +917,7 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::delete_bucket`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn delete_bucket(
-        &self,
-        #[builder(into)] bucket_id: String,
-        #[builder(default)] missing_ok: bool,
-    ) -> HFResult<()> {
+    pub fn delete_bucket(&self, bucket_id: &str, #[builder(default)] missing_ok: bool) -> HFResult<()> {
         self.runtime
             .block_on(self.inner.delete_bucket().bucket_id(bucket_id).missing_ok(missing_ok).send())
     }
@@ -955,7 +940,7 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::move_bucket`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn move_bucket(&self, #[builder(into)] from_id: String, #[builder(into)] to_id: String) -> HFResult<()> {
+    pub fn move_bucket(&self, from_id: &str, to_id: &str) -> HFResult<()> {
         self.runtime
             .block_on(self.inner.move_bucket().from_id(from_id).to_id(to_id).send())
     }

--- a/hf-hub/src/repository/commits.rs
+++ b/hf-hub/src/repository/commits.rs
@@ -198,8 +198,7 @@ impl<T: RepoType> HFRepository<T> {
         ///   `"v1.0"`, `"abc123…"`), or
         /// - Two revisions in `<base>..<head>` form (two dots), comparing `base` to `head` (e.g., `"main..feature"`,
         ///   `"<sha1>..<sha2>"`).
-        #[builder(into)]
-        compare: String,
+        compare: &str,
     ) -> HFResult<String> {
         let url = format!("{}/compare/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), compare);
 
@@ -239,8 +238,7 @@ impl<T: RepoType> HFRepository<T> {
         ///   `"v1.0"`, `"abc123…"`), or
         /// - Two revisions in `<base>..<head>` form (two dots), comparing `base` to `head` (e.g., `"main..feature"`,
         ///   `"<sha1>..<sha2>"`).
-        #[builder(into)]
-        compare: String,
+        compare: &str,
     ) -> HFResult<String> {
         let url = format!("{}/compare/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), compare);
 
@@ -321,8 +319,7 @@ impl<T: RepoType> HFRepository<T> {
     pub async fn create_branch(
         &self,
         /// Name of the branch to create.
-        #[builder(into)]
-        branch: String,
+        branch: &str,
         /// Revision to branch from. Defaults to the current main branch head.
         #[builder(into)]
         revision: Option<String>,
@@ -330,8 +327,8 @@ impl<T: RepoType> HFRepository<T> {
         let url = format!("{}/branch/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), branch);
 
         let mut body = serde_json::Map::new();
-        if let Some(ref rev) = revision {
-            body.insert("startingPoint".into(), serde_json::Value::String(rev.clone()));
+        if let Some(rev) = revision {
+            body.insert("startingPoint".into(), serde_json::Value::String(rev));
         }
 
         let headers = self.hf_client.auth_headers();
@@ -363,8 +360,7 @@ impl<T: RepoType> HFRepository<T> {
     pub async fn delete_branch(
         &self,
         /// Name of the branch to delete.
-        #[builder(into)]
-        branch: String,
+        branch: &str,
     ) -> HFResult<()> {
         let url = format!("{}/branch/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), branch);
 
@@ -394,21 +390,19 @@ impl<T: RepoType> HFRepository<T> {
     pub async fn create_tag(
         &self,
         /// Name of the tag to create.
-        #[builder(into)]
-        tag: String,
+        tag: &str,
         /// Revision to tag. Defaults to the current main branch head.
-        #[builder(into)]
-        revision: Option<String>,
+        revision: Option<&str>,
         /// Annotation message for the tag.
         #[builder(into)]
         message: Option<String>,
     ) -> HFResult<()> {
-        let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let revision = revision.unwrap_or(constants::DEFAULT_REVISION);
         let url = format!("{}/tag/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), revision);
 
         let mut body = serde_json::json!({ "tag": tag });
-        if let Some(ref m) = message {
-            body["message"] = serde_json::Value::String(m.clone());
+        if let Some(m) = message {
+            body["message"] = serde_json::Value::String(m);
         }
 
         let headers = self.hf_client.auth_headers();
@@ -440,8 +434,7 @@ impl<T: RepoType> HFRepository<T> {
     pub async fn delete_tag(
         &self,
         /// Name of the tag to delete.
-        #[builder(into)]
-        tag: String,
+        tag: &str,
     ) -> HFResult<()> {
         let url = format!("{}/tag/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), tag);
 
@@ -492,14 +485,14 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::get_commit_diff`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn get_commit_diff(&self, #[builder(into)] compare: String) -> HFResult<String> {
+    pub fn get_commit_diff(&self, compare: &str) -> HFResult<String> {
         self.runtime.block_on(self.inner.get_commit_diff().compare(compare).send())
     }
 
     /// Blocking counterpart of [`HFRepository::get_raw_diff`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn get_raw_diff(&self, #[builder(into)] compare: String) -> HFResult<String> {
+    pub fn get_raw_diff(&self, compare: &str) -> HFResult<String> {
         self.runtime.block_on(self.inner.get_raw_diff().compare(compare).send())
     }
 
@@ -521,11 +514,7 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::create_branch`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn create_branch(
-        &self,
-        #[builder(into)] branch: String,
-        #[builder(into)] revision: Option<String>,
-    ) -> HFResult<()> {
+    pub fn create_branch(&self, branch: &str, #[builder(into)] revision: Option<String>) -> HFResult<()> {
         self.runtime
             .block_on(self.inner.create_branch().branch(branch).maybe_revision(revision).send())
     }
@@ -533,7 +522,7 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::delete_branch`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn delete_branch(&self, #[builder(into)] branch: String) -> HFResult<()> {
+    pub fn delete_branch(&self, branch: &str) -> HFResult<()> {
         self.runtime.block_on(self.inner.delete_branch().branch(branch).send())
     }
 
@@ -542,8 +531,8 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn create_tag(
         &self,
-        #[builder(into)] tag: String,
-        #[builder(into)] revision: Option<String>,
+        tag: &str,
+        revision: Option<&str>,
         #[builder(into)] message: Option<String>,
     ) -> HFResult<()> {
         self.runtime.block_on(
@@ -559,7 +548,7 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::delete_tag`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn delete_tag(&self, #[builder(into)] tag: String) -> HFResult<()> {
+    pub fn delete_tag(&self, tag: &str) -> HFResult<()> {
         self.runtime.block_on(self.inner.delete_tag().tag(tag).send())
     }
 }

--- a/hf-hub/src/repository/listing.rs
+++ b/hf-hub/src/repository/listing.rs
@@ -126,11 +126,10 @@ impl<T: RepoType> HFRepository<T> {
         #[builder(into)]
         filepath: String,
         /// Git revision. Defaults to the main branch.
-        #[builder(into)]
-        revision: Option<String>,
+        revision: Option<&str>,
     ) -> HFResult<FileMetadataInfo> {
-        let filename = filepath.clone();
-        let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let filename = filepath;
+        let revision = revision.unwrap_or(constants::DEFAULT_REVISION);
         let repo_path = self.repo_path();
         let url = self
             .hf_client
@@ -225,7 +224,7 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     pub fn get_file_metadata(
         &self,
         #[builder(into)] filepath: String,
-        #[builder(into)] revision: Option<String>,
+        revision: Option<&str>,
     ) -> HFResult<FileMetadataInfo> {
         self.runtime.block_on(
             self.inner

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -910,8 +910,7 @@ impl HFClient {
     pub async fn create_repository(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
-        #[builder(into)]
-        repo_id: String,
+        repo_id: &str,
         /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
         /// or [`RepoTypeKernel`]).
         repo_type: impl RepoType,
@@ -927,7 +926,7 @@ impl HFClient {
     ) -> HFResult<RepoUrl> {
         let url = format!("{}/api/repos/create", self.endpoint());
 
-        let (namespace, name) = split_repo_id(&repo_id);
+        let (namespace, name) = split_repo_id(repo_id);
 
         let mut body = serde_json::json!({
             "name": name,
@@ -938,8 +937,8 @@ impl HFClient {
         if let Some(ns) = namespace {
             body["organization"] = serde_json::Value::String(ns.to_string());
         }
-        if let Some(ref sdk) = space_sdk {
-            body["sdk"] = serde_json::Value::String(sdk.clone());
+        if let Some(sdk) = space_sdk {
+            body["sdk"] = serde_json::Value::String(sdk);
         }
 
         let headers = self.auth_headers();
@@ -977,8 +976,7 @@ impl HFClient {
     pub async fn delete_repository(
         &self,
         /// Repository ID in `"owner/name"` or `"name"` format.
-        #[builder(into)]
-        repo_id: String,
+        repo_id: &str,
         /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
         /// or [`RepoTypeKernel`]).
         repo_type: impl RepoType,
@@ -988,7 +986,7 @@ impl HFClient {
     ) -> HFResult<()> {
         let url = format!("{}/api/repos/delete", self.endpoint());
 
-        let (namespace, name) = split_repo_id(&repo_id);
+        let (namespace, name) = split_repo_id(repo_id);
 
         let mut body = serde_json::json!({
             "name": name,
@@ -1008,7 +1006,7 @@ impl HFClient {
             return Ok(());
         }
 
-        self.check_response(response, Some(&repo_id), crate::error::NotFoundContext::Repo)
+        self.check_response(response, Some(repo_id), crate::error::NotFoundContext::Repo)
             .await?;
         Ok(())
     }
@@ -1030,11 +1028,9 @@ impl HFClient {
     pub async fn move_repository(
         &self,
         /// Current repository ID in `"owner/name"` format.
-        #[builder(into)]
-        from_id: String,
+        from_id: &str,
         /// New repository ID in `"owner/name"` format.
-        #[builder(into)]
-        to_id: String,
+        to_id: &str,
         /// The repo kind ([`RepoTypeModel`], [`RepoTypeDataset`], [`RepoTypeSpace`],
         /// or [`RepoTypeKernel`]).
         repo_type: impl RepoType,
@@ -1177,8 +1173,7 @@ impl<T: RepoType> HFRepository<T> {
     pub async fn revision_exists(
         &self,
         /// Git revision to check for existence.
-        #[builder(into)]
-        revision: String,
+        revision: &str,
     ) -> HFResult<bool> {
         let url =
             format!("{}/revision/{}", self.hf_client.api_url(self.repo_type.plural(), &self.repo_path()), revision);
@@ -1206,23 +1201,21 @@ impl<T: RepoType> HFRepository<T> {
     pub async fn file_exists(
         &self,
         /// Path of the file to check within the repository.
-        #[builder(into)]
-        filename: String,
+        filename: &str,
         /// Git revision to check. Defaults to the main branch.
-        #[builder(into)]
-        revision: Option<String>,
+        revision: Option<&str>,
     ) -> HFResult<bool> {
-        let revision = revision.as_deref().unwrap_or(constants::DEFAULT_REVISION);
+        let revision = revision.unwrap_or(constants::DEFAULT_REVISION);
         let url = self
             .hf_client
-            .download_url(self.repo_type.url_prefix(), &self.repo_path(), revision, &filename);
+            .download_url(self.repo_type.url_prefix(), &self.repo_path(), revision, filename);
         let headers = self.hf_client.auth_headers();
         let response = retry::retry(self.hf_client.retry_config(), || {
             self.hf_client.http_client().head(&url).headers(headers.clone()).send()
         })
         .await?;
         if response.status() == reqwest::StatusCode::NOT_FOUND {
-            if self.revision_exists().revision(revision.to_string()).send().await? {
+            if self.revision_exists().revision(revision).send().await? {
                 return Ok(false);
             }
             return Err(HFError::RevisionNotFound {
@@ -1537,7 +1530,7 @@ impl crate::blocking::HFClientSync {
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn create_repository(
         &self,
-        #[builder(into)] repo_id: String,
+        repo_id: &str,
         repo_type: impl RepoType,
         private: Option<bool>,
         #[builder(default)] exist_ok: bool,
@@ -1560,7 +1553,7 @@ impl crate::blocking::HFClientSync {
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn delete_repository(
         &self,
-        #[builder(into)] repo_id: String,
+        repo_id: &str,
         repo_type: impl RepoType,
         #[builder(default)] missing_ok: bool,
     ) -> HFResult<()> {
@@ -1577,12 +1570,7 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::move_repository`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn move_repository(
-        &self,
-        #[builder(into)] from_id: String,
-        #[builder(into)] to_id: String,
-        repo_type: impl RepoType,
-    ) -> HFResult<RepoUrl> {
+    pub fn move_repository(&self, from_id: &str, to_id: &str, repo_type: impl RepoType) -> HFResult<RepoUrl> {
         self.runtime.block_on(
             self.inner
                 .move_repository()
@@ -1606,18 +1594,14 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::revision_exists`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn revision_exists(&self, #[builder(into)] revision: String) -> HFResult<bool> {
+    pub fn revision_exists(&self, revision: &str) -> HFResult<bool> {
         self.runtime.block_on(self.inner.revision_exists().revision(revision).send())
     }
 
     /// Blocking counterpart of [`HFRepository::file_exists`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn file_exists(
-        &self,
-        #[builder(into)] filename: String,
-        #[builder(into)] revision: Option<String>,
-    ) -> HFResult<bool> {
+    pub fn file_exists(&self, filename: &str, revision: Option<&str>) -> HFResult<bool> {
         self.runtime
             .block_on(self.inner.file_exists().filename(filename).maybe_revision(revision).send())
     }

--- a/hf-hub/src/spaces.rs
+++ b/hf-hub/src/spaces.rs
@@ -149,8 +149,7 @@ impl HFRepository<RepoTypeSpace> {
     pub async fn request_hardware(
         &self,
         /// Hardware flavor to request (e.g., `"cpu-basic"`, `"t4-small"`, `"a10g-small"`).
-        #[builder(into)]
-        hardware: String,
+        hardware: &str,
         /// Seconds of inactivity before the Space is put to sleep. `0` means never sleep.
         sleep_time: Option<u64>,
     ) -> HFResult<SpaceRuntime> {
@@ -256,14 +255,11 @@ impl HFRepository<RepoTypeSpace> {
     pub async fn add_secret(
         &self,
         /// Secret key name.
-        #[builder(into)]
-        key: String,
+        key: &str,
         /// Secret value.
-        #[builder(into)]
-        value: String,
+        value: &str,
         /// Human-readable description of the secret.
-        #[builder(into)]
-        description: Option<String>,
+        description: Option<&str>,
     ) -> HFResult<()> {
         let url = format!("{}/api/spaces/{}/secrets", self.hf_client.endpoint(), self.repo_path());
         let mut body = serde_json::json!({ "key": key, "value": value });
@@ -297,8 +293,7 @@ impl HFRepository<RepoTypeSpace> {
     pub async fn delete_secret(
         &self,
         /// Secret key name to delete.
-        #[builder(into)]
-        key: String,
+        key: &str,
     ) -> HFResult<()> {
         let url = format!("{}/api/spaces/{}/secrets", self.hf_client.endpoint(), self.repo_path());
         let body = serde_json::json!({ "key": key });
@@ -331,14 +326,11 @@ impl HFRepository<RepoTypeSpace> {
     pub async fn add_variable(
         &self,
         /// Variable key name.
-        #[builder(into)]
-        key: String,
+        key: &str,
         /// Variable value.
-        #[builder(into)]
-        value: String,
+        value: &str,
         /// Human-readable description of the variable.
-        #[builder(into)]
-        description: Option<String>,
+        description: Option<&str>,
     ) -> HFResult<()> {
         let url = format!("{}/api/spaces/{}/variables", self.hf_client.endpoint(), self.repo_path());
         let mut body = serde_json::json!({ "key": key, "value": value });
@@ -372,8 +364,7 @@ impl HFRepository<RepoTypeSpace> {
     pub async fn delete_variable(
         &self,
         /// Variable key name to delete.
-        #[builder(into)]
-        key: String,
+        key: &str,
     ) -> HFResult<()> {
         let url = format!("{}/api/spaces/{}/variables", self.hf_client.endpoint(), self.repo_path());
         let body = serde_json::json!({ "key": key });
@@ -442,18 +433,15 @@ impl HFRepository<RepoTypeSpace> {
         &self,
         /// Destination repository ID in `"owner/name"` format. Defaults to the authenticated user's namespace
         /// with the same name.
-        #[builder(into)]
-        to_id: Option<String>,
+        to_id: Option<&str>,
         /// Whether the duplicated Space should be private.
         private: Option<bool>,
         /// Hardware flavor identifier the duplicated Space should run on. When omitted, the Hub picks a default
         /// (typically `"cpu-basic"`) — pass a value explicitly to mirror the source Space's hardware.
-        #[builder(into)]
-        hardware: Option<String>,
+        hardware: Option<&str>,
         /// Persistent storage tier identifier. One of `"small"`, `"medium"`, or `"large"`. Omit to duplicate
         /// without persistent storage.
-        #[builder(into)]
-        storage: Option<String>,
+        storage: Option<&str>,
         /// Seconds of inactivity before the Space is put to sleep. `0` means never sleep.
         sleep_time: Option<u64>,
         /// Encrypted environment variables to set on the duplicated Space.
@@ -515,11 +503,7 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
     /// Blocking counterpart of [`HFRepository::request_hardware`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn request_hardware(
-        &self,
-        #[builder(into)] hardware: String,
-        sleep_time: Option<u64>,
-    ) -> HFResult<SpaceRuntime> {
+    pub fn request_hardware(&self, hardware: &str, sleep_time: Option<u64>) -> HFResult<SpaceRuntime> {
         self.runtime.block_on(
             self.inner
                 .request_hardware()
@@ -553,12 +537,7 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
     /// Blocking counterpart of [`HFRepository::add_secret`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn add_secret(
-        &self,
-        #[builder(into)] key: String,
-        #[builder(into)] value: String,
-        #[builder(into)] description: Option<String>,
-    ) -> HFResult<()> {
+    pub fn add_secret(&self, key: &str, value: &str, description: Option<&str>) -> HFResult<()> {
         self.runtime.block_on(
             self.inner
                 .add_secret()
@@ -572,19 +551,14 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
     /// Blocking counterpart of [`HFRepository::delete_secret`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn delete_secret(&self, #[builder(into)] key: String) -> HFResult<()> {
+    pub fn delete_secret(&self, key: &str) -> HFResult<()> {
         self.runtime.block_on(self.inner.delete_secret().key(key).send())
     }
 
     /// Blocking counterpart of [`HFRepository::add_variable`]. See the async method for parameters and
     /// behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn add_variable(
-        &self,
-        #[builder(into)] key: String,
-        #[builder(into)] value: String,
-        #[builder(into)] description: Option<String>,
-    ) -> HFResult<()> {
+    pub fn add_variable(&self, key: &str, value: &str, description: Option<&str>) -> HFResult<()> {
         self.runtime.block_on(
             self.inner
                 .add_variable()
@@ -598,7 +572,7 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
     /// Blocking counterpart of [`HFRepository::delete_variable`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn delete_variable(&self, #[builder(into)] key: String) -> HFResult<()> {
+    pub fn delete_variable(&self, key: &str) -> HFResult<()> {
         self.runtime.block_on(self.inner.delete_variable().key(key).send())
     }
 
@@ -607,10 +581,10 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn duplicate(
         &self,
-        #[builder(into)] to_id: Option<String>,
+        to_id: Option<&str>,
         private: Option<bool>,
-        #[builder(into)] hardware: Option<String>,
-        #[builder(into)] storage: Option<String>,
+        hardware: Option<&str>,
+        storage: Option<&str>,
         sleep_time: Option<u64>,
         secrets: Option<Vec<serde_json::Value>>,
         variables: Option<Vec<serde_json::Value>>,

--- a/hf-hub/src/users.rs
+++ b/hf-hub/src/users.rs
@@ -161,8 +161,7 @@ impl HFClient {
     pub async fn user_overview(
         &self,
         /// Hub handle (slug) of the user.
-        #[builder(into)]
-        username: String,
+        username: &str,
     ) -> HFResult<User> {
         let url = format!("{}/api/users/{}/overview", self.endpoint(), username);
         let headers = self.auth_headers();
@@ -185,8 +184,7 @@ impl HFClient {
     pub async fn organization_overview(
         &self,
         /// Hub handle (slug) of the organization.
-        #[builder(into)]
-        organization: String,
+        organization: &str,
     ) -> HFResult<Organization> {
         let url = format!("{}/api/organizations/{}/overview", self.endpoint(), organization);
         let headers = self.auth_headers();
@@ -274,14 +272,14 @@ impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::user_overview`]. See the async method for parameters
     /// and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn user_overview(&self, #[builder(into)] username: String) -> HFResult<User> {
+    pub fn user_overview(&self, username: &str) -> HFResult<User> {
         self.runtime.block_on(self.inner.user_overview().username(username).send())
     }
 
     /// Blocking counterpart of [`HFClient::organization_overview`]. See the async method for
     /// parameters and behavior.
     #[builder(finish_fn = send, derive(Debug, Clone))]
-    pub fn organization_overview(&self, #[builder(into)] organization: String) -> HFResult<Organization> {
+    pub fn organization_overview(&self, organization: &str) -> HFResult<Organization> {
         self.runtime
             .block_on(self.inner.organization_overview().organization(organization).send())
     }

--- a/hfrs/src/commands/repos/branch.rs
+++ b/hfrs/src/commands/repos/branch.rs
@@ -67,7 +67,7 @@ async fn create(client: &HFClient, args: BranchCreateArgs) -> Result<CommandResu
     };
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     repo.create_branch()
-        .branch(args.branch)
+        .branch(&args.branch)
         .maybe_revision(args.revision)
         .send()
         .await?;
@@ -80,6 +80,6 @@ async fn delete(client: &HFClient, args: BranchDeleteArgs) -> Result<CommandResu
         None => ("", args.repo_id.as_str()),
     };
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
-    repo.delete_branch().branch(args.branch).send().await?;
+    repo.delete_branch().branch(&args.branch).send().await?;
     Ok(CommandResult::Silent)
 }

--- a/hfrs/src/commands/repos/create.rs
+++ b/hfrs/src/commands/repos/create.rs
@@ -32,7 +32,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let result = client
         .create_repository()
         .repo_type(RepoTypeAny::from(args.r#type))
-        .repo_id(args.repo_id)
+        .repo_id(&args.repo_id)
         .maybe_private(if args.private { Some(true) } else { None })
         .exist_ok(args.exist_ok)
         .maybe_space_sdk(args.space_sdk)

--- a/hfrs/src/commands/repos/delete.rs
+++ b/hfrs/src/commands/repos/delete.rs
@@ -24,7 +24,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     client
         .delete_repository()
         .repo_type(RepoTypeAny::from(args.r#type))
-        .repo_id(args.repo_id)
+        .repo_id(&args.repo_id)
         .missing_ok(args.missing_ok)
         .send()
         .await?;

--- a/hfrs/src/commands/repos/file_metadata.rs
+++ b/hfrs/src/commands/repos/file_metadata.rs
@@ -37,7 +37,7 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let metadata = repo
         .get_file_metadata()
         .filepath(args.filepath)
-        .maybe_revision(args.revision)
+        .maybe_revision(args.revision.as_deref())
         .send()
         .await?;
 

--- a/hfrs/src/commands/repos/move_repo.rs
+++ b/hfrs/src/commands/repos/move_repo.rs
@@ -23,8 +23,8 @@ pub async fn execute(client: &HFClient, args: Args) -> Result<CommandResult> {
     let result = client
         .move_repository()
         .repo_type(RepoTypeAny::from(args.r#type))
-        .from_id(args.from_id)
-        .to_id(args.to_id)
+        .from_id(&args.from_id)
+        .to_id(&args.to_id)
         .send()
         .await?;
     Ok(CommandResult::Raw(result.url))

--- a/hfrs/src/commands/repos/tag.rs
+++ b/hfrs/src/commands/repos/tag.rs
@@ -90,8 +90,8 @@ async fn create(client: &HFClient, args: TagCreateArgs) -> Result<CommandResult>
     };
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
     repo.create_tag()
-        .tag(args.tag)
-        .maybe_revision(args.revision)
+        .tag(&args.tag)
+        .maybe_revision(args.revision.as_deref())
         .maybe_message(args.message)
         .send()
         .await?;
@@ -104,7 +104,7 @@ async fn delete(client: &HFClient, args: TagDeleteArgs) -> Result<CommandResult>
         None => ("", args.repo_id.as_str()),
     };
     let repo = client.repository::<hf_hub::RepoTypeAny>(args.r#type.into(), owner, name);
-    repo.delete_tag().tag(args.tag).send().await?;
+    repo.delete_tag().tag(&args.tag).send().await?;
     Ok(CommandResult::Silent)
 }
 

--- a/hfrs/src/commands/upload.rs
+++ b/hfrs/src/commands/upload.rs
@@ -94,7 +94,7 @@ async fn do_upload(
         client
             .create_repository()
             .repo_type(*repo.repo_type())
-            .repo_id(args.repo_id.clone())
+            .repo_id(&args.repo_id)
             .maybe_private(if args.private { Some(true) } else { None })
             .exist_ok(true)
             .send()

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -253,7 +253,7 @@ fn test_sync_get_commit_diff() {
 
     let diff = gpt2
         .get_commit_diff()
-        .compare(format!("{}..{}", commits[1].id, commits[0].id))
+        .compare(&format!("{}..{}", commits[1].id, commits[0].id))
         .send()
         .unwrap();
     assert!(!diff.is_empty());

--- a/integration-tests/tests/bucket_xet_transfer_test.rs
+++ b/integration-tests/tests/bucket_xet_transfer_test.rs
@@ -70,7 +70,7 @@ async fn create_test_bucket(client: &HFClient, suffix: &str) -> (String, String)
 
 async fn delete_test_bucket(client: &HFClient, namespace: &str, name: &str) {
     let bucket_id = format!("{namespace}/{name}");
-    let _ = client.delete_bucket().bucket_id(bucket_id).missing_ok(true).send().await;
+    let _ = client.delete_bucket().bucket_id(&bucket_id).missing_ok(true).send().await;
 }
 
 /// Poll the bucket tree until `path` is visible — the batch endpoint can

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -631,7 +631,7 @@ async fn test_get_file_metadata_with_revision() {
     let pinned = model
         .get_file_metadata()
         .filepath("config.json")
-        .revision(meta_main.commit_hash.clone())
+        .revision(&meta_main.commit_hash)
         .send()
         .await
         .unwrap();
@@ -693,7 +693,7 @@ async fn test_get_commit_diff() {
 
     let diff = gpt2
         .get_commit_diff()
-        .compare(format!("{}..{}", second.id, first.id))
+        .compare(&format!("{}..{}", second.id, first.id))
         .send()
         .await
         .unwrap();
@@ -713,7 +713,7 @@ async fn test_get_raw_diff() {
 
     let raw = gpt2
         .get_raw_diff()
-        .compare(format!("{}..{}", second.id, first.id))
+        .compare(&format!("{}..{}", second.id, first.id))
         .send()
         .await
         .unwrap();
@@ -1221,7 +1221,7 @@ async fn test_space_secrets_and_variables() {
     client
         .create_repository()
         .repo_type(RepoTypeSpace)
-        .repo_id(space.repo_path())
+        .repo_id(&space.repo_path())
         .private(true)
         .space_sdk("static")
         .send()
@@ -1245,7 +1245,7 @@ async fn test_space_secrets_and_variables() {
     let _ = client
         .delete_repository()
         .repo_type(RepoTypeSpace)
-        .repo_id(space.repo_path())
+        .repo_id(&space.repo_path())
         .send()
         .await;
 }


### PR DESCRIPTION
In a lot of different places, `String` is not necessary. Pass by ref or make it `#[builder(into)] var: String` so that you can call `.to_string` on `var`. This accepts `&str` too.

closes #184 