### PR TITLE
Add HFRepository::delete_cached_revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",

--- a/hf-hub/src/cache/delete.rs
+++ b/hf-hub/src/cache/delete.rs
@@ -462,7 +462,14 @@ mod tests {
         let plan_result = plan(dir.path(), "models--o--n", "aaa").unwrap();
         let outcome = apply(plan_result).unwrap();
 
+        // On Unix the pointer is a symlink with no bytes of its own, so only the blob is
+        // counted. On Windows it is a plain copy, so its bytes are counted when the snapshot
+        // goes and the blob's bytes are counted again when the emptied repo folder goes —
+        // both really are on disk, so both really are freed.
+        #[cfg(unix)]
         assert_eq!(outcome.freed, 7);
+        #[cfg(not(unix))]
+        assert_eq!(outcome.freed, 14);
         assert!(outcome.repo_removed);
         assert!(!repo.exists());
     }

--- a/hf-hub/src/cache/delete.rs
+++ b/hf-hub/src/cache/delete.rs
@@ -1,0 +1,570 @@
+//! Deletion of a single cached revision.
+//!
+//! Split into a planning pass that touches nothing and an apply pass that runs with every
+//! doomed blob's lock held. The caller acquires those locks between the two.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use super::storage;
+use crate::error::{HFError, HFResult};
+
+/// Everything needed to delete one cached revision, computed by [`plan`] before any blob
+/// lock is held and consumed by [`apply`] once they are.
+#[derive(Debug)]
+pub(crate) struct DeletePlan {
+    pub(crate) repo: PathBuf,
+    pub(crate) snapshots_dir: PathBuf,
+    pub(crate) snap: PathBuf,
+    pub(crate) commit: String,
+    /// Cache folder name for the repo, e.g. `models--o--n`.
+    pub(crate) folder: String,
+    pub(crate) locks_dir: PathBuf,
+    pub(crate) doomed: HashMap<PathBuf, u64>,
+    pub(crate) snap_canon: Option<PathBuf>,
+    pub(crate) blobs_dir_canon: Option<PathBuf>,
+    /// Blob file names (etags) under `blobs/` that looked like candidates for removal at
+    /// planning time — i.e. doomed blobs not referenced by any other revision then. Locks
+    /// must be acquired for every one of these, sorted, before [`apply`] runs. [`apply`]
+    /// rechecks references itself once those locks are held, since this snapshot of `keep`
+    /// can go stale between planning and locking.
+    pub(crate) candidate_etags: Vec<String>,
+}
+
+/// Result of [`apply`]: bytes freed, and whether the repo folder was removed because no
+/// revisions were left. When it was, the caller still owes a removal of the plan's
+/// `locks_dir`, which is safe only once every lock guard has been dropped.
+#[derive(Debug)]
+pub(crate) struct ApplyOutcome {
+    pub(crate) freed: u64,
+    pub(crate) repo_removed: bool,
+}
+
+/// Rejects an empty string, anything starting with `.`, and anything outside
+/// `[A-Za-z0-9._-]`. A commit of `"."` would otherwise resolve back to the snapshots
+/// directory itself and delete every revision in the repo; a leading `.` also rejects
+/// `".."`, and the character allow-list rejects any path separator.
+fn valid_commit(commit: &str) -> bool {
+    !commit.is_empty()
+        && !commit.starts_with('.')
+        && commit
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+fn is_dir_no_follow(entry: &std::fs::DirEntry) -> bool {
+    entry.file_type().is_ok_and(|ft| ft.is_dir())
+}
+
+/// Recursively maps every file under `dir` to the canonicalized path it resolves to and
+/// that path's size. On Unix, files under a `snapshots/<commit>` directory are symlinks
+/// that resolve to `blobs/<etag>`; on Windows they are plain copies, so canonicalization
+/// resolves to the file itself.
+///
+/// Recursion only follows real directories (`DirEntry::file_type`, which does not follow
+/// symlinks) so a directory symlink planted under `dir` can't walk this function outside
+/// the cache.
+fn collect_targets(dir: &Path) -> HashMap<PathBuf, u64> {
+    let mut out = HashMap::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if is_dir_no_follow(&entry) {
+                stack.push(entry.path());
+                continue;
+            }
+            let path = entry.path();
+            if let Ok(canonical) = std::fs::canonicalize(&path) {
+                let size = std::fs::metadata(&canonical).map(|m| m.len()).unwrap_or(0);
+                out.insert(canonical, size);
+            }
+        }
+    }
+    out
+}
+
+/// Removes every ref file (recursively, since PR refs nest under `refs/pr/<n>`) whose
+/// trimmed content names `commit`. Recursion follows only real directories, and only real
+/// files (never symlinks) are read and removed, so a symlink planted under `refs_dir`
+/// can't be used to read or delete something outside the cache.
+fn remove_matching_refs(refs_dir: &Path, commit: &str) {
+    let mut stack = vec![refs_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if is_dir_no_follow(&entry) {
+                stack.push(entry.path());
+                continue;
+            }
+            let Ok(ft) = entry.file_type() else {
+                continue;
+            };
+            if !ft.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if std::fs::read_to_string(&path).is_ok_and(|c| c.trim() == commit) {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+    }
+}
+
+/// Sum of file sizes under `dir`. Recursion follows only real directories.
+fn dir_size(dir: &Path) -> u64 {
+    let mut total = 0;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if is_dir_no_follow(&entry) {
+                stack.push(entry.path());
+                continue;
+            }
+            if let Ok(meta) = std::fs::metadata(entry.path()) {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+/// Removes `dir` and returns the number of bytes it held, or `0` if it doesn't exist.
+fn remove_dir_and_size(dir: &Path) -> u64 {
+    if !dir.is_dir() {
+        return 0;
+    }
+    let size = dir_size(dir);
+    let _ = std::fs::remove_dir_all(dir);
+    size
+}
+
+/// Paths under `snapshots_dir` (other than `snap` itself) that are still referenced,
+/// mapped to their size. Used both by [`plan`] (to pick an initial set of candidate blobs
+/// to lock) and, recomputed, by [`apply`] (to make the final call on what's actually still
+/// referenced once the locks are held).
+fn collect_keep(snapshots_dir: &Path, snap: &Path) -> HashMap<PathBuf, u64> {
+    let mut keep = HashMap::new();
+    if let Ok(entries) = std::fs::read_dir(snapshots_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path == snap || !is_dir_no_follow(&entry) {
+                continue;
+            }
+            keep.extend(collect_targets(&path));
+        }
+    }
+    keep
+}
+
+/// Plan the deletion of `commit` from the repo cached at `<cache_dir>/<repo_folder>`.
+///
+/// Touches no state. Returns [`crate::error::HFError::LocalEntryNotFound`] when the revision
+/// is not cached, and [`crate::error::HFError::InvalidParameter`] when `commit` is malformed
+/// or the snapshot is not a real directory under `snapshots/`.
+pub(crate) fn plan(cache_dir: &Path, repo_folder: &str, commit: &str) -> HFResult<DeletePlan> {
+    if !valid_commit(commit) {
+        return Err(HFError::InvalidParameter(format!("invalid commit: {commit:?}")));
+    }
+
+    let repo = cache_dir.join(repo_folder);
+    let snapshots_dir = repo.join("snapshots");
+    let snap = snapshots_dir.join(commit);
+
+    if !snap.is_dir() {
+        return Err(HFError::LocalEntryNotFound {
+            path: snap.display().to_string(),
+        });
+    }
+    // Defense in depth beyond `valid_commit`: a commit of "." normalizes `snap` back to
+    // `snapshots_dir` itself, and a symlinked "snapshot" could point anywhere: both would
+    // otherwise cause `remove_dir_all` in `apply` to destroy the wrong directory.
+    if snap.parent() != Some(snapshots_dir.as_path()) {
+        return Err(HFError::InvalidParameter(format!("invalid commit: {commit:?}")));
+    }
+    if !std::fs::symlink_metadata(&snap)?.file_type().is_dir() {
+        return Err(HFError::InvalidParameter(format!("invalid commit: {commit:?}")));
+    }
+
+    let keep = collect_keep(&snapshots_dir, &snap);
+    let doomed = collect_targets(&snap);
+    // Captured now, before `remove_dir_all` in `apply` deletes `snap`, so it stays
+    // resolvable for the Windows-copy case handled there.
+    let snap_canon = std::fs::canonicalize(&snap).ok();
+    let blobs_dir_canon = std::fs::canonicalize(repo.join("blobs")).ok();
+
+    let mut candidate_etags: Vec<String> = Vec::new();
+    for path in doomed.keys() {
+        if keep.contains_key(path) {
+            continue;
+        }
+        if blobs_dir_canon.as_ref().is_some_and(|b| path.starts_with(b))
+            && let Some(etag) = path.file_name()
+        {
+            candidate_etags.push(etag.to_string_lossy().into_owned());
+        }
+    }
+
+    Ok(DeletePlan {
+        repo,
+        snapshots_dir,
+        snap,
+        commit: commit.to_string(),
+        folder: repo_folder.to_string(),
+        locks_dir: locks_dir(cache_dir, repo_folder),
+        doomed,
+        snap_canon,
+        blobs_dir_canon,
+        candidate_etags,
+    })
+}
+
+/// Execute a plan.
+///
+/// Every etag in [`DeletePlan::candidate_etags`] must be locked by the caller before this
+/// runs, and those locks must stay held until it returns.
+pub(crate) fn apply(plan: DeletePlan) -> HFResult<ApplyOutcome> {
+    let DeletePlan {
+        repo,
+        snapshots_dir,
+        snap,
+        commit,
+        folder: _,
+        locks_dir: _,
+        doomed,
+        snap_canon,
+        blobs_dir_canon,
+        candidate_etags: _,
+    } = plan;
+
+    std::fs::remove_dir_all(&snap)?;
+    remove_matching_refs(&repo.join("refs"), &commit);
+
+    // Recompute `keep` now, with every doomed blob's lock held, instead of trusting the
+    // set `plan` computed earlier. A concurrent download's content-addressed dedup fast
+    // path can link a new snapshot pointer onto an existing blob without ever taking that
+    // blob's lock (the content is already on disk, so there's nothing for it to write) —
+    // so the set computed before locking can go stale by the time we get here. Rechecking
+    // this late, under lock, closes nearly all of that race window.
+    let keep = collect_keep(&snapshots_dir, &snap);
+
+    let mut freed: u64 = 0;
+    for (path, size) in doomed {
+        if keep.contains_key(&path) {
+            continue;
+        }
+        if blobs_dir_canon.as_ref().is_some_and(|b| path.starts_with(b)) {
+            // Unix: pointer files are symlinks, so `path` is the real blob under
+            // `blobs/`. Only count it as freed if we actually removed it. Its hf-hub
+            // blob lock is held by the caller for the duration of this call.
+            if std::fs::remove_file(&path).is_ok() {
+                freed += size;
+            }
+        } else if snap_canon.as_ref().is_some_and(|s| path.starts_with(s)) {
+            // Windows: pointer files are plain copies, not symlinks, so canonicalizing a
+            // snapshot file returns the snapshot file itself. It was already removed
+            // above by `remove_dir_all`, and — matching the Python reference
+            // implementation — the blob under `blobs/` is left alone and only
+            // reclaimed once every revision referencing it is gone, since a plain copy
+            // carries no on-disk link back to it.
+            freed += size;
+        }
+        // Anything else canonicalized somewhere outside both `blobs/` and this snapshot
+        // (e.g. a symlink escaping the cache) is left untouched and not counted as freed.
+    }
+
+    freed += remove_dir_and_size(&repo.join(".no_exist").join(&commit));
+
+    let snapshots_empty = std::fs::read_dir(&snapshots_dir)
+        .map(|mut it| it.next().is_none())
+        .unwrap_or(true);
+    let mut repo_removed = false;
+    if snapshots_empty {
+        freed += remove_dir_and_size(&repo);
+        repo_removed = true;
+    }
+
+    Ok(ApplyOutcome { freed, repo_removed })
+}
+
+/// Directory holding this repo's blob locks, for post-apply cleanup. Derived from
+/// [`storage::lock_path`] rather than rebuilt independently, so a future layout change has
+/// one home; the etag passed in is irrelevant since only the parent is kept.
+pub(crate) fn locks_dir(cache_dir: &Path, repo_folder: &str) -> PathBuf {
+    storage::lock_path(cache_dir, repo_folder, "")
+        .parent()
+        .expect("lock_path always nests the lock file under a directory")
+        .to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_symlinked_repo(cache_dir: &Path) -> PathBuf {
+        let repo = cache_dir.join("models--o--n");
+        let blobs = repo.join("blobs");
+        std::fs::create_dir_all(&blobs).unwrap();
+        std::fs::write(blobs.join("shared"), b"12345").unwrap();
+        std::fs::write(blobs.join("only_a"), b"1234567").unwrap();
+
+        let snap_a = repo.join("snapshots").join("aaa");
+        std::fs::create_dir_all(&snap_a).unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("../../blobs/shared", snap_a.join("s.txt")).unwrap();
+            std::os::unix::fs::symlink("../../blobs/only_a", snap_a.join("a.txt")).unwrap();
+        }
+
+        let snap_b = repo.join("snapshots").join("bbb");
+        std::fs::create_dir_all(&snap_b).unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("../../blobs/shared", snap_b.join("s.txt")).unwrap();
+        }
+
+        std::fs::create_dir_all(repo.join("refs")).unwrap();
+        std::fs::write(repo.join("refs").join("main"), "aaa").unwrap();
+
+        repo
+    }
+
+    #[test]
+    fn plan_rejects_empty_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = plan(dir.path(), "models--o--n", "").unwrap_err();
+        assert!(matches!(err, HFError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn plan_rejects_dot_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("models--o--n");
+        std::fs::create_dir_all(repo.join("snapshots").join("aaa")).unwrap();
+
+        let err = plan(dir.path(), "models--o--n", ".").unwrap_err();
+
+        assert!(matches!(err, HFError::InvalidParameter(_)));
+        assert!(repo.join("snapshots").join("aaa").is_dir());
+    }
+
+    #[test]
+    fn plan_rejects_dotdot_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = plan(dir.path(), "models--o--n", "..").unwrap_err();
+        assert!(matches!(err, HFError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn plan_rejects_path_separator_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = plan(dir.path(), "models--o--n", "../x").unwrap_err();
+        assert!(matches!(err, HFError::InvalidParameter(_)));
+    }
+
+    #[test]
+    fn plan_returns_local_entry_not_found_for_missing_revision() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = plan(dir.path(), "models--o--n", "nope").unwrap_err();
+        assert!(matches!(err, HFError::LocalEntryNotFound { .. }));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn plan_rejects_symlinked_snapshot_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("models--o--n");
+        let snapshots = repo.join("snapshots");
+        std::fs::create_dir_all(&snapshots).unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), snapshots.join("aaa")).unwrap();
+
+        let err = plan(dir.path(), "models--o--n", "aaa").unwrap_err();
+
+        assert!(matches!(err, HFError::InvalidParameter(_)));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn delete_frees_unreferenced_blob_but_keeps_shared_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = write_symlinked_repo(dir.path());
+
+        let plan_result = plan(dir.path(), "models--o--n", "aaa").unwrap();
+        assert_eq!(plan_result.candidate_etags, vec!["only_a".to_string()]);
+        let outcome = apply(plan_result).unwrap();
+
+        assert_eq!(outcome.freed, 7);
+        assert!(!outcome.repo_removed);
+        assert!(!repo.join("snapshots").join("aaa").exists());
+        assert!(repo.join("snapshots").join("bbb").is_dir());
+        assert!(repo.join("blobs").join("shared").exists(), "blob referenced by bbb must survive");
+        assert!(!repo.join("blobs").join("only_a").exists(), "unreferenced blob must be freed");
+    }
+
+    #[test]
+    fn delete_removes_matching_refs_including_nested_pr_refs() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("models--o--n");
+        std::fs::create_dir_all(repo.join("snapshots").join("aaa")).unwrap();
+        std::fs::create_dir_all(repo.join("snapshots").join("bbb")).unwrap();
+        std::fs::create_dir_all(repo.join("refs").join("pr")).unwrap();
+        std::fs::write(repo.join("refs").join("main"), "bbb").unwrap();
+        std::fs::write(repo.join("refs").join("pr").join("3"), "aaa").unwrap();
+
+        let plan_result = plan(dir.path(), "models--o--n", "aaa").unwrap();
+        apply(plan_result).unwrap();
+
+        assert!(!repo.join("refs").join("pr").join("3").exists());
+        assert!(repo.join("refs").join("main").exists());
+        assert!(repo.join("snapshots").join("bbb").is_dir());
+    }
+
+    #[test]
+    fn delete_removes_no_exist_dir_without_removing_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("models--o--n");
+        std::fs::create_dir_all(repo.join("snapshots").join("aaa")).unwrap();
+        std::fs::create_dir_all(repo.join("snapshots").join("bbb")).unwrap();
+        let no_exist_dir = repo.join(".no_exist").join("aaa");
+        std::fs::create_dir_all(&no_exist_dir).unwrap();
+        std::fs::write(no_exist_dir.join("missing.json"), b"").unwrap();
+
+        let plan_result = plan(dir.path(), "models--o--n", "aaa").unwrap();
+        let outcome = apply(plan_result).unwrap();
+
+        assert!(!no_exist_dir.exists());
+        assert!(!outcome.repo_removed);
+        assert!(repo.join("snapshots").join("bbb").is_dir());
+    }
+
+    #[test]
+    fn deleting_last_revision_removes_repo_folder_and_reports_repo_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("models--o--n");
+        let blobs = repo.join("blobs");
+        std::fs::create_dir_all(&blobs).unwrap();
+        std::fs::write(blobs.join("only"), b"1234567").unwrap();
+        let snap = repo.join("snapshots").join("aaa");
+        std::fs::create_dir_all(&snap).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("../../blobs/only", snap.join("a.txt")).unwrap();
+        #[cfg(not(unix))]
+        std::fs::write(snap.join("a.txt"), b"1234567").unwrap();
+
+        let plan_result = plan(dir.path(), "models--o--n", "aaa").unwrap();
+        let outcome = apply(plan_result).unwrap();
+
+        assert_eq!(outcome.freed, 7);
+        assert!(outcome.repo_removed);
+        assert!(!repo.exists());
+    }
+
+    #[test]
+    fn windows_shaped_copies_free_snapshot_bytes_and_spare_shared_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("models--o--n");
+        let blobs = repo.join("blobs");
+        std::fs::create_dir_all(&blobs).unwrap();
+        std::fs::write(blobs.join("etag1"), b"123456789").unwrap();
+
+        let snap_a = repo.join("snapshots").join("aaa");
+        std::fs::create_dir_all(&snap_a).unwrap();
+        std::fs::write(snap_a.join("cfg.txt"), b"123456789").unwrap();
+
+        let snap_b = repo.join("snapshots").join("bbb");
+        std::fs::create_dir_all(&snap_b).unwrap();
+        std::fs::write(snap_b.join("cfg.txt"), b"123456789").unwrap();
+
+        let plan_result = plan(dir.path(), "models--o--n", "aaa").unwrap();
+        let outcome = apply(plan_result).unwrap();
+
+        assert_eq!(outcome.freed, 9);
+        assert!(!repo.join("snapshots").join("aaa").exists());
+        assert!(repo.join("snapshots").join("bbb").is_dir());
+        assert!(
+            blobs.join("etag1").exists(),
+            "blob should survive until the last revision referencing it is removed"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn apply_rechecks_keep_set_and_spares_blob_that_gained_a_new_reference() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = write_symlinked_repo(dir.path());
+
+        let plan_result = plan(dir.path(), "models--o--n", "aaa").unwrap();
+        assert_eq!(plan_result.candidate_etags, vec!["only_a".to_string()]);
+
+        // Simulate a concurrent download's dedup fast path: it links a brand new
+        // snapshot onto the blob we're about to delete without ever taking that blob's
+        // lock (there's nothing for it to write, the content already exists), between
+        // planning and locking.
+        let snap_c = repo.join("snapshots").join("ccc");
+        std::fs::create_dir_all(&snap_c).unwrap();
+        std::os::unix::fs::symlink("../../blobs/only_a", snap_c.join("c.txt")).unwrap();
+
+        let outcome = apply(plan_result).unwrap();
+
+        assert_eq!(outcome.freed, 0);
+        assert!(!outcome.repo_removed);
+        assert!(
+            repo.join("blobs").join("only_a").exists(),
+            "blob gained a new reference after planning and must survive"
+        );
+        assert!(!repo.join("snapshots").join("aaa").exists());
+        assert!(repo.join("snapshots").join("bbb").is_dir());
+        assert!(repo.join("snapshots").join("ccc").is_dir());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn refs_directory_symlink_is_not_followed() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = write_symlinked_repo(dir.path());
+
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), b"do not touch").unwrap();
+        std::os::unix::fs::symlink(outside.path(), repo.join("refs").join("evil")).unwrap();
+
+        let plan_result = plan(dir.path(), "models--o--n", "aaa").unwrap();
+        apply(plan_result).unwrap();
+
+        assert!(outside.path().join("secret.txt").exists());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn escaping_symlink_target_survives_and_is_not_counted() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = write_symlinked_repo(dir.path());
+
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = outside.path().join("escaped.bin");
+        std::fs::write(&outside_file, b"0123456789").unwrap();
+        std::os::unix::fs::symlink(&outside_file, repo.join("snapshots").join("aaa").join("e.bin")).unwrap();
+
+        let plan_result = plan(dir.path(), "models--o--n", "aaa").unwrap();
+        let outcome = apply(plan_result).unwrap();
+
+        assert_eq!(outcome.freed, 7);
+        assert!(outside_file.exists());
+    }
+
+    #[test]
+    fn locks_dir_reuses_storage_lock_path_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            locks_dir(dir.path(), "models--o--n"),
+            storage::lock_path(dir.path(), "models--o--n", "etag").parent().unwrap()
+        );
+    }
+}

