### PR TITLE
Add info() on HFRepository<RepoTypeAny> returning runtime-tagged RepoInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serial_test",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",

--- a/examples/repo_type_any.rs
+++ b/examples/repo_type_any.rs
@@ -5,13 +5,15 @@
 //! `HFRepository<RepoTypeAny>` is a sized, concrete type — no `Box`, no `dyn`. Trait
 //! methods dispatch on the enum variant at runtime.
 //!
-//! Kind-specific methods like the per-kind `info()` are not available on
-//! `HFRepository<RepoTypeAny>`; use the typed handles (`client.model(..)` /
-//! `client.dataset(..)` / etc.) when you need a kind-specific response shape.
+//! `info()` on the runtime-tagged handle returns a [`RepoInfo`] enum: its accessor
+//! methods read fields shared across repo kinds without matching, and matching on the
+//! variant (or `as_model()` / `as_space()` / ...) yields the same per-kind struct the
+//! typed handles (`client.model(..)` / `client.dataset(..)` / etc.) return.
 //!
 //! Read-only operations require no auth.
 //! Run: cargo run -p examples --example repo_type_any
 
+use hf_hub::repository::RepoInfo;
 use hf_hub::{HFClient, RepoType, RepoTypeAny};
 
 #[tokio::main]
@@ -35,8 +37,16 @@ async fn main() -> hf_hub::HFResult<()> {
             repo.repo_type().plural()
         );
 
-        let exists = repo.exists().send().await?;
-        println!("  exists: {exists}");
+        let info = repo.info().send().await?;
+        println!("  author={:?} likes={:?} last_modified={:?}", info.author(), info.likes(), info.last_modified());
+
+        match &info {
+            RepoInfo::Model(model) => println!("  pipeline_tag={:?}", model.pipeline_tag),
+            RepoInfo::Dataset(dataset) => println!("  citation set: {}", dataset.citation.is_some()),
+            RepoInfo::Space(space) => println!("  sdk={:?}", space.sdk),
+            RepoInfo::Kernel(kernel) => println!("  trusted_publisher={:?}", kernel.trusted_publisher),
+            _ => {},
+        }
     }
 
     Ok(())

