### PR TITLE
fix: run blocking API futures on a dedicated runtime thread so Sync handles are safe in async contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,9 +125,8 @@ helper that already has the field as an `Option<T>` local).
 Every async method MUST have a manually-written blocking counterpart on the corresponding
 `*Sync` struct under `#[cfg(feature = "blocking")]`. Mirror the same `#[builder]` parameter list
 verbatim. The body calls the inner async builder and blocks on the runtime. (`self.runtime` is a
-`RuntimeThread`, not a `tokio::runtime::Runtime`: the runtime lives on a dedicated background
-thread so sync methods are safe to call from inside another tokio runtime. Its `block_on` takes
-any `Send` future — no `'static` bound — so the wrapper body borrows `self.inner` directly.)
+`RuntimeThread`: the runtime lives on a background thread so sync methods are safe from inside
+another tokio runtime, and its `block_on` takes any `Send` future — no `'static` bound.)
 
 ```rust
 #[cfg(feature = "blocking")]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,10 @@ helper that already has the field as an `Option<T>` local).
 
 Every async method MUST have a manually-written blocking counterpart on the corresponding
 `*Sync` struct under `#[cfg(feature = "blocking")]`. Mirror the same `#[builder]` parameter list
-verbatim. The body calls the inner async builder and blocks on the runtime:
+verbatim. The body calls the inner async builder and blocks on the runtime. (`self.runtime` is a
+`RuntimeThread`, not a `tokio::runtime::Runtime`: the runtime lives on a dedicated background
+thread so sync methods are safe to call from inside another tokio runtime. Its `block_on` takes
+any `Send` future — no `'static` bound — so the wrapper body borrows `self.inner` directly.)
 
 ```rust
 #[cfg(feature = "blocking")]
@@ -149,8 +152,7 @@ impl crate::blocking::HFRepositorySync {
 
 For stream-returning methods, the sync counterpart collects into `Vec<T>`: pin the stream and
 drain with `while let Some` (see existing examples in `repository/listing.rs` and
-`repository/mod.rs`). On `HFSpaceSync`, the runtime is reached via `&self.repo_sync.runtime`
-because the struct has no direct `runtime` field. Do NOT reintroduce the legacy `sync_api!` /
+`repository/mod.rs`). Do NOT reintroduce the legacy `sync_api!` /
 `sync_api_stream!` / `sync_api_async_stream!` macros — they were removed deliberately when the
 crate moved to bon.
 

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -24,7 +24,7 @@ pub(crate) struct RuntimeThread {
 impl RuntimeThread {
     /// Spawns the background thread and waits for its runtime to come up.
     fn spawn() -> HFResult<Arc<Self>> {
-        let (handle_tx, handle_rx) = std::sync::mpsc::channel();
+        let (handle_tx, handle_rx) = std::sync::mpsc::sync_channel(1);
         let (shutdown_tx, shutdown_rx) = futures::channel::oneshot::channel::<()>();
         std::thread::Builder::new()
             .name("hf-hub-blocking-runtime".to_string())

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -5,24 +5,17 @@ use crate::client::HFClient;
 use crate::error::{HFError, HFResult};
 use crate::repository::{HFRepository, RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};
 
-/// A dedicated background thread that owns a single-threaded tokio runtime,
+/// A dedicated background thread owning a single-threaded tokio runtime,
 /// modeled on `reqwest::blocking`.
 ///
-/// The runtime is created on — and never leaves — the background thread.
-/// `tokio::runtime::Runtime::block_on` and `Runtime`'s `Drop` both panic when
-/// invoked from inside another tokio runtime, which is exactly the situation
-/// a blocking API embedded in an async application ends up in. Keeping the
-/// runtime off every caller thread removes both panic modes: sync wrapper
-/// methods run their futures via [`RuntimeThread::block_on`], which merely
-/// blocks the calling thread until the future completes.
+/// The runtime never leaves this thread: `Runtime::block_on` and `Runtime`'s
+/// `Drop` both panic inside another tokio runtime, so keeping the runtime off
+/// caller threads removes both panic modes.
 ///
-/// Shutdown: the background thread sits in `runtime.block_on(shutdown_rx)`,
-/// which also drives the IO/timer drivers and any tasks the wrapped futures
-/// spawn. When the last handle sharing this `RuntimeThread` drops, the
-/// `_shutdown` sender drops with it, the receiver resolves, `block_on`
-/// returns, and the runtime is dropped on its own thread. The thread is
-/// detached rather than joined so that dropping the last handle never blocks
-/// the caller (reqwest-style).
+/// The thread parks in `runtime.block_on(shutdown_rx)`, driving IO, timers,
+/// and spawned tasks. When the last handle drops, the shutdown sender drops,
+/// `block_on` returns, and the runtime is dropped on its own thread. The
+/// thread is detached so dropping the last handle never blocks.
 pub(crate) struct RuntimeThread {
     handle: tokio::runtime::Handle,
     _shutdown: futures::channel::oneshot::Sender<()>,
@@ -61,22 +54,17 @@ impl RuntimeThread {
             })
     }
 
-    /// Runs `future` to completion on the background runtime, blocking the
-    /// calling thread until it finishes.
+    /// Runs `future` on the background runtime, blocking the caller until it
+    /// completes.
     ///
-    /// Safe to call from inside another tokio runtime: the future is polled by
-    /// a short-lived scoped thread via `Handle::block_on` (IO, timers, and
-    /// spawned tasks are driven by the parked background thread), so no tokio
-    /// blocking API ever runs on the caller thread and the nested-runtime
-    /// enter guard is never tripped. The scoped thread also lets `future`
-    /// borrow from the caller's stack — no `'static` bound — so wrapper
-    /// methods can pass `self.inner...` futures directly. If the future
-    /// panics, the panic is resumed on the calling thread, matching the
-    /// semantics `Runtime::block_on` had.
+    /// Safe inside another tokio runtime: the future is polled on a
+    /// short-lived scoped thread via `Handle::block_on`, so no tokio blocking
+    /// API runs on the caller thread. The scoped thread also lets `future`
+    /// borrow from the caller's stack — no `'static` bound. Panics are
+    /// resumed on the caller.
     ///
