### PR TITLE
Make the TLS backend selectable: native-tls and rustls-tls features

### DIFF
--- a/hf-hub/Cargo.toml
+++ b/hf-hub/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
 bytes = "1"
-reqwest = { version = "0.13", features = ["json", "stream", "multipart", "query"] }
+reqwest = { version = "0.13", features = ["json", "stream", "multipart", "query"], default-features = false }
 hyper = "1"
 tokio = { version = "1", features = ["io-util"] }
 tokio-retry = "0.3"
@@ -32,13 +32,14 @@ pathdiff = "0.2"
 percent-encoding = "2"
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"
-hf-xet = "1.6"
+hf-xet = { version = "1.6", default-features = false }
 sha2 = "0.11"
 
 [features]
-default = []
+default = ["rustls-tls"]
 blocking = ["tokio/rt"]
-rustls-tls = ["reqwest/rustls"]
+native-tls = ["reqwest/native-tls", "hf-xet/native-tls"]
+rustls-tls = ["reqwest/rustls", "hf-xet/rustls-tls"]
 socks = ["reqwest/socks"]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]


### PR DESCRIPTION
reqwest and hf-xet are pulled with their default features, so rustls is always compiled in, and because reqwest 0.13 defaults `TlsBackend` to rustls whenever that feature is present, it is always what goes on the wire, including from hf-xet's own clients. Injecting a `use_native_tls()` client through `HFClientBuilder::client` only covers the API calls; xet transfers still use rustls. A consumer that has to run on a FIPS-enforcing host, where the validated module is the system OpenSSL, has no way to opt out today.

This turns both dependencies' defaults off and adds `native-tls` / `rustls-tls` features that fan out to reqwest and hf-xet together. `rustls-tls` stays the default, so nothing changes for existing users; `default-features = false, features = ["native-tls"]` gives an OpenSSL-only build.

Verified downstream (vllm-vcr): with this change `cargo tree` for the native-tls build resolves no `rustls`, `ring`, or `aws-lc-rs`, and downloads of xet-backed files (e.g. `Qwen/Qwen3-0.6B/tokenizer.json`) succeed through native-tls.