--- a/hf-hub/src/repository/download.rs
+++ b/hf-hub/src/repository/download.rs
@@ -122,7 +122,7 @@ impl<T: RepoType> HFRepository<T> {
         let repo_path = self.repo_path();
         let url = self
             .hf_client
-            .download_url(T::default().url_prefix(), &repo_path, revision, filename)?;
+            .download_url(self.repo_type.url_prefix(), &repo_path, revision, filename)?;
         let headers = self.hf_client.auth_headers();
         let head_response = retry::retry(self.hf_client.retry_config(), || {
             self.hf_client.http_client().head(&url).headers(headers.clone()).send()

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -259,27 +259,171 @@ pub struct EvalResultSource {
     pub org: Option<String>,
 }
 
-/// Parsed YAML metadata from a repo card (`README.md` front matter).
-///
-/// The schema varies by repo kind and by the libraries/tags a repo declares, so this wraps the
-/// raw JSON value rather than modeling every possible field. [`Deref`](std::ops::Deref) to
-/// [`serde_json::Value`] for field lookups (e.g. `card_data.get("license")`).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct CardData(pub serde_json::Value);
-
-impl std::ops::Deref for CardData {
-    type Target = serde_json::Value;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+// Several repo-card YAML fields (`license`, `language`, `datasets`, ...) accept either a single
+// string or a list of strings; normalize both shapes to `Vec<String>`.
+fn deserialize_string_or_vec<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec {
+        One(String),
+        Many(Vec<String>),
     }
+
+    Ok(Option::<StringOrVec>::deserialize(deserializer)?.map(|value| match value {
+        StringOrVec::One(s) => vec![s],
+        StringOrVec::Many(v) => v,
+    }))
 }
 
-impl From<serde_json::Value> for CardData {
-    fn from(value: serde_json::Value) -> Self {
-        Self(value)
-    }
+/// Model Card metadata parsed from a model repo's `README.md` YAML front matter.
+///
+/// Mirrors `huggingface_hub.ModelCardData`. Fields the card declares that aren't modeled above
+/// (e.g. `model-index`, `model_name`, or repo-specific custom keys) are preserved in `extra`.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+pub struct ModelCardData {
+    /// Base model(s) this model derives from (e.g. a fine-tune or adapter).
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub base_model: Option<Vec<String>>,
+    /// Dataset(s) used to train this model.
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub datasets: Option<Vec<String>>,
+    /// Language(s) of the model's training data, as ISO 639 codes or special values like "code".
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub language: Option<Vec<String>>,
+    /// Library used by this model (e.g. `"transformers"`, `"timm"`).
+    #[serde(default)]
+    pub library_name: Option<String>,
+    /// License identifier (e.g. `"apache-2.0"`), or `"other"` when using `license_name`/`license_link`.
+    #[serde(default)]
+    pub license: Option<String>,
+    /// Name of the license, when `license` is `"other"`.
+    #[serde(default)]
+    pub license_name: Option<String>,
+    /// Link to the license, when `license` is `"other"`.
+    #[serde(default)]
+    pub license_link: Option<String>,
+    /// Metric names used to evaluate this model.
+    #[serde(default)]
+    pub metrics: Option<Vec<String>>,
+    /// Pipeline tag associated with the model (e.g. `"text-classification"`).
+    #[serde(default)]
+    pub pipeline_tag: Option<String>,
+    /// Hub tags declared on the card.
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    /// Fields present in the card's YAML front matter that aren't modeled above.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Dataset Card metadata parsed from a dataset repo's `README.md` YAML front matter.
+///
+/// Mirrors `huggingface_hub.DatasetCardData`. Fields the card declares that aren't modeled above
+/// (e.g. `train-eval-index`, `tags`, or repo-specific custom keys) are preserved in `extra`.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+pub struct DatasetCardData {
+    /// Language(s) of the dataset's data or metadata.
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub language: Option<Vec<String>>,
+    /// License(s) of the dataset.
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub license: Option<Vec<String>>,
+    /// How the dataset's annotations were created (e.g. `"crowdsourced"`, `"expert-generated"`).
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub annotations_creators: Option<Vec<String>>,
+    /// How the dataset's text-based data was created.
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub language_creators: Option<Vec<String>>,
+    /// Whether the dataset is monolingual, multilingual, a translation, or other.
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub multilinguality: Option<Vec<String>>,
+    /// Order-of-magnitude bucket for the dataset's example count (e.g. `"1K<n<10K"`).
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub size_categories: Option<Vec<String>>,
+    /// Whether the dataset is original or extended from another dataset.
+    #[serde(default)]
+    pub source_datasets: Option<Vec<String>>,
+    /// Task categories the dataset supports (e.g. `"text-classification"`).
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub task_categories: Option<Vec<String>>,
+    /// Specific tasks the dataset supports.
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub task_ids: Option<Vec<String>>,
+    /// ID of the dataset on PapersWithCode.
+    #[serde(default)]
+    pub paperswithcode_id: Option<String>,
+    /// Human-readable name for the dataset (e.g. `"Cats vs. Dogs"`).
+    #[serde(default)]
+    pub pretty_name: Option<String>,
+    /// Available dataset configs.
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub config_names: Option<Vec<String>>,
+    /// Fields present in the card's YAML front matter that aren't modeled above.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Space Card metadata parsed from a Space repo's `README.md` YAML front matter.
+///
+/// Mirrors `huggingface_hub.SpaceCardData`. Fields the card declares that aren't modeled above
+/// are preserved in `extra`. See <https://huggingface.co/docs/hub/spaces-config-reference>.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+pub struct SpaceCardData {
+    /// Title of the Space.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// SDK powering the Space (`"gradio"`, `"streamlit"`, `"docker"`, or `"static"`).
+    #[serde(default)]
+    pub sdk: Option<String>,
+    /// Version of the SDK in use (Gradio/Streamlit only).
+    #[serde(default)]
+    pub sdk_version: Option<String>,
+    /// Python version used in the Space (Gradio/Streamlit only).
+    #[serde(default)]
+    pub python_version: Option<String>,
+    /// Path to the main application file, relative to the repo root.
+    #[serde(default)]
+    pub app_file: Option<String>,
+    /// Port the application listens on (Docker SDK only).
+    #[serde(default)]
+    pub app_port: Option<u32>,
+    /// License of the Space.
+    #[serde(default)]
+    pub license: Option<String>,
+    /// ID of the original Space, if this one was duplicated.
+    #[serde(default)]
+    pub duplicated_from: Option<String>,
+    /// Models related to this Space.
+    #[serde(default)]
+    pub models: Option<Vec<String>>,
+    /// Datasets related to this Space.
+    #[serde(default)]
+    pub datasets: Option<Vec<String>>,
+    /// Hub tags declared on the card.
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    /// Fields present in the card's YAML front matter that aren't modeled above.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Repo-card metadata for a repo whose kind is only known at runtime, returned by
+/// [`RepoInfo::card_data`].
+///
+/// Wraps the same per-kind card-data structs the typed handles return ([`ModelCardData`],
+/// [`DatasetCardData`], [`SpaceCardData`]), tagged by the runtime repo kind.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum CardData {
+    /// Card metadata for a model repository.
+    Model(ModelCardData),
+    /// Card metadata for a dataset repository.
+    Dataset(DatasetCardData),
+    /// Card metadata for a Space repository.
+    Space(SpaceCardData),
 }
 
 /// Metadata for a model repository on the Hub.
@@ -301,7 +445,7 @@ pub struct ModelInfo {
     #[serde(default)]
     pub base_models: Option<Vec<String>>,
     /// Parsed YAML metadata from the model card (`README.md` front matter).
-    pub card_data: Option<CardData>,
+    pub card_data: Option<ModelCardData>,
     /// Number of children (derived) models.
     pub children_model_count: Option<u64>,
     /// Model configuration (e.g., parsed `config.json` for Transformers models).
@@ -415,7 +559,7 @@ pub struct DatasetInfo {
     /// is set on each entry. See [`RepoSibling`].
     pub siblings: Option<Vec<RepoSibling>>,
     /// Parsed YAML metadata from the dataset card (`README.md` front matter).
-    pub card_data: Option<CardData>,
+    pub card_data: Option<DatasetCardData>,
     /// Citation information for the dataset.
     pub citation: Option<String>,
     /// Papers-with-code identifier, when the dataset is registered there.
@@ -467,7 +611,7 @@ pub struct SpaceInfo {
     /// is set on each entry. See [`RepoSibling`].
     pub siblings: Option<Vec<RepoSibling>>,
     /// Parsed YAML metadata from the Space card (`README.md` front matter).
-    pub card_data: Option<CardData>,
+    pub card_data: Option<SpaceCardData>,
     /// SDK powering the Space (e.g., `"gradio"`, `"streamlit"`, `"docker"`, `"static"`).
     pub sdk: Option<String>,
     /// Trending score used to rank the Space on the Hub's trending lists.
@@ -679,11 +823,11 @@ impl RepoInfo {
 
     /// Parsed repo card (README front matter) data. Always `None` for kernels — the slim
     /// kernel info shape does not include it.
-    pub fn card_data(&self) -> Option<&CardData> {
+    pub fn card_data(&self) -> Option<CardData> {
         match self {
-            Self::Model(info) => info.card_data.as_ref(),
-            Self::Dataset(info) => info.card_data.as_ref(),
-            Self::Space(info) => info.card_data.as_ref(),
+            Self::Model(info) => info.card_data.clone().map(CardData::Model),
+            Self::Dataset(info) => info.card_data.clone().map(CardData::Dataset),
+            Self::Space(info) => info.card_data.clone().map(CardData::Space),
             Self::Kernel(_) => None,
         }
     }
@@ -2076,9 +2220,9 @@ mod tests {
     use futures::StreamExt;
 
     use super::{
-        DatasetInfo, EvalResultEntry, GatedApprovalMode, HFRepository, InferenceProviderMapping, KernelInfo, ModelInfo,
-        RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace, SafeTensorsInfo, SpaceInfo,
-        TransformersInfo, split_repo_id,
+        CardData, DatasetInfo, EvalResultEntry, GatedApprovalMode, HFRepository, InferenceProviderMapping, KernelInfo,
+        ModelCardData, ModelInfo, RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace,
+        SafeTensorsInfo, SpaceInfo, TransformersInfo, split_repo_id,
     };
     use crate::client::HFClient;
 
@@ -2137,7 +2281,13 @@ mod tests {
         assert_eq!(model.tags(), Some(&["tag-a".to_string(), "tag-b".to_string()][..]));
         assert_eq!(model.trending_score(), Some(1.5));
         assert_eq!(model.used_storage(), Some(1024));
-        assert!(model.card_data().is_some());
+        assert_eq!(
+            model.card_data(),
+            Some(CardData::Model(ModelCardData {
+                license: Some("mit".to_string()),
+                ..Default::default()
+            }))
+        );
         assert_eq!(model.siblings().map(<[_]>::len), Some(1));
 
         let space = sample_repo_info(super::RepoTypeAny::Space);
@@ -2332,6 +2482,23 @@ mod tests {
         let json = r#"{"id":"o/m","modelId":"o/m","brandNewField":42}"#;
         let info: ModelInfo = serde_json::from_str(json).unwrap();
         assert_eq!(info.id, "o/m");
+    }
+
+    #[test]
+    fn model_card_data_normalizes_string_or_vec_and_keeps_extra_fields() {
+        let json = serde_json::json!({
+            "license": "mit",
+            "language": "en",
+            "datasets": ["squad", "glue"],
+            "tags": ["nlp"],
+            "custom_field": "keep me",
+        });
+        let card: ModelCardData = serde_json::from_value(json).unwrap();
+        assert_eq!(card.license.as_deref(), Some("mit"));
+        assert_eq!(card.language, Some(vec!["en".to_string()]));
+        assert_eq!(card.datasets, Some(vec!["squad".to_string(), "glue".to_string()]));
+        assert_eq!(card.tags, Some(vec!["nlp".to_string()]));
+        assert_eq!(card.extra.get("custom_field"), Some(&serde_json::json!("keep me")));
     }
 
     /// Real `/api/kernels/{repo_id}` response shape (slim — no `tags`,

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -27,7 +27,7 @@ pub mod listing;
 pub mod repo_type;
 pub mod upload;
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 
 use bon::bon;
@@ -316,7 +316,7 @@ pub struct ModelCardData {
     pub tags: Option<Vec<String>>,
     /// Fields present in the card's YAML front matter that aren't modeled above.
     #[serde(flatten)]
-    pub extra: serde_json::Map<String, serde_json::Value>,
+    pub extra: BTreeMap<String, serde_json::Value>,
 }
 
 /// Dataset Card metadata parsed from a dataset repo's `README.md` YAML front matter.
@@ -363,7 +363,7 @@ pub struct DatasetCardData {
     pub config_names: Option<Vec<String>>,
     /// Fields present in the card's YAML front matter that aren't modeled above.
     #[serde(flatten)]
-    pub extra: serde_json::Map<String, serde_json::Value>,
+    pub extra: BTreeMap<String, serde_json::Value>,
 }
 
 /// Space Card metadata parsed from a Space repo's `README.md` YAML front matter.
@@ -407,7 +407,7 @@ pub struct SpaceCardData {
     pub tags: Option<Vec<String>>,
     /// Fields present in the card's YAML front matter that aren't modeled above.
     #[serde(flatten)]
-    pub extra: serde_json::Map<String, serde_json::Value>,
+    pub extra: BTreeMap<String, serde_json::Value>,
 }
 
 /// Repo-card metadata for a repo whose kind is only known at runtime, returned by

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -53,7 +53,8 @@ use crate::{constants, retry};
 ///
 /// Controls whether users must request access and how requests are approved.
 /// Serializes as `false` when [`GatedApprovalMode::Disabled`], or as the lowercase mode string otherwise.
-#[derive(Debug, Clone)]
+/// Deserializes from the same shapes (the Hub's `gated` field is a JSON boolean or string union).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GatedApprovalMode {
     /// Access is open; no request is required.
     Disabled,
@@ -258,6 +259,29 @@ pub struct EvalResultSource {
     pub org: Option<String>,
 }
 
+/// Parsed YAML metadata from a repo card (`README.md` front matter).
+///
+/// The schema varies by repo kind and by the libraries/tags a repo declares, so this wraps the
+/// raw JSON value rather than modeling every possible field. [`Deref`](std::ops::Deref) to
+/// [`serde_json::Value`] for field lookups (e.g. `card_data.get("license")`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CardData(pub serde_json::Value);
+
+impl std::ops::Deref for CardData {
+    type Target = serde_json::Value;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<serde_json::Value> for CardData {
+    fn from(value: serde_json::Value) -> Self {
+        Self(value)
+    }
+}
+
 /// Metadata for a model repository on the Hub.
 ///
 /// Returned by [`HFClient::list_models`] and by
@@ -276,9 +300,8 @@ pub struct ModelInfo {
     /// Base models this model is derived from.
     #[serde(default)]
     pub base_models: Option<Vec<String>>,
-    /// Parsed YAML metadata from the model card (`README.md` front matter). Modeled as raw JSON
-    /// because the schema varies by library.
-    pub card_data: Option<serde_json::Value>,
+    /// Parsed YAML metadata from the model card (`README.md` front matter).
+    pub card_data: Option<CardData>,
     /// Number of children (derived) models.
     pub children_model_count: Option<u64>,
     /// Model configuration (e.g., parsed `config.json` for Transformers models).
@@ -295,9 +318,8 @@ pub struct ModelInfo {
     /// Evaluation results parsed from the model's `.eval_results/*.yaml` files.
     #[serde(default, rename = "evalResults")]
     pub eval_results: Option<Vec<EvalResultEntry>>,
-    /// Gated-access state. Either the boolean `false` (open) or the string `"auto"`/`"manual"` indicating
-    /// the approval mode for access requests. Modeled as raw JSON because the field is union-typed.
-    pub gated: Option<serde_json::Value>,
+    /// Gated-access state.
+    pub gated: Option<GatedApprovalMode>,
     /// GGUF-specific metadata, when the repo contains GGUF files.
     pub gguf: Option<serde_json::Value>,
     /// Inference-providers status. Currently, `Some("warm")` when the model is served by at least
@@ -372,9 +394,8 @@ pub struct DatasetInfo {
     pub sha: Option<String>,
     /// Whether the repo is private.
     pub private: Option<bool>,
-    /// Gated-access state. Either the boolean `false` (open) or the string `"auto"`/`"manual"` indicating
-    /// the approval mode for access requests. Modeled as raw JSON because the field is union-typed.
-    pub gated: Option<serde_json::Value>,
+    /// Gated-access state.
+    pub gated: Option<GatedApprovalMode>,
     /// Whether the repo is disabled.
     pub disabled: Option<bool>,
     /// Number of downloads over the last 30 days.
@@ -394,7 +415,7 @@ pub struct DatasetInfo {
     /// is set on each entry. See [`RepoSibling`].
     pub siblings: Option<Vec<RepoSibling>>,
     /// Parsed YAML metadata from the dataset card (`README.md` front matter).
-    pub card_data: Option<serde_json::Value>,
+    pub card_data: Option<CardData>,
     /// Citation information for the dataset.
     pub citation: Option<String>,
     /// Papers-with-code identifier, when the dataset is registered there.
@@ -429,9 +450,8 @@ pub struct SpaceInfo {
     pub sha: Option<String>,
     /// Whether the repo is private.
     pub private: Option<bool>,
-    /// Gated-access state. Either the boolean `false` (open) or the string `"auto"`/`"manual"` indicating
-    /// the approval mode for access requests. Modeled as raw JSON because the field is union-typed.
-    pub gated: Option<serde_json::Value>,
+    /// Gated-access state.
+    pub gated: Option<GatedApprovalMode>,
     /// Whether the Space is disabled.
     pub disabled: Option<bool>,
     /// Number of likes on the Space.
@@ -447,7 +467,7 @@ pub struct SpaceInfo {
     /// is set on each entry. See [`RepoSibling`].
     pub siblings: Option<Vec<RepoSibling>>,
     /// Parsed YAML metadata from the Space card (`README.md` front matter).
-    pub card_data: Option<serde_json::Value>,
+    pub card_data: Option<CardData>,
     /// SDK powering the Space (e.g., `"gradio"`, `"streamlit"`, `"docker"`, `"static"`).
     pub sdk: Option<String>,
     /// Trending score used to rank the Space on the Hub's trending lists.
@@ -496,9 +516,8 @@ pub struct KernelInfo {
     pub sha: Option<String>,
     /// Whether the repo is private.
     pub private: Option<bool>,
-    /// Gated-access state. Either the boolean `false` (open) or the string `"auto"`/`"manual"` indicating
-    /// the approval mode for access requests. Modeled as raw JSON because the field is union-typed.
-    pub gated: Option<serde_json::Value>,
+    /// Gated-access state.
+    pub gated: Option<GatedApprovalMode>,
     /// Total downloads of this kernel.
     pub downloads: Option<u64>,
     /// Number of likes on the kernel.
@@ -595,9 +614,8 @@ impl RepoInfo {
         }
     }
 
-    /// Gated-access state. Either the boolean `false` (open) or the string `"auto"`/`"manual"`
-    /// indicating the approval mode for access requests. Raw JSON because the field is union-typed.
-    pub fn gated(&self) -> Option<&serde_json::Value> {
+    /// Gated-access state.
+    pub fn gated(&self) -> Option<&GatedApprovalMode> {
         match self {
             Self::Model(info) => info.gated.as_ref(),
             Self::Dataset(info) => info.gated.as_ref(),
@@ -661,7 +679,7 @@ impl RepoInfo {
 
     /// Parsed repo card (README front matter) data. Always `None` for kernels — the slim
     /// kernel info shape does not include it.
-    pub fn card_data(&self) -> Option<&serde_json::Value> {
+    pub fn card_data(&self) -> Option<&CardData> {
         match self {
             Self::Model(info) => info.card_data.as_ref(),
             Self::Dataset(info) => info.card_data.as_ref(),
@@ -840,6 +858,43 @@ impl FromStr for GatedApprovalMode {
                 "unknown gated approval mode: {s:?}. Expected 'auto', 'manual', or 'false'"
             ))),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for GatedApprovalMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct GatedApprovalModeVisitor;
+
+        impl serde::de::Visitor<'_> for GatedApprovalModeVisitor {
+            type Value = GatedApprovalMode;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("`false` or one of the strings \"auto\", \"manual\"")
+            }
+
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if v {
+                    Err(E::invalid_value(serde::de::Unexpected::Bool(v), &self))
+                } else {
+                    Ok(GatedApprovalMode::Disabled)
+                }
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                v.parse().map_err(|_| E::invalid_value(serde::de::Unexpected::Str(v), &self))
+            }
+        }
+
+        deserializer.deserialize_any(GatedApprovalModeVisitor)
     }
 }
 
@@ -2021,9 +2076,9 @@ mod tests {
     use futures::StreamExt;
 
     use super::{
-        DatasetInfo, EvalResultEntry, HFRepository, InferenceProviderMapping, KernelInfo, ModelInfo, RepoType,
-        RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace, SafeTensorsInfo, SpaceInfo, TransformersInfo,
-        split_repo_id,
+        DatasetInfo, EvalResultEntry, GatedApprovalMode, HFRepository, InferenceProviderMapping, KernelInfo, ModelInfo,
+        RepoType, RepoTypeDataset, RepoTypeKernel, RepoTypeModel, RepoTypeSpace, SafeTensorsInfo, SpaceInfo,
+        TransformersInfo, split_repo_id,
     };
     use crate::client::HFClient;
 
@@ -2068,7 +2123,7 @@ mod tests {
             assert_eq!(info.author(), Some("acme"));
             assert_eq!(info.sha(), Some("abc123"));
             assert_eq!(info.private(), Some(false));
-            assert_eq!(info.gated(), Some(&serde_json::json!("manual")));
+            assert_eq!(info.gated(), Some(&GatedApprovalMode::Manual));
             assert_eq!(info.likes(), Some(7));
             assert_eq!(info.last_modified(), Some("2026-01-02T03:04:05.000Z"));
         }
@@ -2308,8 +2363,7 @@ mod tests {
         assert_eq!(info.likes, Some(6));
         assert_eq!(info.trusted_publisher, Some(false));
         assert_eq!(info.supported_driver_families.as_deref(), Some(&["cuda".into(), "xpu".into(), "cpu".into()][..]));
-        // `gated: false` is kept as JSON (consistent with ModelInfo/SpaceInfo).
-        assert_eq!(info.gated.as_ref().and_then(|v| v.as_bool()), Some(false));
+        assert_eq!(info.gated, Some(GatedApprovalMode::Disabled));
     }
 
     /// `supportedDriverFamilies` is absent on some kernels — must remain optional.

--- a/hf-hub/src/repository/mod.rs
+++ b/hf-hub/src/repository/mod.rs
@@ -513,6 +513,261 @@ pub struct KernelInfo {
     pub supported_driver_families: Option<Vec<String>>,
 }
 
+/// Repository metadata for a repo whose kind is only known at runtime, returned by
+/// [`HFRepository::<RepoTypeAny>::info`](HFRepository::info).
+///
+/// Wraps the same per-kind info structs the typed handles return ([`ModelInfo`],
+/// [`DatasetInfo`], [`SpaceInfo`], [`KernelInfo`]), tagged by the runtime repo kind.
+/// Match on the variant (or use the `as_*`/`into_*` converters) for kind-specific
+/// fields; the accessor methods read data shared across kinds without a match.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum RepoInfo {
+    /// Metadata for a model repository. Boxed because [`ModelInfo`] is much larger than the
+    /// other variants; field access auto-derefs, so `match` ergonomics are unaffected.
+    Model(Box<ModelInfo>),
+    /// Metadata for a dataset repository.
+    Dataset(DatasetInfo),
+    /// Metadata for a Space repository.
+    Space(SpaceInfo),
+    /// Metadata for a kernel repository.
+    Kernel(KernelInfo),
+}
+
+impl RepoInfo {
+    /// The repo kind this metadata describes, as a runtime-tagged [`RepoTypeAny`].
+    pub fn repo_type(&self) -> RepoTypeAny {
+        match self {
+            Self::Model(_) => RepoTypeAny::Model,
+            Self::Dataset(_) => RepoTypeAny::Dataset,
+            Self::Space(_) => RepoTypeAny::Space,
+            Self::Kernel(_) => RepoTypeAny::Kernel,
+        }
+    }
+
+    /// Repo ID, in the form `owner/name`.
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Model(info) => &info.id,
+            Self::Dataset(info) => &info.id,
+            Self::Space(info) => &info.id,
+            Self::Kernel(info) => &info.id,
+        }
+    }
+
+    /// Internal Hub identifier (the API's `_id` field). Most callers should use [`id`](Self::id) instead.
+    pub fn internal_id(&self) -> Option<&str> {
+        match self {
+            Self::Model(info) => info.internal_id.as_deref(),
+            Self::Dataset(info) => info.internal_id.as_deref(),
+            Self::Space(info) => info.internal_id.as_deref(),
+            Self::Kernel(info) => info.internal_id.as_deref(),
+        }
+    }
+
+    /// Owner of the repo (the part before `/` in `id`).
+    pub fn author(&self) -> Option<&str> {
+        match self {
+            Self::Model(info) => info.author.as_deref(),
+            Self::Dataset(info) => info.author.as_deref(),
+            Self::Space(info) => info.author.as_deref(),
+            Self::Kernel(info) => info.author.as_deref(),
+        }
+    }
+
+    /// Git commit SHA at the revision the response describes.
+    pub fn sha(&self) -> Option<&str> {
+        match self {
+            Self::Model(info) => info.sha.as_deref(),
+            Self::Dataset(info) => info.sha.as_deref(),
+            Self::Space(info) => info.sha.as_deref(),
+            Self::Kernel(info) => info.sha.as_deref(),
+        }
+    }
+
+    /// Whether the repo is private.
+    pub fn private(&self) -> Option<bool> {
+        match self {
+            Self::Model(info) => info.private,
+            Self::Dataset(info) => info.private,
+            Self::Space(info) => info.private,
+            Self::Kernel(info) => info.private,
+        }
+    }
+
+    /// Gated-access state. Either the boolean `false` (open) or the string `"auto"`/`"manual"`
+    /// indicating the approval mode for access requests. Raw JSON because the field is union-typed.
+    pub fn gated(&self) -> Option<&serde_json::Value> {
+        match self {
+            Self::Model(info) => info.gated.as_ref(),
+            Self::Dataset(info) => info.gated.as_ref(),
+            Self::Space(info) => info.gated.as_ref(),
+            Self::Kernel(info) => info.gated.as_ref(),
+        }
+    }
+
+    /// Number of likes on the repo.
+    pub fn likes(&self) -> Option<u64> {
+        match self {
+            Self::Model(info) => info.likes,
+            Self::Dataset(info) => info.likes,
+            Self::Space(info) => info.likes,
+            Self::Kernel(info) => info.likes,
+        }
+    }
+
+    /// ISO-8601 timestamp of the most recent commit to the repo.
+    pub fn last_modified(&self) -> Option<&str> {
+        match self {
+            Self::Model(info) => info.last_modified.as_deref(),
+            Self::Dataset(info) => info.last_modified.as_deref(),
+            Self::Space(info) => info.last_modified.as_deref(),
+            Self::Kernel(info) => info.last_modified.as_deref(),
+        }
+    }
+
+    /// Download count over the trailing window. Always `None` for Spaces — the Hub does not
+    /// report downloads for them.
+    pub fn downloads(&self) -> Option<u64> {
+        match self {
+            Self::Model(info) => info.downloads,
+            Self::Dataset(info) => info.downloads,
+            Self::Space(_) => None,
+            Self::Kernel(info) => info.downloads,
+        }
+    }
+
+    /// ISO-8601 timestamp of repo creation. Always `None` for kernels — the slim kernel info
+    /// shape does not include it.
+    pub fn created_at(&self) -> Option<&str> {
+        match self {
+            Self::Model(info) => info.created_at.as_deref(),
+            Self::Dataset(info) => info.created_at.as_deref(),
+            Self::Space(info) => info.created_at.as_deref(),
+            Self::Kernel(_) => None,
+        }
+    }
+
+    /// Tags attached to the repo. Always `None` for kernels — the slim kernel info shape
+    /// does not include them.
+    pub fn tags(&self) -> Option<&[String]> {
+        match self {
+            Self::Model(info) => info.tags.as_deref(),
+            Self::Dataset(info) => info.tags.as_deref(),
+            Self::Space(info) => info.tags.as_deref(),
+            Self::Kernel(_) => None,
+        }
+    }
+
+    /// Parsed repo card (README front matter) data. Always `None` for kernels — the slim
+    /// kernel info shape does not include it.
+    pub fn card_data(&self) -> Option<&serde_json::Value> {
+        match self {
+            Self::Model(info) => info.card_data.as_ref(),
+            Self::Dataset(info) => info.card_data.as_ref(),
+            Self::Space(info) => info.card_data.as_ref(),
+            Self::Kernel(_) => None,
+        }
+    }
+
+    /// Flat file listing of the repo. Always `None` for kernels — the slim kernel info shape
+    /// does not include it.
+    pub fn siblings(&self) -> Option<&[RepoSibling]> {
+        match self {
+            Self::Model(info) => info.siblings.as_deref(),
+            Self::Dataset(info) => info.siblings.as_deref(),
+            Self::Space(info) => info.siblings.as_deref(),
+            Self::Kernel(_) => None,
+        }
+    }
+
+    /// Trending score of the repo. Always `None` for kernels — the slim kernel info shape
+    /// does not include it.
+    pub fn trending_score(&self) -> Option<f64> {
+        match self {
+            Self::Model(info) => info.trending_score,
+            Self::Dataset(info) => info.trending_score,
+            Self::Space(info) => info.trending_score,
+            Self::Kernel(_) => None,
+        }
+    }
+
+    /// Storage used by the repo, in bytes. Always `None` for kernels — the slim kernel info
+    /// shape does not include it.
+    pub fn used_storage(&self) -> Option<u64> {
+        match self {
+            Self::Model(info) => info.used_storage,
+            Self::Dataset(info) => info.used_storage,
+            Self::Space(info) => info.used_storage,
+            Self::Kernel(_) => None,
+        }
+    }
+
+    /// Borrow the inner [`ModelInfo`], or `None` if this is not a model repo.
+    pub fn as_model(&self) -> Option<&ModelInfo> {
+        match self {
+            Self::Model(info) => Some(info),
+            _ => None,
+        }
+    }
+
+    /// Borrow the inner [`DatasetInfo`], or `None` if this is not a dataset repo.
+    pub fn as_dataset(&self) -> Option<&DatasetInfo> {
+        match self {
+            Self::Dataset(info) => Some(info),
+            _ => None,
+        }
+    }
+
+    /// Borrow the inner [`SpaceInfo`], or `None` if this is not a Space repo.
+    pub fn as_space(&self) -> Option<&SpaceInfo> {
+        match self {
+            Self::Space(info) => Some(info),
+            _ => None,
+        }
+    }
+
+    /// Borrow the inner [`KernelInfo`], or `None` if this is not a kernel repo.
+    pub fn as_kernel(&self) -> Option<&KernelInfo> {
+        match self {
+            Self::Kernel(info) => Some(info),
+            _ => None,
+        }
+    }
+
+    /// Consume the value and return the inner [`ModelInfo`], or `None` if this is not a model repo.
+    pub fn into_model(self) -> Option<ModelInfo> {
+        match self {
+            Self::Model(info) => Some(*info),
+            _ => None,
+        }
+    }
+
+    /// Consume the value and return the inner [`DatasetInfo`], or `None` if this is not a dataset repo.
+    pub fn into_dataset(self) -> Option<DatasetInfo> {
+        match self {
+            Self::Dataset(info) => Some(info),
+            _ => None,
+        }
+    }
+
+    /// Consume the value and return the inner [`SpaceInfo`], or `None` if this is not a Space repo.
+    pub fn into_space(self) -> Option<SpaceInfo> {
+        match self {
+            Self::Space(info) => Some(info),
+            _ => None,
+        }
+    }
+
+    /// Consume the value and return the inner [`KernelInfo`], or `None` if this is not a kernel repo.
+    pub fn into_kernel(self) -> Option<KernelInfo> {
+        match self {
+            Self::Kernel(info) => Some(info),
+            _ => None,
+        }
+    }
+}
+
 /// URL of a repository, returned by create/move endpoints.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RepoUrl {
@@ -1413,6 +1668,43 @@ impl HFRepository<RepoTypeKernel> {
     }
 }
 
+#[bon]
+impl HFRepository<RepoTypeAny> {
+    /// Fetch repo metadata, dispatching on the runtime repo kind and returning a
+    /// runtime-tagged [`RepoInfo`].
+    ///
+    /// Use the accessor methods on [`RepoInfo`] to read data shared across repo kinds
+    /// without matching, or match on the variant for the full kind-specific struct.
+    /// For kernel repos the Hub returns the same slim shape as
+    /// [`HFRepository::<RepoTypeKernel>::info`](HFRepository::info) and silently ignores
+    /// `expand`.
+    #[doc = info_method_doc!()]
+    #[builder(
+        finish_fn = send,
+        builder_type = HFAnyRepoInfoBuilder,
+        state_mod(name = hf_any_repo_info_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub async fn info(
+        &self,
+        /// Git revision (branch, tag, or commit SHA). Defaults to the main branch.
+        #[builder(into)]
+        revision: Option<String>,
+        /// List of properties to expand in the response (e.g., `"trendingScore"`, `"cardData"`).
+        expand: Option<Vec<String>>,
+    ) -> HFResult<RepoInfo> {
+        match self.repo_type {
+            RepoTypeAny::Model => self
+                .fetch_repo_info(revision, expand)
+                .await
+                .map(|model_info| RepoInfo::Model(Box::new(model_info))),
+            RepoTypeAny::Dataset => self.fetch_repo_info(revision, expand).await.map(RepoInfo::Dataset),
+            RepoTypeAny::Space => self.fetch_repo_info(revision, expand).await.map(RepoInfo::Space),
+            RepoTypeAny::Kernel => self.fetch_repo_info(revision, expand).await.map(RepoInfo::Kernel),
+        }
+    }
+}
+
 /// Split "namespace/name" into (Some("namespace"), "name") or (None, "name")
 fn split_repo_id(repo_id: &str) -> (Option<&str>, &str) {
     match repo_id.split_once('/') {
@@ -1708,6 +2000,22 @@ impl crate::blocking::HFRepositorySync<RepoTypeKernel> {
     }
 }
 
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
+#[bon]
+impl crate::blocking::HFRepositorySync<RepoTypeAny> {
+    /// Blocking counterpart of [`HFRepository::<RepoTypeAny>::info`].
+    #[builder(
+        finish_fn = send,
+        builder_type = HFAnyRepoInfoSyncBuilder,
+        state_mod(name = hf_any_repo_info_sync_builder, vis = "pub(crate)"),
+        derive(Debug, Clone),
+    )]
+    pub fn info(&self, #[builder(into)] revision: Option<String>, expand: Option<Vec<String>>) -> HFResult<RepoInfo> {
+        self.runtime
+            .block_on(self.inner.info().maybe_revision(revision).maybe_expand(expand).send())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use futures::StreamExt;
@@ -1718,6 +2026,102 @@ mod tests {
         split_repo_id,
     };
     use crate::client::HFClient;
+
+    fn sample_repo_info(kind: super::RepoTypeAny) -> super::RepoInfo {
+        let body = serde_json::json!({
+            "id": "acme/thing",
+            "_id": "internal-123",
+            "author": "acme",
+            "sha": "abc123",
+            "private": false,
+            "gated": "manual",
+            "likes": 7,
+            "downloads": 42,
+            "lastModified": "2026-01-02T03:04:05.000Z",
+            "createdAt": "2025-01-02T03:04:05.000Z",
+            "tags": ["tag-a", "tag-b"],
+            "trendingScore": 1.5,
+            "usedStorage": 1024,
+            "siblings": [{"rfilename": "README.md"}],
+            "cardData": {"license": "mit"},
+        });
+        match kind {
+            super::RepoTypeAny::Model => super::RepoInfo::Model(Box::new(serde_json::from_value(body).unwrap())),
+            super::RepoTypeAny::Dataset => super::RepoInfo::Dataset(serde_json::from_value(body).unwrap()),
+            super::RepoTypeAny::Space => super::RepoInfo::Space(serde_json::from_value(body).unwrap()),
+            super::RepoTypeAny::Kernel => super::RepoInfo::Kernel(serde_json::from_value(body).unwrap()),
+        }
+    }
+
+    #[test]
+    fn repo_info_common_accessors_no_match_needed() {
+        for kind in [
+            super::RepoTypeAny::Model,
+            super::RepoTypeAny::Dataset,
+            super::RepoTypeAny::Space,
+            super::RepoTypeAny::Kernel,
+        ] {
+            let info = sample_repo_info(kind);
+            assert_eq!(info.repo_type(), kind);
+            assert_eq!(info.id(), "acme/thing");
+            assert_eq!(info.internal_id(), Some("internal-123"));
+            assert_eq!(info.author(), Some("acme"));
+            assert_eq!(info.sha(), Some("abc123"));
+            assert_eq!(info.private(), Some(false));
+            assert_eq!(info.gated(), Some(&serde_json::json!("manual")));
+            assert_eq!(info.likes(), Some(7));
+            assert_eq!(info.last_modified(), Some("2026-01-02T03:04:05.000Z"));
+        }
+    }
+
+    #[test]
+    fn repo_info_union_accessors_respect_kind_gaps() {
+        let model = sample_repo_info(super::RepoTypeAny::Model);
+        assert_eq!(model.downloads(), Some(42));
+        assert_eq!(model.created_at(), Some("2025-01-02T03:04:05.000Z"));
+        assert_eq!(model.tags(), Some(&["tag-a".to_string(), "tag-b".to_string()][..]));
+        assert_eq!(model.trending_score(), Some(1.5));
+        assert_eq!(model.used_storage(), Some(1024));
+        assert!(model.card_data().is_some());
+        assert_eq!(model.siblings().map(<[_]>::len), Some(1));
+
+        let space = sample_repo_info(super::RepoTypeAny::Space);
+        assert_eq!(space.downloads(), None);
+        assert_eq!(space.created_at(), Some("2025-01-02T03:04:05.000Z"));
+
+        let kernel = sample_repo_info(super::RepoTypeAny::Kernel);
+        assert_eq!(kernel.downloads(), Some(42));
+        assert_eq!(kernel.created_at(), None);
+        assert_eq!(kernel.tags(), None);
+        assert_eq!(kernel.card_data(), None);
+        assert!(kernel.siblings().is_none());
+        assert_eq!(kernel.trending_score(), None);
+        assert_eq!(kernel.used_storage(), None);
+    }
+
+    #[test]
+    fn repo_info_narrowing_conversions() {
+        let info = sample_repo_info(super::RepoTypeAny::Dataset);
+        assert!(info.as_dataset().is_some());
+        assert!(info.as_model().is_none());
+        assert!(info.as_space().is_none());
+        assert!(info.as_kernel().is_none());
+        assert!(info.clone().into_model().is_none());
+        let dataset = info.into_dataset().unwrap();
+        assert_eq!(dataset.id, "acme/thing");
+
+        let space = sample_repo_info(super::RepoTypeAny::Space);
+        assert!(space.as_space().is_some());
+        assert!(space.into_space().is_some());
+
+        let model = sample_repo_info(super::RepoTypeAny::Model);
+        assert!(model.as_model().is_some());
+        assert!(model.into_model().is_some());
+
+        let kernel = sample_repo_info(super::RepoTypeAny::Kernel);
+        assert!(kernel.as_kernel().is_some());
+        assert!(kernel.into_kernel().is_some());
+    }
 
     #[test]
     fn test_repo_path_and_accessors() {

--- a/hf-hub/src/repository/repo_type.rs
+++ b/hf-hub/src/repository/repo_type.rs
@@ -141,11 +141,13 @@ pub struct RepoTypeKernel;
 /// All the standard file, commit, and repo-management APIs are available on
 /// `HFRepository<RepoTypeAny>` — uploads/downloads, tree listings, commit history and diffs,
 /// branches, tags, settings, and existence checks all work identically to a typed handle and
-/// hit the right Hub endpoint for the runtime variant. The kind-specific
-/// [`HFRepository::<RepoTypeModel>::info`](super::HFRepository::info) (and its per-kind
-/// siblings) and the Space-only runtime helpers (`runtime`, `pause`, `restart`, secrets,
-/// variables, hardware, duplicate) are *not* available — they live on the per-kind typed
-/// handles.
+/// hit the right Hub endpoint for the runtime variant.
+/// [`HFRepository::<RepoTypeAny>::info`](super::HFRepository::info) dispatches on the runtime
+/// variant and returns a runtime-tagged [`RepoInfo`](super::RepoInfo) — its accessor methods
+/// read fields shared across kinds without matching, and matching on the variant yields the
+/// same per-kind struct the typed handles return. The Space-only runtime helpers (`runtime`,
+/// `pause`, `restart`, secrets, variables, hardware, duplicate) are *not* available — they
+/// live on `HFRepository<RepoTypeSpace>`.
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum RepoTypeAny {
     #[default]

--- a/integration-tests/tests/blocking_test.rs
+++ b/integration-tests/tests/blocking_test.rs
@@ -105,6 +105,19 @@ fn test_sync_dataset_info() {
 }
 
 #[test]
+fn test_sync_repo_type_any_info() {
+    let Some(client) = prod_sync_api() else { return };
+    let kind: RepoTypeAny = "model".parse().unwrap();
+    let (owner, name) = split_id(TEST_MODEL_REPO);
+    let handle = client.repository(kind, owner, name);
+
+    let info = handle.info().send().unwrap();
+    assert_eq!(info.repo_type(), RepoTypeAny::Model);
+    assert_eq!(info.id(), TEST_MODEL_REPO);
+    assert!(info.as_model().is_some());
+}
+
+#[test]
 fn test_sync_repo_handle_info_and_file_exists() {
     let Some(client) = prod_sync_api() else { return };
     let model_repo = TEST_MODEL_REPO;

--- a/integration-tests/tests/integration_test.rs
+++ b/integration-tests/tests/integration_test.rs
@@ -141,6 +141,29 @@ async fn test_dataset_info() {
 }
 
 #[tokio::test]
+async fn test_repo_type_any_info() {
+    let Some(client) = prod_api() else { return };
+
+    for (kind_str, repo_id) in [("model", TEST_MODEL_REPO), ("dataset", TEST_DATASET_REPO)] {
+        let kind: RepoTypeAny = kind_str.parse().unwrap();
+        let (owner, name) = split_id(repo_id);
+        let handle = client.repository(kind, owner, name);
+
+        let info = handle.info().send().await.unwrap();
+        assert_eq!(info.repo_type(), kind);
+        assert_eq!(info.id(), repo_id);
+        assert!(info.sha().is_some());
+        assert!(info.last_modified().is_some());
+
+        match kind {
+            RepoTypeAny::Model => assert!(info.as_model().is_some()),
+            RepoTypeAny::Dataset => assert!(info.as_dataset().is_some()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[tokio::test]
 async fn test_repo_exists() {
     let Some(client) = prod_api() else { return };
     assert!(repo(&client, TEST_MODEL_REPO).exists().send().await.unwrap());


### PR DESCRIPTION
## Summary

Adds `info()` to the runtime-tagged repo handle `HFRepository<RepoTypeAny>`, so callers whose repo kind is only known at runtime (CLI flag, config, upstream enum) can fetch repo metadata without matching over repo kinds.

The method returns a new `RepoInfo` enum wrapping the existing per-kind structs (`ModelInfo`, `DatasetInfo`, `SpaceInfo`, `KernelInfo`):

- **Common accessors** read fields shared by all kinds without a match: `id()`, `author()`, `sha()`, `private()`, `gated()`, `likes()`, `last_modified()`, `internal_id()`, `repo_type()`.
- **Union accessors** cover fields most kinds have, returning `None` where a kind lacks them (documented per method): `downloads()` (Spaces), `created_at()`, `tags()`, `card_data()`, `siblings()`, `trending_score()`, `used_storage()` (kernels).
- **Narrowing** via `as_*()` / `into_*()` or a plain `match` yields the exact same per-kind struct the typed handles return — no field duplication.

The dispatch match lives once inside the library; `fetch_repo_info` already builds the correct URL from the runtime variant, so only the deserialization target differs per kind.

## Changes

- `RepoInfo` enum + accessors in `repository/mod.rs`. `#[non_exhaustive]`; the `Model` variant is boxed (clippy `large_enum_variant`: `ModelInfo` ~896B vs 648B next-largest), following the `HFError`/`HttpErrorContext` precedent. Field access auto-derefs so match ergonomics are unaffected.
- `HFRepository<RepoTypeAny>::info()` bon builder (`HFAnyRepoInfoBuilder`), mirroring the four per-kind `info` impls, plus the mandatory blocking counterpart `HFRepositorySync<RepoTypeAny>::info()` (`HFAnyRepoInfoSyncBuilder`).
- `RepoTypeAny` rustdoc updated — it previously stated `info` was not available on the any-handle.
- `examples/repo_type_any.rs` extended to demonstrate `info()`, common accessors, and variant matching.
- `Cargo.lock`: one-line sync (stale `serial_test` entry from an earlier manifest change); regenerated by any build.

## Testing

- 3 unit tests: common accessors across all four kinds, union-accessor kind gaps, narrowing conversions.
- 2 read-only integration tests (`test_repo_type_any_info`, `test_sync_repo_type_any_info`), run live against the Hub and passing.
- `cargo test -p hf-hub --all-features` (215 passed), `cargo clippy -p hf-hub --all-features -- -D warnings` clean, `cargo +nightly fmt`, `./scripts/verify_wasm.sh` green, examples build.