### PR TITLE
fix: require tower-http >= 0.6.9 so bracketed-filename redirects are followed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,6 +1119,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-util",
+ "tower-http",
  "tracing",
  "url",
  "wasm-bindgen-futures",
@@ -1477,16 +1478,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -2954,20 +2945,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]

--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -39,6 +39,15 @@ blocking = ["tokio/rt"]
 rustls-tls = ["reqwest/rustls"]
 socks = ["reqwest/socks"]
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+# Not used directly: raises the floor on reqwest's redirect middleware. Before
+# 0.6.9, tower-http resolved `Location` against the request URI with a strict
+# RFC 3986 parser and silently returned the 3xx unfollowed when the request
+# path contained characters the WHATWG `url` crate leaves unencoded but RFC
+# 3986 forbids (`[`, `]`, `^`, `|`), so downloads of such filenames failed
+# with a bare `302 Found`. reqwest itself only requires 0.6.8.
+tower-http = { version = "0.6.9", default-features = false }
+
 [target.'cfg(target_family = "wasm")'.dependencies]
 # `tokio-retry` -> `rand` 0.8 -> `rand_core` 0.6 -> `getrandom` 0.2 transitively
 # needs the `js` feature on wasm32 to compile.
@@ -46,7 +55,7 @@ getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 tempfile = "3"
 serial_test = "3"
 

--- a/hf-hub/src/client.rs
+++ b/hf-hub/src/client.rs
@@ -603,6 +603,40 @@ mod tests {
 
     use super::{HFClientBuilder, append_path_segments, encode_ref, is_relative_location, split_id};
 
+    /// A `resolve` URL built from a bracketed filename must still be redirect-followable.
+    /// reqwest delegates redirect handling to `tower-http`, which before 0.6.9 resolved
+    /// `Location` against the request URI with a strict RFC 3986 parser and silently
+    /// returned the 3xx unfollowed when the request path contained characters the WHATWG
+    /// URL standard leaves unencoded but RFC 3986 forbids (`[`, `]`, `^`, `|`) — the
+    /// caller saw a bare `302 Found` instead of the file. Guards the `tower-http >= 0.6.9`
+    /// floor in Cargo.toml.
+    #[tokio::test]
+    async fn redirect_is_followed_for_a_filename_with_brackets() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let responses = [
+                format!(
+                    "HTTP/1.1 302 Found\r\nLocation: http://{addr}/cdn\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                ),
+                "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\npayload!".to_string(),
+            ];
+            for response in responses {
+                let (mut sock, _) = listener.accept().await.unwrap();
+                let _ = tokio::io::AsyncReadExt::read(&mut sock, &mut [0u8; 2048]).await;
+                let _ = tokio::io::AsyncWriteExt::write_all(&mut sock, response.as_bytes()).await;
+            }
+        });
+
+        let mut url = Url::parse(&format!("http://{addr}/datasets/owner/repo/resolve/main")).unwrap();
+        append_path_segments(&mut url, "[artist] name.png").unwrap();
+
+        let response = reqwest::Client::new().get(url.as_str()).send().await.unwrap();
+        assert_eq!(response.status(), 200, "redirect was not followed, landed on {}", response.url());
+        assert_eq!(response.text().await.unwrap(), "payload!");
+    }
+
     #[test]
     fn append_path_segments_encodes_special_chars() {
         let mut url = Url::parse("https://example.com/base").unwrap();

--- a/wasm/smoke/Cargo.lock
+++ b/wasm/smoke/Cargo.lock
@@ -828,6 +828,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-util",
+ "tower-http",
  "tracing",
  "url",
  "wasm-bindgen-futures",

--- a/wasm/tests/Cargo.lock
+++ b/wasm/tests/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-util",
+ "tower-http",
  "tracing",
  "url",
  "wasm-bindgen-futures",


### PR DESCRIPTION
## Problem

Downloading any file whose path contains `[` or `]` fails with a bare `HTTP error: 302 Found` instead of returning the file.

```
hf-hub error: HTTP error: 302 Found
  (url=https://huggingface.co/datasets/dsixteen/processed/resolve/<rev>/final/suiton00/[suiton00]%20Junpei%20x%20Ruo%20%231/99595347_p1.png,
   request_id=Root=1-6a6dbeee-6f455af9287fdb5e78bd4bf9)
```

Note the literal brackets — that's the bug.

## Cause

`url::Url` implements the WHATWG URL Standard, which leaves `[`, `]`, `^`, and `|` unencoded in paths; RFC 3986 forbids them.

reqwest delegates redirect handling to `tower-http`'s `FollowRedirect`. Before tower-http 0.6.9, it resolved `Location` against the request URI using `iri-string`'s strict RFC 3986 parser:

```rust
fn resolve_uri(relative: &str, base: &Uri) -> Option<Uri> {
    let relative = UriReferenceStr::new(relative).ok()?;
    let base = UriAbsoluteString::try_from(base.to_string()).ok()?;   // <-- fails on raw [ ]
    Uri::try_from(relative.resolve_against(&base).to_string()).ok()
}
```

When that returns `None` the middleware returns the 3xx unfollowed rather than erroring, so `check_response` sees a non-2xx and maps it to `HFError::Http`.

## Fix

tower-http 0.6.9 ([tower-rs/tower-http, May 2026](https://github.com/tower-rs/tower-http)) dropped `iri-string` from `follow_redirect` and resolves `Location` with `url::Url::join` instead — the same WHATWG parser hf-hub builds URLs with, so they agree by construction:

```rust
fn resolve_uri(relative: &str, base: &Uri) -> Option<Uri> {
    let base_url = Url::parse(&base.to_string()).ok()?;
    let resolved = base_url.join(relative).ok()?;
    Uri::try_from(String::from(resolved)).ok()
}
```

reqwest (including latest 0.13.4) still declares `tower-http = "^0.6.8"`, so nothing in the dependency graph forces the fixed version — a consumer with a stale lockfile keeps the bug. This PR adds a direct `tower-http = { version = "0.6.9", default-features = false }` dependency (non-wasm only, where reqwest uses it) purely to raise the floor for downstream lockfiles, and updates our own lockfiles to 0.6.11.

An earlier revision of this PR instead percent-encoded all path components to strict RFC 3986 in `client.rs`. That remains the "fix at the source" option, but the dependency floor resolves the observed failure with no behavior change to URL construction. Known trade-offs accepted here:

- Request URIs still carry raw `[ ] ^ |` on the wire (WHATWG-legal, RFC-illegal). The Hub and its CDN accept them today.
- A `\` in a repo id is still rewritten to `/` by `Url::parse` (latent — Hub naming rules forbid it).

## Tests

`redirect_is_followed_for_a_filename_with_brackets` — end-to-end against a local server that 302s; reproduces the original failure and guards the version floor. Confirmed to fail against tower-http 0.6.8 with this branch's URL-building code, and pass at 0.6.11:

```
tower-http 0.6.8:  redirect was not followed, landed on .../[artist]%20name.png (302)
tower-http 0.6.11: passes
```

```
cargo test -p hf-hub --all-features            218 passed
cargo clippy -p hf-hub --all-features --all-targets -- -D warnings   clean
cargo +nightly fmt --check                     clean
./scripts/verify_wasm.sh                       green
```

## Impact

Found while investigating a production scan-error-rate alert on repository-scanner. Bracketed filenames are common in image and archive datasets that group files into `[artist]`-style directories; one such dataset failed ~230k blob downloads in a single night, pushing that service's scan error rate from a ~2% baseline to 60%.
