### PR TITLE
fix(ci): publish release to crates.io explicitly

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -28,10 +28,8 @@ jobs:
 
       - name: Publish package rust
         working-directory: ./hf-hub
-        # The HF registry proxy setup replaces the crates-io source with a
-        # non-remote-registry mirror (hf-mirror), which cannot be published to.
-        # Pass --registry crates-io so the publish targets crates.io directly.
-        # The token is provided via CARGO_REGISTRY_TOKEN rather than the
+        # --registry crates-io bypasses the hf-mirror source replacement from
+        # the proxy setup (which can't be published to). Token via env, not the
         # deprecated --token flag.
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -31,4 +31,8 @@ jobs:
         # The HF registry proxy setup replaces the crates-io source with a
         # non-remote-registry mirror (hf-mirror), which cannot be published to.
         # Pass --registry crates-io so the publish targets crates.io directly.
-        run: cargo publish --registry crates-io --token "${{ secrets.CRATES_TOKEN }}"
+        # The token is provided via CARGO_REGISTRY_TOKEN rather than the
+        # deprecated --token flag.
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        run: cargo publish --registry crates-io

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -28,4 +28,7 @@ jobs:
 
       - name: Publish package rust
         working-directory: ./hf-hub
-        run: cargo publish --token "${{ secrets.CRATES_TOKEN }}"
+        # The HF registry proxy setup replaces the crates-io source with a
+        # non-remote-registry mirror (hf-mirror), which cannot be published to.
+        # Pass --registry crates-io so the publish targets crates.io directly.
+        run: cargo publish --registry crates-io --token "${{ secrets.CRATES_TOKEN }}"

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -11,6 +11,9 @@ jobs:
   rust_publish:
     runs-on:
       group: aws-general-8-plus
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -26,11 +29,13 @@ jobs:
           path: ~/.cargo/registry
           key: aws-general-8-plus-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
+        id: auth
+
       - name: Publish package rust
         working-directory: ./hf-hub
-        # --registry crates-io bypasses the hf-mirror source replacement from
-        # the proxy setup (which can't be published to). Token via env, not the
-        # deprecated --token flag.
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        # --registry crates-io bypasses the hf-mirror registry proxy (which can't be published to)
         run: cargo publish --registry crates-io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+


### PR DESCRIPTION
## Problem

The `Rust Release` workflow failed on the `v1.0.0-rc.2` tag push ([run](https://github.com/huggingface/hf-hub/actions/runs/29033772628/job/86173174909)):

```
error: crates-io is replaced with non-remote-registry source registry `hf-mirror`;
include `--registry crates-io` to use crates.io
```

The `setup-hf-registry-proxies` action rewrites the `crates-io` source to point at the internal `hf-mirror` proxy (great for *fetching* deps behind the proxy). But that mirror is not a remote registry you can *publish* to, so a bare `cargo publish` is redirected there and errors out.

## Fix

Pass `--registry crates-io` to `cargo publish` so the publish targets crates.io directly, bypassing the source replacement. This is exactly what cargo's error message recommends.

## Testing

- CI (this workflow) only runs on tag pushes, so it can't be exercised by this PR directly.
- Once merged, re-pushing the `v1.0.0-rc.2` tag (or the next release tag) should publish successfully. The `--token` flag continues to authenticate against crates.io as before.