### PR TITLE
Remove environment configuration from hf-hub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hf-hub"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64",
  "bon",
@@ -1112,7 +1112,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serial_test",
  "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",

--- a/README.md
+++ b/README.md
@@ -222,27 +222,25 @@ async fn main() -> hf_hub::HFResult<()> {
 }
 ```
 
-## Authentication
+## Authentication and configuration
 
-The client resolves authentication tokens in this order:
+`hf-hub` does not read environment variables. `HFClient::new()` uses the public Hub endpoint
+without authentication and caches files in `.cache/huggingface/hub` relative to the current
+working directory. Configure a token, endpoint, or cache location explicitly with
+`HFClient::builder()`:
 
-1. Explicit token via `HFClientBuilder::token()`
-2. `HF_TOKEN` environment variable
-3. Token file at the path specified by `HF_TOKEN_PATH`
-4. Default token file at `~/.cache/huggingface/token`
+```rust,no_run
+use hf_hub::HFClient;
 
-Set `HF_HUB_DISABLE_IMPLICIT_TOKEN` to any non-empty value to disable automatic token resolution.
+let client = HFClient::builder()
+    .token("hf_xxx")
+    .endpoint("https://huggingface.co")
+    .cache_dir("/tmp/hf-cache")
+    .build()?;
+# Ok::<(), hf_hub::HFError>(())
+```
 
-## Configuration
-
-| Environment Variable            | Description                                            |
-|---------------------------------|--------------------------------------------------------|
-| `HF_ENDPOINT`                   | Hub API endpoint (default: `https://huggingface.co`)   |
-| `HF_TOKEN`                      | Authentication token                                   |
-| `HF_TOKEN_PATH`                 | Path to token file                                     |
-| `HF_HOME`                       | Cache directory root (default: `~/.cache/huggingface`) |
-| `HF_HUB_DISABLE_IMPLICIT_TOKEN` | Disable automatic token loading                        |
-| `HF_HUB_USER_AGENT_ORIGIN`      | Custom User-Agent origin string                        |
+The `hfrs` CLI continues to support its existing environment-based configuration.
 
 ## Error Handling
 

--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hf-hub"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "Rust client for the Hugging Face Hub API"
 license = "Apache-2.0"
@@ -48,5 +48,3 @@ wasm-bindgen-futures = "0.4"
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tempfile = "3"
-serial_test = "3"
-

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
-use tracing::debug;
 use url::Url;
 
 use crate::constants;
@@ -85,7 +84,7 @@ fn is_relative_location(location: &str) -> bool {
 /// ```rust,no_run
 /// use hf_hub::HFClient;
 ///
-/// // Reads token and settings from the environment (HF_TOKEN, HF_ENDPOINT, …).
+/// // Uses the default endpoint with no authentication token.
 /// let client = HFClient::new()?;
 ///
 /// // Or configure explicitly:
@@ -164,14 +163,13 @@ impl HFClientBuilder {
         }
     }
 
-    /// Overrides the Hub base URL (default: `https://huggingface.co`, or `HF_ENDPOINT` env var).
+    /// Overrides the Hub base URL (default: `https://huggingface.co`).
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
 
