### PR TITLE
feat(docs): build docs.rs for wasm32-unknown-unknown alongside linux

### DIFF
--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -11,6 +11,8 @@ documentation = "https://docs.rs/hf-hub"
 [package.metadata.docs.rs]
 features = ["blocking"]
 rustdoc-args = ["--cfg", "docsrs"]
+default-target = "x86_64-unknown-linux-gnu"
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
 bytes = "1"

--- a/hf-hub/src/buckets/mod.rs
+++ b/hf-hub/src/buckets/mod.rs
@@ -1094,7 +1094,7 @@ impl HFClient {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::create_bucket`]. See the async method for parameters
@@ -1152,7 +1152,7 @@ impl crate::blocking::HFClientSync {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFBucketSync {
     /// Blocking counterpart of [`HFBucket::info`].

--- a/hf-hub/src/buckets/sync.rs
+++ b/hf-hub/src/buckets/sync.rs
@@ -861,7 +861,7 @@ impl HFBucket {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFBucketSync {
     /// Blocking counterpart of [`HFBucket::sync`]. See the async method for parameters and

--- a/hf-hub/src/cache/mod.rs
+++ b/hf-hub/src/cache/mod.rs
@@ -123,7 +123,7 @@ impl HFClient {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::scan_cache`].

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -297,7 +297,7 @@ impl HFClientBuilder {
     /// Returns an error if the endpoint URL is not a valid URL, if the `reqwest` client
     /// cannot be constructed (e.g., an invalid `User-Agent` string was provided), or if the
     /// tokio runtime handle could not be correctly created for the blocking client.
-    #[cfg(feature = "blocking")]
+    #[cfg(all(feature = "blocking", not(target_family = "wasm")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
     pub fn build_sync(self) -> HFResult<crate::blocking::HFClientSync> {
         let async_client = self.build()?;

--- a/hf-hub/src/repository/commits.rs
+++ b/hf-hub/src/repository/commits.rs
@@ -481,7 +481,7 @@ impl<T: RepoType> HFRepository<T> {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::list_commits`]. Collects the stream into a

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -1323,7 +1323,7 @@ impl<T: RepoType> HFRepository<T> {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::download_file`]. See the async method for

--- a/hf-hub/src/repository/listing.rs
+++ b/hf-hub/src/repository/listing.rs
@@ -189,10 +189,10 @@ impl<T: RepoType> HFRepository<T> {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 use futures::stream::StreamExt as _;
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::list_tree`]. Returns the collected stream as a

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -1421,7 +1421,7 @@ fn split_repo_id(repo_id: &str) -> (Option<&str>, &str) {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::list_models`]. Returns the collected stream as a
@@ -1586,7 +1586,7 @@ impl crate::blocking::HFClientSync {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::exists`].
@@ -1640,7 +1640,7 @@ impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
 /// runtime. Builder type names are unique to keep the bon-generated state types from
 /// colliding across the four impl blocks.
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFRepositorySync<RepoTypeModel> {
     /// Blocking counterpart of [`HFRepository::<RepoTypeModel>::info`].
@@ -1656,7 +1656,7 @@ impl crate::blocking::HFRepositorySync<RepoTypeModel> {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFRepositorySync<RepoTypeDataset> {
     /// Blocking counterpart of [`HFRepository::<RepoTypeDataset>::info`].
@@ -1676,7 +1676,7 @@ impl crate::blocking::HFRepositorySync<RepoTypeDataset> {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
     /// Blocking counterpart of [`HFRepository::<RepoTypeSpace>::info`].
@@ -1692,7 +1692,7 @@ impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFRepositorySync<RepoTypeKernel> {
     /// Blocking counterpart of [`HFRepository::<RepoTypeKernel>::info`].

--- a/hf-hub/src/repository/upload.rs
+++ b/hf-hub/src/repository/upload.rs
@@ -969,7 +969,7 @@ impl<T: RepoType> HFRepository<T> {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
     /// Blocking counterpart of [`HFRepository::create_commit`]. See the async method for

--- a/hf-hub/src/spaces.rs
+++ b/hf-hub/src/spaces.rs
@@ -490,7 +490,7 @@ impl HFRepository<RepoTypeSpace> {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFRepositorySync<RepoTypeSpace> {
     /// Blocking counterpart of [`HFRepository::runtime`]. See the async method for parameters and

--- a/hf-hub/src/users.rs
+++ b/hf-hub/src/users.rs
@@ -260,7 +260,7 @@ impl HFClient {
     }
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
 #[bon]
 impl crate::blocking::HFClientSync {
     /// Blocking counterpart of [`HFClient::whoami`].

--- a/scripts/verify_wasm.sh
+++ b/scripts/verify_wasm.sh
@@ -16,6 +16,12 @@ fi
 echo "==> cargo check -p hf-hub --target wasm32-unknown-unknown --no-default-features"
 cargo check -p hf-hub --target wasm32-unknown-unknown --no-default-features
 
+# docs.rs builds the wasm32 target with the same features as the linux target
+# (see [package.metadata.docs.rs]), so `blocking` must stay wasm-compatible.
+echo
+echo "==> cargo check -p hf-hub --target wasm32-unknown-unknown --features blocking"
+cargo check -p hf-hub --target wasm32-unknown-unknown --features blocking
+
 echo
 echo "==> cargo check (wasm/smoke) — exercises HFRepository::download_file_stream through wasm-bindgen"
 (cd wasm/smoke && cargo check --target wasm32-unknown-unknown)


### PR DESCRIPTION
## What

Makes docs.rs generate documentation for `wasm32-unknown-unknown` in addition to the existing `x86_64-unknown-linux-gnu` docs on each release, so the wasm-visible API surface (and what's absent on wasm) is browsable.

## How

- **`hf-hub/Cargo.toml`**: add `default-target` + `targets` to `[package.metadata.docs.rs]`. Linux remains the default page; wasm32 becomes selectable in the docs.rs target dropdown.
- **cfg gating fix**: docs.rs builds every target with the same feature list (`blocking`), but the `*Sync` impl blocks scattered across the crate were gated only on `feature = "blocking"` while the `blocking` module itself is gated on `all(feature = "blocking", not(target_family = "wasm")))` — so `blocking` + wasm32 never compiled. Updated all 19 sites to the full gate, making the feature a clean no-op on wasm.
- **`scripts/verify_wasm.sh`**: add `cargo check -p hf-hub --target wasm32-unknown-unknown --features blocking` so CI guards the exact combination docs.rs builds.

## Notes

- The wasm rustdoc build emits ~23 unresolved intra-doc-link warnings (links to native-only items like `HFClientSync` from docs that are visible on wasm). docs.rs treats these as non-fatal; the CI `docs` job (`-D warnings`) only builds the host target and stays clean.

## Verification

- `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p hf-hub --features blocking --no-deps --target wasm32-unknown-unknown` — succeeds (failed before the gating fix)
- `RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo +nightly doc -p hf-hub --features blocking --no-deps` — clean (CI docs job equivalent)
- `./scripts/verify_wasm.sh` — green, including the new blocking check
- `cargo clippy -p hf-hub --all-features -- -D warnings` — clean
- `cargo test -p hf-hub --features blocking` — 217 passed