### PR TITLE
fix: don't trust redirect Content-Length as file size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "getrandom 0.2.17",
  "globset",
  "hf-xet",
+ "http",
  "hyper",
  "pathdiff",
  "percent-encoding",

--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -49,4 +49,5 @@ wasm-bindgen-futures = "0.4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tempfile = "3"
 serial_test = "3"
+http = "1"
 

--- a/hf-hub/src/repository/files.rs
+++ b/hf-hub/src/repository/files.rs
@@ -352,9 +352,17 @@ pub(super) fn extract_commit_hash(response: &reqwest::Response) -> Option<String
 
 pub(crate) fn extract_file_size(response: &reqwest::Response) -> Option<u64> {
     let headers = response.headers();
+    if let Some(linked_size) = headers.get(constants::HEADER_X_LINKED_SIZE) {
+        return linked_size.to_str().ok().and_then(|value| value.parse().ok());
+    }
+
+    // A redirect's Content-Length describes its body, not the target file.
+    if response.status().is_redirection() {
+        return None;
+    }
+
     headers
-        .get(constants::HEADER_X_LINKED_SIZE)
-        .or_else(|| headers.get(reqwest::header::CONTENT_LENGTH))
+        .get(reqwest::header::CONTENT_LENGTH)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.parse().ok())
 }
@@ -379,7 +387,48 @@ pub(super) fn matches_any_glob(patterns: &[String], path: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlobSecurityInfo, CommitInfo, FileMetadataInfo, RepoTreeEntry};
+    use super::{BlobSecurityInfo, CommitInfo, FileMetadataInfo, RepoTreeEntry, extract_file_size};
+
+    fn response_with(status: u16, headers: &[(&str, &str)]) -> reqwest::Response {
+        let mut builder = http::Response::builder().status(status);
+        for (k, v) in headers {
+            builder = builder.header(*k, *v);
+        }
+        reqwest::Response::from(builder.body("").unwrap())
+    }
+
+    #[test]
+    fn extract_file_size_prefers_linked_size() {
+        let resp = response_with(200, &[("x-linked-size", "818"), ("content-length", "341")]);
+        assert_eq!(extract_file_size(&resp), Some(818));
+    }
+
+    #[test]
+    fn extract_file_size_uses_content_length_for_non_redirect() {
+        let resp = response_with(200, &[("content-length", "818")]);
+        assert_eq!(extract_file_size(&resp), Some(818));
+    }
+
+    #[test]
+    fn extract_file_size_ignores_content_length_on_redirect() {
+        // A 307 from the `resolve` endpoint carries a `content-length` for the
+        // redirect body, not the target file. Without `x-linked-size` we must
+        // not trust it, otherwise the post-download size check fails.
+        let resp = response_with(307, &[("content-length", "341")]);
+        assert_eq!(extract_file_size(&resp), None);
+    }
+
+    #[test]
+    fn extract_file_size_trusts_linked_size_on_redirect() {
+        let resp = response_with(307, &[("x-linked-size", "818"), ("content-length", "341")]);
+        assert_eq!(extract_file_size(&resp), Some(818));
+    }
+
+    #[test]
+    fn extract_file_size_does_not_fallback_when_linked_size_is_invalid() {
+        let resp = response_with(200, &[("x-linked-size", "invalid"), ("content-length", "341")]);
+        assert_eq!(extract_file_size(&resp), None);
+    }
 
     #[test]
     fn test_repo_tree_entry_deserialize_file() {


### PR DESCRIPTION
## Summary

Prevent redirect response bodies from being mistaken for the size of the file they point to.

`extract_file_size` previously fell back to `Content-Length` whenever `X-Linked-Size` was absent. For a `3xx` response from the Hub resolve endpoint, that value describes the redirect body rather than the target file. The download path could therefore record and propagate a small, incorrect expected size.

This keeps `X-Linked-Size` authoritative on every response, but only uses `Content-Length` for non-redirect responses. A redirect without `X-Linked-Size` now leaves the size unknown instead of propagating an incorrect value into metadata, progress totals, or Xet size hints.

The change is rebased from Mesh-LLM/hf-hub@27573dc6036a273992a4334d9eb371ecd7359e16 and preserves the original author.

## Python implementation

Python's `huggingface_hub` uses the same metadata request strategy proposed in #176:

- send a `HEAD` request with `Accept-Encoding: identity`
- follow relative redirects, such as repository renames
- stop at absolute redirects to external storage or a CDN

Its size extraction currently selects:

```python
response.headers.get("X-Linked-Size") or response.headers.get("Content-Length")
```

That means Python has the same edge case when an absolute redirect does not include `X-Linked-Size`: `Content-Length` is the size of the redirect response, not the target file. Python later requires the size to be present and raises `FileMetadataError` if it is unknown.

Rust already represents the extracted size as `Option<u64>` and tolerates an unknown size in its download paths. This PR intentionally uses that representation rather than accepting a known-wrong value. It is complementary to #176: that PR follows relative redirects to reach their metadata, while this change handles redirects that intentionally remain unfollowed.

## Tests

Added focused unit coverage for:

- preferring `X-Linked-Size` over `Content-Length`
- using `Content-Length` on a normal response
- ignoring `Content-Length` on a redirect
- trusting `X-Linked-Size` on a redirect
- preserving the existing behavior for an invalid `X-Linked-Size`

Validation:

- `cargo test -p hf-hub` — 189 unit tests, 2 integration-style future-size tests, and 22 doctests passed
- `cargo clippy -p hf-hub --all-features -- -D warnings`
- nightly `cargo fmt -- --check`
- `./scripts/verify_wasm.sh`