-    /// Sets the authentication token. Without this, the client falls back to the `HF_TOKEN` env
-    /// var and the cached token file written by `huggingface-cli login`.
+    /// Sets the authentication token. By default, requests are unauthenticated.
     pub fn token(mut self, token: impl Into<String>) -> Self {
         self.token = Some(token.into());
         self
@@ -198,8 +196,8 @@ impl HFClientBuilder {
         self
     }
 
-    /// Sets the local cache directory. Defaults to `HF_HUB_CACHE` → `$HF_HOME/hub` →
-    /// `~/.cache/huggingface/hub`.
+    /// Sets the local cache directory. Defaults to `.cache/huggingface/hub` relative to the
+    /// current working directory.
     pub fn cache_dir(mut self, path: impl Into<std::path::PathBuf>) -> Self {
         self.cache_dir = Some(path.into());
         self
@@ -230,26 +228,21 @@ impl HFClientBuilder {
     /// Returns an error if the endpoint URL is not a valid URL or if the `reqwest` client
     /// cannot be constructed (e.g., an invalid `User-Agent` string was provided).
     pub fn build(self) -> HFResult<HFClient> {
-        let endpoint = self
-            .endpoint
-            .or_else(|| std::env::var(constants::HF_ENDPOINT).ok())
-            .unwrap_or_else(|| constants::DEFAULT_HF_ENDPOINT.to_string());
+        let endpoint = self.endpoint.unwrap_or_else(|| constants::DEFAULT_HF_ENDPOINT.to_string());
 
         let _ = url::Url::parse(&endpoint)?;
 
-        let token = self.token.or_else(resolve_token);
+        let token = self.token;
 
-        let cache_dir = self.cache_dir.unwrap_or_else(constants::resolve_cache_dir);
+        let cache_dir = self
+            .cache_dir
+            .unwrap_or_else(|| std::path::PathBuf::from(".cache/huggingface/hub"));
 
         let mut default_headers = self.headers.unwrap_or_default();
 
-        let user_agent = self.user_agent.unwrap_or_else(|| {
-            let ua_origin = std::env::var(constants::HF_HUB_USER_AGENT_ORIGIN).ok();
-            match ua_origin {
-                Some(origin) => format!("hf-hub/{}; {origin}", env!("CARGO_PKG_VERSION")),
-                None => format!("hf-hub/{}", env!("CARGO_PKG_VERSION")),
-            }
-        });
+        let user_agent = self
+            .user_agent
+            .unwrap_or_else(|| format!("hf-hub/{}", env!("CARGO_PKG_VERSION")));
         default_headers.insert(
             USER_AGENT,
             HeaderValue::from_str(&user_agent)
@@ -313,8 +306,8 @@ impl Default for HFClientBuilder {
 }
 
 impl HFClient {
-    /// Creates a client with default settings, reading the token and endpoint from the
-    /// environment. Equivalent to `HFClient::builder().build()`.
+    /// Creates an unauthenticated client with default settings. Equivalent to
+    /// `HFClient::builder().build()`.
     ///
     /// # Errors
     ///
@@ -344,8 +337,7 @@ impl HFClient {
     /// Hub base URL this client targets, with any trailing slash trimmed.
     ///
     /// Resolved at [`build`](HFClientBuilder::build) time from
-    /// [`HFClientBuilder::endpoint`] → `HF_ENDPOINT` → the default
-    /// (`https://huggingface.co`).
+    /// [`HFClientBuilder::endpoint`] or the default (`https://huggingface.co`).
     pub fn endpoint(&self) -> &str {
         &self.inner.endpoint
     }
@@ -353,9 +345,9 @@ impl HFClient {
     /// Local cache directory used for downloaded files.
     ///
     /// Resolved at [`build`](HFClientBuilder::build) time from
-    /// [`HFClientBuilder::cache_dir`] → `HF_HUB_CACHE` → `$HF_HOME/hub` →
-    /// `~/.cache/huggingface/hub`. Returned even when caching is disabled —
-    /// see [`cache_enabled`](Self::cache_enabled) to check that.
+    /// [`HFClientBuilder::cache_dir`] or `.cache/huggingface/hub` relative to the current
+    /// working directory. Returned even when caching is disabled — see
+    /// [`cache_enabled`](Self::cache_enabled) to check that.
     pub fn cache_dir(&self) -> &std::path::Path {
         &self.inner.cache_dir
     }
@@ -555,50 +547,8 @@ impl HFClient {
     }
 }
 
-/// Resolve token from environment or a token file.
-/// Priority: HF_TOKEN env → HF_TOKEN_PATH file → $HF_HOME/token file.
-fn resolve_token() -> Option<String> {
-    if let Ok(val) = std::env::var(constants::HF_HUB_DISABLE_IMPLICIT_TOKEN)
-        && !val.is_empty()
-    {
-        debug!("implicit token disabled via HF_HUB_DISABLE_IMPLICIT_TOKEN");
-        return None;
-    }
-
-    if let Ok(token) = std::env::var(constants::HF_TOKEN)
-        && !token.is_empty()
-    {
-        debug!("resolved token from HF_TOKEN env var");
-        return Some(token);
-    }
-
-    if let Ok(path) = std::env::var(constants::HF_TOKEN_PATH)
-        && let Ok(token) = std::fs::read_to_string(&path)
-    {
-        let token = token.trim().to_string();
-        if !token.is_empty() {
-            debug!("resolved token from HF_TOKEN_PATH file");
-            return Some(token);
-        }
-    }
-
-    let hf_home = constants::hf_home();
-    let token_path = hf_home.join(constants::TOKEN_FILENAME);
-    if let Ok(token) = std::fs::read_to_string(&token_path) {
-        let token = token.trim().to_string();
-        if !token.is_empty() {
-            debug!("resolved token from stored token file");
-            return Some(token);
-        }
-    }
-
-    debug!("no token found");
-    None
-}
-
 #[cfg(test)]
 mod tests {
-    use serial_test::serial;
     use url::Url;
 
     use super::{HFClientBuilder, append_path_segments, encode_ref, is_relative_location, split_id};
@@ -729,14 +679,10 @@ mod tests {
         assert_eq!(client.cache_dir(), std::path::Path::new("/tmp/my-cache"));
     }
 
-    // `#[serial]` because the precedence tests below mutate `HF_HOME`, and the default
-    // cache dir is derived from it.
     #[test]
-    #[serial]
     fn test_builder_cache_dir_default() {
         let client = HFClientBuilder::new().build().unwrap();
-        let path_str = client.cache_dir().to_string_lossy();
-        assert!(path_str.contains("huggingface") && path_str.ends_with("hub"));
+        assert_eq!(client.cache_dir(), std::path::Path::new(".cache/huggingface/hub"));
     }
 
     #[test]
@@ -848,146 +794,15 @@ mod tests {
         assert!(s2.new_file_download_group().is_ok());
     }
 
-    /// Token resolution precedence tests.
-    ///
-    /// These tests mutate process-wide environment variables, so they must run
-    /// serially. Each test isolates `HF_HOME` to a tempdir so the developer's
-    /// real `~/.cache/huggingface/token` cannot leak into the result.
-    mod token_precedence {
-        use std::io::Write;
+    #[test]
+    fn test_builder_without_token_is_unauthenticated() {
+        let client = HFClientBuilder::new().build().unwrap();
+        assert!(client.inner.token.is_none());
+    }
 
-        use serial_test::serial;
-        use tempfile::TempDir;
-
-        use super::HFClientBuilder;
-        use crate::constants::{HF_HOME, HF_HUB_DISABLE_IMPLICIT_TOKEN, HF_TOKEN, HF_TOKEN_PATH, TOKEN_FILENAME};
-
-        struct EnvGuard {
-            saved: Vec<(&'static str, Option<String>)>,
-            _hf_home: TempDir,
-        }
-
-        impl EnvGuard {
-            fn new() -> Self {
-                let hf_home = tempfile::tempdir().expect("tempdir for HF_HOME");
-                let keys = [HF_TOKEN, HF_TOKEN_PATH, HF_HOME, HF_HUB_DISABLE_IMPLICIT_TOKEN];
-                let saved = keys.iter().map(|k| (*k, std::env::var(*k).ok())).collect();
-                for k in keys {
-                    unsafe { std::env::remove_var(k) };
-                }
-                unsafe { std::env::set_var(HF_HOME, hf_home.path()) };
-                Self {
-                    saved,
-                    _hf_home: hf_home,
-                }
-            }
-        }
-
-        impl Drop for EnvGuard {
-            fn drop(&mut self) {
-                for (k, v) in &self.saved {
-                    match v {
-                        Some(val) => unsafe { std::env::set_var(k, val) },
-                        None => unsafe { std::env::remove_var(k) },
-                    }
-                }
-            }
-        }
-
-        fn write_token_file(dir: &std::path::Path, name: &str, contents: &str) -> std::path::PathBuf {
-            let path = dir.join(name);
-            let mut f = std::fs::File::create(&path).unwrap();
-            f.write_all(contents.as_bytes()).unwrap();
-            path
-        }
-
-        #[test]
-        #[serial]
-        fn test_explicit_token_overrides_env() {
-            let _g = EnvGuard::new();
-            unsafe { std::env::set_var(HF_TOKEN, "env-token") };
-
-            let client = HFClientBuilder::new().token("explicit-token").build().unwrap();
-            assert_eq!(client.inner.token.as_deref(), Some("explicit-token"));
-        }
-
-        #[test]
-        #[serial]
-        fn test_env_token_used_when_no_explicit() {
-            let _g = EnvGuard::new();
-            unsafe { std::env::set_var(HF_TOKEN, "env-token") };
-
-            let client = HFClientBuilder::new().build().unwrap();
-            assert_eq!(client.inner.token.as_deref(), Some("env-token"));
-        }
-
-        #[test]
-        #[serial]
-        fn test_env_token_overrides_token_path_file() {
-            let g = EnvGuard::new();
-            let dir = tempfile::tempdir().unwrap();
-            let token_file = write_token_file(dir.path(), "tok", "file-token");
-            unsafe { std::env::set_var(HF_TOKEN, "env-token") };
-            unsafe { std::env::set_var(HF_TOKEN_PATH, &token_file) };
-
-            let client = HFClientBuilder::new().build().unwrap();
-            assert_eq!(client.inner.token.as_deref(), Some("env-token"));
-            drop(g);
-        }
-
-        #[test]
-        #[serial]
-        fn test_token_path_file_used_when_no_env() {
-            let _g = EnvGuard::new();
-            let dir = tempfile::tempdir().unwrap();
-            let token_file = write_token_file(dir.path(), "tok", "file-token\n");
-            unsafe { std::env::set_var(HF_TOKEN_PATH, &token_file) };
-
-            let client = HFClientBuilder::new().build().unwrap();
-            assert_eq!(client.inner.token.as_deref(), Some("file-token"));
-        }
-
-        #[test]
-        #[serial]
-        fn test_token_from_hf_home_file() {
-            let g = EnvGuard::new();
-            // HF_HOME was set to a tempdir by EnvGuard. Place a token file inside it.
-            let hf_home = std::env::var(HF_HOME).unwrap();
-            write_token_file(std::path::Path::new(&hf_home), TOKEN_FILENAME, "home-token");
-
-            let client = HFClientBuilder::new().build().unwrap();
-            assert_eq!(client.inner.token.as_deref(), Some("home-token"));
-            drop(g);
-        }
-
-        #[test]
-        #[serial]
-        fn test_disable_implicit_token_returns_none() {
-            let _g = EnvGuard::new();
-            unsafe { std::env::set_var(HF_TOKEN, "env-token") };
-            unsafe { std::env::set_var(HF_HUB_DISABLE_IMPLICIT_TOKEN, "1") };
-
-            let client = HFClientBuilder::new().build().unwrap();
-            assert!(client.inner.token.is_none());
-        }
-
-        #[test]
-        #[serial]
-        fn test_disable_implicit_token_does_not_block_explicit() {
-            let _g = EnvGuard::new();
-            unsafe { std::env::set_var(HF_HUB_DISABLE_IMPLICIT_TOKEN, "1") };
-
-            let client = HFClientBuilder::new().token("explicit-token").build().unwrap();
-            assert_eq!(client.inner.token.as_deref(), Some("explicit-token"));
-        }
-
-        #[test]
-        #[serial]
-        fn test_no_token_anywhere_is_none() {
-            let _g = EnvGuard::new();
-            // EnvGuard isolates HF_HOME to a fresh tempdir with no token file inside.
-            let client = HFClientBuilder::new().build().unwrap();
-            assert!(client.inner.token.is_none());
-        }
+    #[test]
+    fn test_explicit_token_is_used() {
+        let client = HFClientBuilder::new().token("explicit-token").build().unwrap();
+        assert_eq!(client.inner.token.as_deref(), Some("explicit-token"));
     }
 }

--- a/hf-hub/src/constants.rs
+++ b/hf-hub/src/constants.rs
@@ -4,53 +4,9 @@ pub(crate) const DEFAULT_HF_ENDPOINT: &str = "https://huggingface.co";
 /// Default revision (branch)
 pub(crate) const DEFAULT_REVISION: &str = "main";
 
-pub(crate) const HF_ENDPOINT: &str = "HF_ENDPOINT";
-pub(crate) const HF_TOKEN: &str = "HF_TOKEN";
-pub(crate) const HF_TOKEN_PATH: &str = "HF_TOKEN_PATH";
-pub(crate) const HF_HOME: &str = "HF_HOME";
-pub(crate) const HF_HUB_CACHE: &str = "HF_HUB_CACHE";
-pub(crate) const HUGGINGFACE_HUB_CACHE: &str = "HUGGINGFACE_HUB_CACHE";
-pub(crate) const XDG_CACHE_HOME: &str = "XDG_CACHE_HOME";
-pub(crate) const HF_HUB_DISABLE_IMPLICIT_TOKEN: &str = "HF_HUB_DISABLE_IMPLICIT_TOKEN";
-pub(crate) const HF_HUB_USER_AGENT_ORIGIN: &str = "HF_HUB_USER_AGENT_ORIGIN";
-
-/// Token filename within HF_HOME
-pub(crate) const TOKEN_FILENAME: &str = "token";
-
 pub(crate) const HEADER_X_XET_HASH: &str = "x-xet-hash";
 
 pub(crate) const CACHE_LOCK_TIMEOUT_SECS: u64 = 10;
 pub(crate) const HEADER_X_REPO_COMMIT: &str = "x-repo-commit";
 pub(crate) const HEADER_X_LINKED_ETAG: &str = "x-linked-etag";
 pub(crate) const HEADER_X_LINKED_SIZE: &str = "x-linked-size";
-
-pub(crate) fn dirs_or_home() -> String {
-    std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string())
-}
-
-/// Resolve the Hugging Face home directory.
-///
-/// Order: `HF_HOME` env var, then `XDG_CACHE_HOME/huggingface`, then `~/.cache/huggingface`.
-pub fn hf_home() -> std::path::PathBuf {
-    if let Ok(path) = std::env::var(HF_HOME) {
-        return std::path::PathBuf::from(path);
-    }
-    if let Ok(xdg) = std::env::var(XDG_CACHE_HOME) {
-        return std::path::PathBuf::from(xdg).join("huggingface");
-    }
-    let home = dirs_or_home();
-    std::path::PathBuf::from(format!("{home}/.cache/huggingface"))
-}
-
-/// Resolve the Hugging Face Hub cache directory.
-///
-/// Order: `HF_HUB_CACHE`, then `HUGGINGFACE_HUB_CACHE`, then `<hf_home>/hub`.
-pub fn resolve_cache_dir() -> std::path::PathBuf {
-    if let Ok(cache) = std::env::var(HF_HUB_CACHE) {
-        return std::path::PathBuf::from(cache);
-    }
-    if let Ok(cache) = std::env::var(HUGGINGFACE_HUB_CACHE) {
-        return std::path::PathBuf::from(cache);
-    }
-    hf_home().join("hub")
-}

--- a/hf-hub/src/lib.rs
+++ b/hf-hub/src/lib.rs
@@ -41,16 +41,9 @@
 //!
 //! ## Creating a client
 //!
-//! [`HFClient::new()`] resolves configuration from the environment:
-//!
-//! | Variable | Purpose |
-//! |---|---|
-//! | `HF_TOKEN` | Authentication token (preferred source) |
-//! | `HF_TOKEN_PATH` | Path to a file containing the token |
-//! | `HF_ENDPOINT` | Override the Hub base URL |
-//! | `HF_HOME` | Root for Hugging Face state (defaults to `~/.cache/huggingface`) |
-//! | `HF_HUB_CACHE` | Cache directory for downloaded files |
-//! | `HF_HUB_DISABLE_IMPLICIT_TOKEN` | Ignore the ambient `HF_TOKEN`/token file |
+//! [`HFClient::new()`] uses the default Hub endpoint without an authentication token. The
+//! library does not read environment variables; configure credentials, endpoints, and cache
+//! locations explicitly with [`HFClient::builder()`].
 //!
 //! For explicit configuration use [`HFClient::builder()`]:
 //!
@@ -235,10 +228,11 @@ pub use blocking::{HFBucketSync, HFClientSync, HFRepositorySync};
 #[doc(inline)]
 pub use buckets::HFBucket;
 pub use client::{HFClient, HFClientBuilder, split_id};
-#[doc(hidden)]
-pub use constants::{hf_home, resolve_cache_dir};
 pub use error::{HFError, HFResult, XetOperation};
 #[doc(inline)]
 pub use repository::{
     HFRepository, RepoType, RepoTypeAny, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace,
 };
+
+/// Version of the `hf-hub` crate.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/hfrs/src/cli.rs
+++ b/hfrs/src/cli.rs
@@ -13,7 +13,7 @@ const STYLES: Styles = Styles::styled()
 #[command(name = "hfrs", about = "Hugging Face Hub CLI (Rust)", version, styles = STYLES)]
 pub struct Cli {
     /// Authentication token (overrides HF_TOKEN env var and stored credentials)
-    #[arg(long, env = "HF_TOKEN", global = true, hide_env_values = true)]
+    #[arg(long, global = true, hide_env_values = true)]
     pub token: Option<String>,
 
     /// API endpoint override

--- a/hfrs/src/commands/env.rs
+++ b/hfrs/src/commands/env.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use clap::Args as ClapArgs;
-use hf_hub::{hf_home, resolve_cache_dir};
 
 use crate::output::CommandResult;
+use crate::util::config::{hf_home, resolve_cache_dir};
 
 #[derive(ClapArgs)]
 #[command(about = "Print information about the environment")]

--- a/hfrs/src/main.rs
+++ b/hfrs/src/main.rs
@@ -29,14 +29,15 @@ async fn main() -> ExitCode {
     };
     init_logging(color, multi.as_ref());
 
-    let mut builder = HFClientBuilder::new();
-    if let Some(t) = cli.token {
-        debug!("using token from --token flag");
-        builder = builder.token(t);
+    let mut builder = HFClientBuilder::new()
+        .endpoint(util::config::resolve_endpoint(cli.endpoint))
+        .cache_dir(util::config::resolve_cache_dir());
+    if let Some(token) = util::config::resolve_token(cli.token) {
+        debug!("using configured authentication token");
+        builder = builder.token(token);
     }
-    if let Some(ref endpoint) = cli.endpoint {
-        debug!(endpoint = endpoint.as_str(), "using custom API endpoint");
-        builder = builder.endpoint(endpoint);
+    if let Some(user_agent) = util::config::resolve_user_agent() {
+        builder = builder.user_agent(user_agent);
     }
     if let Command::Download(ref args) = cli.command
         && let Some(ref cache_dir) = args.cache_dir

--- a/hfrs/src/util/config.rs
+++ b/hfrs/src/util/config.rs
@@ -1,0 +1,66 @@
+use std::fs;
+use std::path::PathBuf;
+
+const DEFAULT_HF_ENDPOINT: &str = "https://huggingface.co";
+
+pub fn hf_home() -> PathBuf {
+    if let Ok(path) = std::env::var("HF_HOME") {
+        return PathBuf::from(path);
+    }
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        return PathBuf::from(xdg).join("huggingface");
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".cache/huggingface")
+}
+
+pub fn resolve_cache_dir() -> PathBuf {
+    if let Ok(cache) = std::env::var("HF_HUB_CACHE") {
+        return PathBuf::from(cache);
+    }
+    if let Ok(cache) = std::env::var("HUGGINGFACE_HUB_CACHE") {
+        return PathBuf::from(cache);
+    }
+    hf_home().join("hub")
+}
+
+pub fn resolve_token(explicit_token: Option<String>) -> Option<String> {
+    if explicit_token.is_some() {
+        return explicit_token;
+    }
+
+    if std::env::var("HF_HUB_DISABLE_IMPLICIT_TOKEN").is_ok_and(|value| !value.is_empty()) {
+        return None;
+    }
+
+    if let Ok(token) = std::env::var("HF_TOKEN")
+        && !token.is_empty()
+    {
+        return Some(token);
+    }
+
+    if let Ok(path) = std::env::var("HF_TOKEN_PATH")
+        && let Some(token) = read_token_file(PathBuf::from(path))
+    {
+        return Some(token);
+    }
+
+    read_token_file(hf_home().join("token"))
+}
+
+pub fn resolve_endpoint(cli_endpoint: Option<String>) -> String {
+    cli_endpoint
+        .or_else(|| std::env::var("HF_ENDPOINT").ok())
+        .unwrap_or_else(|| DEFAULT_HF_ENDPOINT.to_string())
+}
+
+pub fn resolve_user_agent() -> Option<String> {
+    std::env::var("HF_HUB_USER_AGENT_ORIGIN")
+        .ok()
+        .map(|origin| format!("hf-hub/{}; {origin}", hf_hub::VERSION))
+}
+
+fn read_token_file(path: PathBuf) -> Option<String> {
+    let token = fs::read_to_string(path).ok()?.trim().to_string();
+    (!token.is_empty()).then_some(token)
+}

--- a/hfrs/src/util/mod.rs
+++ b/hfrs/src/util/mod.rs
@@ -1,1 +1,2 @@
+pub mod config;
 pub mod token;

--- a/hfrs/src/util/token.rs
+++ b/hfrs/src/util/token.rs
@@ -25,7 +25,7 @@ pub struct TokenEntry {
 }
 
 fn hf_home() -> PathBuf {
-    hf_hub::hf_home()
+    crate::util::config::hf_home()
 }
 
 fn token_file_path() -> PathBuf {

--- a/wasm/smoke/Cargo.lock
+++ b/wasm/smoke/Cargo.lock
@@ -808,7 +808,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-hub"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64",
  "bon",

--- a/wasm/tests/Cargo.lock
+++ b/wasm/tests/Cargo.lock
@@ -814,7 +814,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-hub"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64",
  "bon",


### PR DESCRIPTION
## Summary
- make hf-hub client construction deterministic and explicit, without environment-variable reads
- preserve hfrs environment-based token, endpoint, cache, and User-Agent configuration
- bump hf-hub to 1.1.0 and update documentation and lockfiles

## Testing
- cargo test -p hf-hub --all-features
- cargo clippy -p hf-hub --all-features -- -D warnings
- targeted hfrs CLI environment-regression tests
- wasm32 checks for hf-hub, wasm/smoke, and wasm/tests