### PR TITLE
hfrs: add crates.io publish metadata

### DIFF
--- a/hfrs/Cargo.toml
+++ b/hfrs/Cargo.toml
@@ -4,9 +4,11 @@ version = "1.0.0"
 edition = "2024"
 description = "Command-line interface for the Hugging Face Hub"
 license = "Apache-2.0"
+repository = "https://github.com/huggingface/hf-hub"
+homepage = "https://github.com/huggingface/hf-hub"
 
 [dependencies]
-hf-hub = { path = "../hf-hub" }
+hf-hub = { path = "../hf-hub", version = "1.1" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 clap = { version = "4", features = ["derive", "env", "color"] }
 indicatif = "0.18"


### PR DESCRIPTION
## Summary
First step toward `cargo install hfrs`: fixes what currently breaks `cargo publish -p hfrs`.

- Pins the `hf-hub` path dependency to `version = "1.1"` (path deps need a version requirement to publish).
- Adds `repository`/`homepage` to `hfrs/Cargo.toml`.

## Remaining before `cargo install hfrs` actually works
- `hf-hub` must be published at 1.1.0 on crates.io first (currently only 1.0.0 is live) — needs an existing owner (`danieldk`/`McPatate`/`Hugoch`) to add publish rights if not already granted.
- Then `cargo publish -p hfrs --registry crates-io` (repo's cargo config replaces crates-io with an internal mirror, so `--registry crates-io` must be passed explicitly).

Verified `cargo publish -p hfrs --dry-run --registry crates-io` fails only on hf-hub 1.1 not existing on crates.io yet, as expected.