-    /// Do not call from the background runtime thread itself (e.g. from a
-    /// progress callback): the scoped thread would wait on a runtime whose
-    /// driver is parked inside this call, deadlocking.
+    /// Do not call from the background runtime thread itself (e.g. a progress
+    /// callback): that deadlocks, since the driver is parked inside this call.
     pub(crate) fn block_on<F>(&self, future: F) -> F::Output
     where
         F: Future + Send,
@@ -93,11 +81,10 @@ impl RuntimeThread {
 
 /// Synchronous/blocking counterpart to [`HFClient`].
 ///
-/// Wraps an [`HFClient`] together with a single-threaded tokio runtime living
-/// on a dedicated background thread (`RuntimeThread` in this module) so the
-/// async API can be used from synchronous code — including from threads that
-/// are themselves inside a tokio runtime, where a caller-owned runtime would
-/// panic on tokio's nested-runtime guard.
+/// Wraps an [`HFClient`] together with a single-threaded tokio runtime on a
+/// dedicated background thread (`RuntimeThread` in this module), so the async
+/// API can be used from synchronous code — including from inside another
+/// tokio runtime, where a caller-owned runtime would panic.
 ///
 /// Xet uploads and downloads do not run on this runtime: hf-xet requires a
 /// multi-threaded runtime with the IO and time drivers enabled, so the
@@ -334,10 +321,9 @@ mod tests {
         HFClientSync::from_inner(inner).unwrap()
     }
 
-    /// Regression test: with the runtime owned by the caller-side handle, this
-    /// panicked on tokio's nested-runtime guard ("Cannot start a runtime from
-    /// within a runtime"). The connection error is expected; the point is
-    /// completing without a panic.
+    /// Regression: panicked with "Cannot start a runtime from within a
+    /// runtime" when the caller-side handle owned the runtime. The connection
+    /// error is expected; the point is completing without a panic.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn sync_call_inside_multi_thread_runtime_does_not_panic() {
         let client = client_with_unreachable_endpoint();
@@ -345,9 +331,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// Same regression as the multi-thread flavor. The call blocks the only
-    /// caller-runtime thread while the work runs on the dedicated background
-    /// thread, so it still completes.
     #[tokio::test]
     async fn sync_call_inside_current_thread_runtime_does_not_panic() {
         let client = client_with_unreachable_endpoint();
@@ -355,9 +338,8 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// Regression test: dropping the handle (and with it the old caller-side
-    /// `Runtime`) from async context also panicked before the runtime moved
-    /// to its own thread.
+    /// Regression: dropping the handle from async context also panicked when
+    /// the caller side owned the runtime.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn construct_and_drop_inside_async_context_does_not_panic() {
         let client = HFClientSync::from_inner(HFClient::builder().build().unwrap()).unwrap();
@@ -390,9 +372,8 @@ mod tests {
         assert_eq!(panic.downcast_ref::<&str>(), Some(&"boom"));
     }
 
-    /// The scoped-thread `block_on` must accept borrowing (non-`'static`)
-    /// futures — that property is what keeps the ~65 wrapper call sites
-    /// unchanged.
+    /// `block_on` must accept borrowing (non-`'static`) futures — the
+    /// property that keeps the wrapper call sites unchanged.
     #[test]
     fn block_on_accepts_borrowing_futures() {
         let runtime = RuntimeThread::spawn().unwrap();

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -94,9 +94,9 @@ impl RuntimeThread {
 /// Synchronous/blocking counterpart to [`HFClient`].
 ///
 /// Wraps an [`HFClient`] together with a single-threaded tokio runtime living
-/// on a dedicated background thread (see [`RuntimeThread`]) so the async API
-/// can be used from synchronous code — including from threads that are
-/// themselves inside a tokio runtime, where a caller-owned runtime would
+/// on a dedicated background thread (`RuntimeThread` in this module) so the
+/// async API can be used from synchronous code — including from threads that
+/// are themselves inside a tokio runtime, where a caller-owned runtime would
 /// panic on tokio's nested-runtime guard.
 ///
 /// Xet uploads and downloads do not run on this runtime: hf-xet requires a

--- a/hf-hub/src/blocking.rs
+++ b/hf-hub/src/blocking.rs
@@ -1,35 +1,117 @@
+use std::future::Future;
 use std::sync::Arc;
 
 use crate::client::HFClient;
 use crate::error::{HFError, HFResult};
 use crate::repository::{HFRepository, RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace};
 
-fn build_runtime() -> HFResult<Arc<tokio::runtime::Runtime>> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map(Arc::new)
-        .map_err(|e| HFError::Other(format!("Failed to create tokio runtime: {e}")))
+/// A dedicated background thread that owns a single-threaded tokio runtime,
+/// modeled on `reqwest::blocking`.
+///
+/// The runtime is created on — and never leaves — the background thread.
+/// `tokio::runtime::Runtime::block_on` and `Runtime`'s `Drop` both panic when
+/// invoked from inside another tokio runtime, which is exactly the situation
+/// a blocking API embedded in an async application ends up in. Keeping the
+/// runtime off every caller thread removes both panic modes: sync wrapper
+/// methods run their futures via [`RuntimeThread::block_on`], which merely
+/// blocks the calling thread until the future completes.
+///
+/// Shutdown: the background thread sits in `runtime.block_on(shutdown_rx)`,
+/// which also drives the IO/timer drivers and any tasks the wrapped futures
+/// spawn. When the last handle sharing this `RuntimeThread` drops, the
+/// `_shutdown` sender drops with it, the receiver resolves, `block_on`
+/// returns, and the runtime is dropped on its own thread. The thread is
+/// detached rather than joined so that dropping the last handle never blocks
+/// the caller (reqwest-style).
+pub(crate) struct RuntimeThread {
+    handle: tokio::runtime::Handle,
+    _shutdown: futures::channel::oneshot::Sender<()>,
+}
+
+impl RuntimeThread {
+    /// Spawns the background thread and waits for its runtime to come up.
+    fn spawn() -> HFResult<Arc<Self>> {
+        let (handle_tx, handle_rx) = std::sync::mpsc::channel();
+        let (shutdown_tx, shutdown_rx) = futures::channel::oneshot::channel::<()>();
+        std::thread::Builder::new()
+            .name("hf-hub-blocking-runtime".to_string())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                    Ok(runtime) => runtime,
+                    Err(e) => {
+                        let _ = handle_tx.send(Err(e));
+                        return;
+                    },
+                };
+                let _ = handle_tx.send(Ok(runtime.handle().clone()));
+                runtime.block_on(async {
+                    let _ = shutdown_rx.await;
+                });
+            })
+            .map_err(|e| HFError::Other(format!("Failed to spawn tokio runtime thread: {e}")))?;
+        handle_rx
+            .recv()
+            .map_err(|_| HFError::Other("tokio runtime thread exited before initializing".to_string()))?
+            .map_err(|e| HFError::Other(format!("Failed to create tokio runtime: {e}")))
+            .map(|handle| {
+                Arc::new(Self {
+                    handle,
+                    _shutdown: shutdown_tx,
+                })
+            })
+    }
+
+    /// Runs `future` to completion on the background runtime, blocking the
+    /// calling thread until it finishes.
+    ///
+    /// Safe to call from inside another tokio runtime: the future is polled by
+    /// a short-lived scoped thread via `Handle::block_on` (IO, timers, and
+    /// spawned tasks are driven by the parked background thread), so no tokio
+    /// blocking API ever runs on the caller thread and the nested-runtime
+    /// enter guard is never tripped. The scoped thread also lets `future`
+    /// borrow from the caller's stack — no `'static` bound — so wrapper
+    /// methods can pass `self.inner...` futures directly. If the future
+    /// panics, the panic is resumed on the calling thread, matching the
+    /// semantics `Runtime::block_on` had.
+    ///
+    /// Do not call from the background runtime thread itself (e.g. from a
+    /// progress callback): the scoped thread would wait on a runtime whose
+    /// driver is parked inside this call, deadlocking.
+    pub(crate) fn block_on<F>(&self, future: F) -> F::Output
+    where
+        F: Future + Send,
+        F::Output: Send,
+    {
+        std::thread::scope(|scope| {
+            scope
+                .spawn(|| self.handle.block_on(future))
+                .join()
+                .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+        })
+    }
 }
 
 /// Synchronous/blocking counterpart to [`HFClient`].
 ///
-/// Wraps an [`HFClient`] together with a dedicated single-threaded tokio
-/// runtime so the async API can be used from synchronous code.
+/// Wraps an [`HFClient`] together with a single-threaded tokio runtime living
+/// on a dedicated background thread (see [`RuntimeThread`]) so the async API
+/// can be used from synchronous code — including from threads that are
+/// themselves inside a tokio runtime, where a caller-owned runtime would
+/// panic on tokio's nested-runtime guard.
 ///
 /// Xet uploads and downloads do not run on this runtime: hf-xet requires a
 /// multi-threaded runtime with the IO and time drivers enabled, so the
 /// single-threaded runtime here does not meet its requirements. When a Xet
 /// transfer is triggered through any blocking handle, hf-xet spins up its
 /// own multi-threaded thread pool to back the `XetSession`, separate from
-/// the runtime owned by `HFClientSync`.
+/// the runtime thread owned by `HFClientSync`.
 ///
 /// See [`HFClient`] for configuration and API semantics.
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 #[derive(Clone)]
 pub struct HFClientSync {
     pub(crate) inner: HFClient,
-    pub(crate) runtime: Arc<tokio::runtime::Runtime>,
+    pub(crate) runtime: Arc<RuntimeThread>,
 }
 
 /// Synchronous/blocking counterpart to [`HFRepository`], parameterized by the repo kind via `T`.
@@ -40,7 +122,7 @@ pub struct HFClientSync {
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub struct HFRepositorySync<T: RepoType> {
     pub(crate) inner: Arc<HFRepository<T>>,
-    pub(crate) runtime: Arc<tokio::runtime::Runtime>,
+    pub(crate) runtime: Arc<RuntimeThread>,
 }
 
 impl<T: RepoType> Clone for HFRepositorySync<T> {
@@ -62,7 +144,7 @@ impl<T: RepoType> Clone for HFRepositorySync<T> {
 #[derive(Clone)]
 pub struct HFBucketSync {
     pub(crate) inner: Arc<crate::buckets::HFBucket>,
-    pub(crate) runtime: Arc<tokio::runtime::Runtime>,
+    pub(crate) runtime: Arc<RuntimeThread>,
 }
 
 impl std::fmt::Debug for HFClientSync {
@@ -94,7 +176,7 @@ impl HFClientSync {
     pub fn new() -> HFResult<Self> {
         Ok(Self {
             inner: HFClient::new()?,
-            runtime: build_runtime()?,
+            runtime: RuntimeThread::spawn()?,
         })
     }
 
@@ -106,7 +188,7 @@ impl HFClientSync {
     pub fn from_inner(inner: HFClient) -> HFResult<Self> {
         Ok(Self {
             inner,
-            runtime: build_runtime()?,
+            runtime: RuntimeThread::spawn()?,
         })
     }
 
@@ -233,5 +315,90 @@ mod tests {
         assert_eq!(repo.name(), "gpt2");
         assert_eq!(repo.repo_type().singular(), "model");
         assert_eq!(space.repo_type().singular(), "space");
+    }
+
+    /// Endpoint that refuses connections: bind an ephemeral port, then free it.
+    fn unreachable_endpoint() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        format!("http://127.0.0.1:{port}")
+    }
+
+    fn client_with_unreachable_endpoint() -> HFClientSync {
+        let inner = HFClient::builder()
+            .endpoint(unreachable_endpoint())
+            .retry_max_attempts(0)
+            .build()
+            .unwrap();
+        HFClientSync::from_inner(inner).unwrap()
+    }
+
+    /// Regression test: with the runtime owned by the caller-side handle, this
+    /// panicked on tokio's nested-runtime guard ("Cannot start a runtime from
+    /// within a runtime"). The connection error is expected; the point is
+    /// completing without a panic.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sync_call_inside_multi_thread_runtime_does_not_panic() {
+        let client = client_with_unreachable_endpoint();
+        let result = client.model("openai-community", "gpt2").info().send();
+        assert!(result.is_err());
+    }
+
+    /// Same regression as the multi-thread flavor. The call blocks the only
+    /// caller-runtime thread while the work runs on the dedicated background
+    /// thread, so it still completes.
+    #[tokio::test]
+    async fn sync_call_inside_current_thread_runtime_does_not_panic() {
+        let client = client_with_unreachable_endpoint();
+        let result = client.model("openai-community", "gpt2").info().send();
+        assert!(result.is_err());
+    }
+
+    /// Regression test: dropping the handle (and with it the old caller-side
+    /// `Runtime`) from async context also panicked before the runtime moved
+    /// to its own thread.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn construct_and_drop_inside_async_context_does_not_panic() {
+        let client = HFClientSync::from_inner(HFClient::builder().build().unwrap()).unwrap();
+        drop(client);
+    }
+
+    #[test]
+    fn clones_share_runtime_thread_and_survive_staggered_drops() {
+        let client = client_with_unreachable_endpoint();
+        let clone = client.clone();
+        let repo = client.model("openai-community", "gpt2");
+        assert!(Arc::ptr_eq(&client.runtime, &clone.runtime));
+        assert!(Arc::ptr_eq(&client.runtime, &repo.runtime));
+
+        drop(client);
+        drop(clone);
+        let result = repo.exists().send();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn block_on_resumes_task_panics_on_the_caller() {
+        let runtime = RuntimeThread::spawn().unwrap();
+        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            runtime.block_on(async {
+                panic!("boom");
+            })
+        }));
+        let panic = caught.unwrap_err();
+        assert_eq!(panic.downcast_ref::<&str>(), Some(&"boom"));
+    }
+
+    /// The scoped-thread `block_on` must accept borrowing (non-`'static`)
+    /// futures — that property is what keeps the ~65 wrapper call sites
+    /// unchanged.
+    #[test]
+    fn block_on_accepts_borrowing_futures() {
+        let runtime = RuntimeThread::spawn().unwrap();
+        let data = String::from("borrowed");
+        let borrowed = &data;
+        let len = runtime.block_on(async move { borrowed.len() });
+        assert_eq!(len, data.len());
     }
 }

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -154,7 +154,10 @@
 //! ## Blocking API
 //!
 //! Enable the `blocking` feature for synchronous wrappers that manage a dedicated
-//! tokio runtime internally:
+//! tokio runtime internally. The runtime lives on a background thread, so the
+//! blocking methods are safe to call even from threads that are inside another
+//! tokio runtime (they block the calling thread while the work runs on the
+//! background runtime):
 //!
 //! ```toml
 //! [dependencies]

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -155,9 +155,7 @@
 //!
 //! Enable the `blocking` feature for synchronous wrappers that manage a dedicated
 //! tokio runtime internally. The runtime lives on a background thread, so the
-//! blocking methods are safe to call even from threads that are inside another
-//! tokio runtime (they block the calling thread while the work runs on the
-//! background runtime):
+//! blocking methods are safe to call even from inside another tokio runtime:
 //!
 //! ```toml
 //! [dependencies]

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -435,11 +435,9 @@ fn test_sync_branch_operations() {
 
 // --- Async-context safety ---
 //
-// Regression tests for the dedicated-runtime-thread execution model: every
-// call below used to panic on tokio's nested-runtime guard ("Cannot start a
-// runtime from within a runtime") when the sync API was invoked from inside
-// an async application, and dropping the client from async context panicked
-// during unwind as well.
+// Regression tests: every call below used to panic on tokio's nested-runtime
+// guard when the sync API was used inside an async application, and dropping
+// the client from async context panicked as well.
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_sync_info_and_download_inside_async_context() {

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -432,3 +432,47 @@ fn test_sync_branch_operations() {
 
     delete_test_repo(&client, &repo_id);
 }
+
+// --- Async-context safety ---
+//
+// Regression tests for the dedicated-runtime-thread execution model: every
+// call below used to panic on tokio's nested-runtime guard ("Cannot start a
+// runtime from within a runtime") when the sync API was invoked from inside
+// an async application, and dropping the client from async context panicked
+// during unwind as well.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sync_info_and_download_inside_async_context() {
+    let Some(client) = prod_sync_api() else { return };
+    let repo = repo_handle(&client, TEST_MODEL_REPO);
+
+    let info = repo.info().send().unwrap();
+    assert_eq!(info.id, TEST_MODEL_REPO);
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = repo
+        .download_file()
+        .filename("config.json")
+        .local_dir(dir.path().to_path_buf())
+        .send()
+        .unwrap();
+    assert!(path.exists());
+}
+
+#[tokio::test]
+async fn test_sync_call_inside_current_thread_runtime() {
+    let Some(client) = prod_sync_api() else { return };
+    let repo = repo_handle(&client, TEST_MODEL_REPO);
+    assert!(repo.exists().send().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sync_client_clone_and_staggered_drop_inside_async_context() {
+    let Some(client) = prod_sync_api() else { return };
+    let clone = client.clone();
+    let repo = repo_handle(&client, TEST_MODEL_REPO);
+    drop(client);
+    drop(clone);
+    assert!(repo.exists().send().unwrap());
+    drop(repo);
+}


### PR DESCRIPTION
## Problem

The `*Sync` handles each own a current-thread `tokio::runtime::Runtime`, and every wrapper method is `self.runtime.block_on(...)` (~65 sites across `blocking.rs` and the sync mirrors). Tokio's enter guard makes `Runtime::block_on` panic when the calling thread is already inside a runtime, and dropping the runtime from async context panics during unwind too. So from async code: constructing an `HFClientSync` works, any method call panics ("Cannot start a runtime from within a runtime"), and even dropping the client panics.

This is a migration trap: hf-hub 0.4's sync API was ureq-backed (no runtime), so calling it inside async handlers was rude but worked. Consumer validation found real exposure — mistral.rs, fastembed, and the sglang router all call the sync API from async contexts. It also violates our own AGENTS.md rule: never panic.

## Fix

Same execution model as #182 (the `reqwest::blocking` pattern — a `RuntimeThread` background thread owns the runtime, created on and dropped on that thread, so both panic modes disappear), but with one structural difference that keeps the change to a single file:

`RuntimeThread::block_on` keeps `Runtime::block_on`'s exact shape — `fn block_on<F: Future + Send>(&self, future: F) -> F::Output`, **no `'static` bound** — by polling the future on a short-lived `std::thread::scope` thread via `Handle::block_on`. The scoped thread lets the future borrow the caller's stack, so:

- all ~65 `self.runtime.block_on(...)` wrapper call sites compile **unchanged** (no clone-into-`async move` boilerplate),
- the `snapshot_download` eager-collection workaround #182 needed for its `Send + 'static` bound is unnecessary (the HRTB failure never arises),
- no `tokio/sync` feature addition (shutdown uses `futures::channel::oneshot`, already a mandatory dep).

IO, timers, and spawned connection tasks are driven by the background thread parked in `runtime.block_on(shutdown_rx)` — precisely the setup `Handle::block_on` documents as required for current-thread runtimes. Per-call cost is one short-lived OS thread (tens of µs, noise next to any HTTP round trip); the reactor and reqwest connection pool persist across calls.

Panics in wrapped futures are resumed on the caller (via scoped-thread join), matching previous semantics. When the last handle drops, the oneshot sender drops, the background `block_on` returns, and the runtime is dropped on its own thread; the thread is detached so dropping never blocks.

Known limitation (documented on `RuntimeThread::block_on`): calling a sync method *from* the background runtime thread itself (e.g. inside a progress callback) would deadlock — same hazard as `reqwest::blocking`.

## WASM

No impact: `mod blocking` is compiled only under `#[cfg(all(feature = "blocking", not(target_family = "wasm")))]`, all new code lives in `blocking.rs`, and `cargo check -p hf-hub --target wasm32-unknown-unknown` is green.

## Tests

New regression tests (each panicked on the base commit):

- unit (`blocking.rs`, network-free via a connection-refused local endpoint): sync call inside multi-thread and current-thread `#[tokio::test]` runtimes; construct-and-drop in async context; clones share the runtime thread and survive staggered drops; task panics resume on the caller; `block_on` accepts borrowing (non-`'static`) futures.
- integration (`blocking_test.rs`, HF_TOKEN-gated): `info()` + `download_file()` inside a multi-thread runtime, a current-thread-runtime call, clone/staggered-drop in async context.

Verification:

- `cargo test -p hf-hub --all-features`: 218 passed
- `cargo test -p integration-tests --test blocking_test` (live): 25 passed, including the 3 new async-context tests
- `cargo clippy --workspace --all-targets` (default and `--all-features`), `-D warnings`: clean
- `cargo +nightly fmt --check`: clean
- `cargo check -p hf-hub --target wasm32-unknown-unknown`: green

## Relation to #182

Supersedes #182 if accepted: same runtime-ownership model, ~4 files / +234 lines instead of 14 files / ~480 lines, and none of the nine sync-mirror files are touched (less conflict surface with #178–#181, which stack on the same base).