--- a/hf-hub/src/cache/mod.rs
+++ b/hf-hub/src/cache/mod.rs
@@ -12,14 +12,16 @@
 //! while revision-level sizes are not — see [`CachedRepoInfo::size_on_disk`]
 //! and [`CachedRevisionInfo::size_on_disk`].
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use bon::bon;
 
 use crate::client::HFClient;
-use crate::error::HFResult;
+use crate::error::{HFError, HFResult};
+use crate::repository::{HFRepository, RepoType};
 
+pub(crate) mod delete;
 pub(crate) mod storage;
 
 /// A single file in a cached revision.
@@ -109,6 +111,17 @@ pub struct HFCacheInfo {
     pub warnings: Vec<String>,
 }
 
+/// Outcome of deleting one cached revision, returned by [`HFRepository::delete_cached_revision`].
+#[derive(Debug, Clone)]
+pub struct DeletedRevision {
+    /// Bytes reclaimed on disk: blobs that became unreferenced by removing this revision,
+    /// plus the revision's `.no_exist` entries and, if this was the last cached revision, the
+    /// repo's cache folder and blob-lock directory.
+    pub freed_size: u64,
+    /// Whether the repo's cache folder was removed because no revisions remained.
+    pub repo_removed: bool,
+}
+
 #[bon]
 impl HFClient {
     /// Scan the configured cache directory and return a summary of all cached repositories,
@@ -130,5 +143,200 @@ impl crate::blocking::HFClientSync {
     #[builder(finish_fn = send, derive(Debug, Clone))]
     pub fn scan_cache(&self) -> HFResult<HFCacheInfo> {
         self.runtime.block_on(self.inner.scan_cache().send())
+    }
+}
+
+#[bon]
+impl<T: RepoType> HFRepository<T> {
+    /// Delete one cached revision of this repository from the local cache.
+    ///
+    /// Removes the revision's snapshot directory and its `.no_exist` entries, then frees any
+    /// blob under `blobs/` that no other cached revision of this repo still references. If this
+    /// was the last cached revision, the repo's whole cache folder (including its blob-lock
+    /// directory) is removed too, and [`DeletedRevision::repo_removed`] is `true`.
+    ///
+    /// Returns [`HFError::CacheNotEnabled`] if the client has no local cache, or
+    /// [`HFError::LocalEntryNotFound`] if `revision` is not cached.
+    #[builder(finish_fn = send, derive(Debug, Clone))]
+    pub async fn delete_cached_revision(&self, #[builder(into)] revision: String) -> HFResult<DeletedRevision> {
+        if !self.hf_client.cache_enabled() {
+            return Err(HFError::CacheNotEnabled);
+        }
+        let cache_dir = self.hf_client.cache_dir().to_path_buf();
+        let repo_folder = storage::repo_folder_name(&self.repo_path(), self.repo_type().plural());
+
+        let plan = {
+            let cache_dir = cache_dir.clone();
+            let repo_folder = repo_folder.clone();
+            tokio::task::spawn_blocking(move || delete::plan(&cache_dir, &repo_folder, &revision))
+                .await
+                .map_err(|e| HFError::Other(format!("delete_cached_revision plan task failed: {e}")))??
+        };
+
+        // The plan carries its own copies of the repo folder and locks directory, already
+        // derived from `cache_dir`/`repo_folder` — reuse them instead of rederiving.
+        let repo_folder = plan.folder.clone();
+        let locks_dir = plan.locks_dir.clone();
+
+        // Sort so every caller acquires locks in the same global order, regardless of which
+        // blobs a given deletion happens to touch — this is what makes two overlapping
+        // deletions unable to deadlock against each other.
+        let mut candidate_etags = plan.candidate_etags.clone();
+        candidate_etags.sort();
+        let mut guards = Vec::with_capacity(candidate_etags.len());
+        for etag in &candidate_etags {
+            guards.push(storage::acquire_lock(&cache_dir, &repo_folder, etag).await?);
+        }
+
+        let outcome = tokio::task::spawn_blocking(move || delete::apply(plan))
+            .await
+            .map_err(|e| HFError::Other(format!("delete_cached_revision apply task failed: {e}")))??;
+
+        // Only drop the locks once `apply` has finished with them. The locks directory is
+        // removed after that, never before: each lock is an open file handle, and Windows
+        // cannot delete a file that is still open.
+        drop(guards);
+
+        let mut freed_size = outcome.freed;
+        if outcome.repo_removed {
+            let freed_locks = tokio::task::spawn_blocking(move || -> HFResult<u64> {
+                match std::fs::metadata(&locks_dir) {
+                    Ok(_) => {
+                        let size = dir_size(&locks_dir)?;
+                        std::fs::remove_dir_all(&locks_dir)?;
+                        Ok(size)
+                    },
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(0),
+                    Err(e) => Err(e.into()),
+                }
+            })
+            .await
+            .map_err(|e| HFError::Other(format!("delete_cached_revision locks cleanup task failed: {e}")))??;
+            freed_size += freed_locks;
+        }
+
+        Ok(DeletedRevision {
+            freed_size,
+            repo_removed: outcome.repo_removed,
+        })
+    }
+}
+
+#[cfg(all(feature = "blocking", not(target_family = "wasm")))]
+#[bon]
+impl<T: RepoType> crate::blocking::HFRepositorySync<T> {
+    /// Blocking counterpart of [`HFRepository::delete_cached_revision`]. See the async method
+    /// for parameters and behavior.
+    #[builder(finish_fn = send, derive(Debug, Clone))]
+    pub fn delete_cached_revision(&self, #[builder(into)] revision: String) -> HFResult<DeletedRevision> {
+        self.runtime
+            .block_on(self.inner.delete_cached_revision().revision(revision).send())
+    }
+}
+
+/// Total size in bytes of all files under `path`, recursing into subdirectories.
+fn dir_size(path: &Path) -> std::io::Result<u64> {
+    let mut total = 0u64;
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            total += dir_size(&entry.path())?;
+        } else {
+            total += entry.metadata()?.len();
+        }
+    }
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    /// Lays out a single cached revision: one blob under `blobs/`, symlinked from a snapshot
+    /// pointer named `file.txt`.
+    #[cfg(not(windows))]
+    fn write_single_revision(cache_dir: &Path, repo_folder: &str, commit: &str, etag: &str, content: &[u8]) {
+        let blob = storage::blob_path(cache_dir, repo_folder, etag);
+        std::fs::create_dir_all(blob.parent().unwrap()).unwrap();
+        std::fs::write(&blob, content).unwrap();
+
+        let snap = storage::snapshot_path(cache_dir, repo_folder, commit, "file.txt");
+        std::fs::create_dir_all(snap.parent().unwrap()).unwrap();
+        let relative = pathdiff::diff_paths(&blob, snap.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(relative, &snap).unwrap();
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_delete_cached_revision_frees_expected_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let client = HFClient::builder().cache_dir(dir.path()).build().unwrap();
+        let repo_folder = storage::repo_folder_name("test/repo", "models");
+        write_single_revision(dir.path(), &repo_folder, "commit1", "etag1", b"hello world");
+        write_single_revision(dir.path(), &repo_folder, "commit2", "etag2", b"other revision content");
+
+        let repo = client.model("test", "repo");
+        let outcome = repo.delete_cached_revision().revision("commit1").send().await.unwrap();
+
+        assert_eq!(outcome.freed_size, "hello world".len() as u64);
+        assert!(!outcome.repo_removed);
+        assert!(!storage::blob_path(dir.path(), &repo_folder, "etag1").exists());
+        assert!(storage::blob_path(dir.path(), &repo_folder, "etag2").exists());
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_delete_cached_revision_blocks_on_held_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let client = HFClient::builder().cache_dir(dir.path()).build().unwrap();
+        let repo_folder = storage::repo_folder_name("test/repo", "models");
+        write_single_revision(dir.path(), &repo_folder, "commit1", "etag1", b"hello world");
+
+        let held = storage::acquire_lock(dir.path(), &repo_folder, "etag1").await.unwrap();
+
+        let repo = client.model("test", "repo");
+        let handle = tokio::spawn(async move { repo.delete_cached_revision().revision("commit1").send().await });
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(!handle.is_finished(), "delete should still be blocked on the held lock");
+
+        drop(held);
+
+        let outcome = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("delete did not complete after lock release")
+            .expect("delete task panicked")
+            .expect("delete_cached_revision failed");
+
+        assert_eq!(outcome.freed_size, "hello world".len() as u64);
+        assert!(outcome.repo_removed);
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_delete_last_revision_removes_repo_and_locks_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let client = HFClient::builder().cache_dir(dir.path()).build().unwrap();
+        let repo_folder = storage::repo_folder_name("test/repo", "models");
+        write_single_revision(dir.path(), &repo_folder, "commit1", "etag1", b"hello world");
+
+        let repo = client.model("test", "repo");
+        let outcome = repo.delete_cached_revision().revision("commit1").send().await.unwrap();
+
+        assert!(outcome.repo_removed);
+        assert!(!dir.path().join(&repo_folder).exists());
+        assert!(!dir.path().join(".locks").join(&repo_folder).exists());
+    }
+
+    #[tokio::test]
+    async fn test_delete_cached_revision_uncached_returns_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let client = HFClient::builder().cache_dir(dir.path()).build().unwrap();
+        let repo = client.model("test", "repo");
+
+        let err = repo.delete_cached_revision().revision("doesnotexist").send().await.unwrap_err();
+        assert!(matches!(err, HFError::LocalEntryNotFound { .. }), "unexpected error: {err:?}");
     }
 }


### PR DESCRIPTION
Adds a public API for deleting one cached revision, so callers can reclaim cache space without reimplementing the cache layout or the downloader's blob locking.

`HFRepository::delete_cached_revision` (and its blocking counterpart) plans the deletion, acquires every doomed blob's lock in sorted order, removes the snapshot along with any blob no other revision references, then releases and cleans up. It returns bytes freed and whether the repo folder went away because no revisions remained.

- Sorted lock acquisition gives all callers one global order, so two overlapping deletions cannot deadlock.
- The set of unreferenced blobs is recomputed under lock, because a concurrent download's dedup fast path can link a new snapshot pointer onto an existing blob without taking that blob's lock.
- Windows accounting matches the Python reference implementation: snapshot pointers are copies rather than symlinks, so a blob is only reclaimed once every revision referencing it is gone.
- Blob locks and the lock guard type stay crate-private.
