### PR TITLE
Always send the bucket tree recursive flag

### DIFF
--- a/hf-hub/src/buckets/mod.rs
+++ b/hf-hub/src/buckets/mod.rs
@@ -158,10 +158,9 @@ impl HFBucket {
             crate::client::append_path_segments(&mut url, prefix)?;
         }
 
-        let mut query = vec![];
-        if recursive {
-            query.push(("recursive".to_string(), "true".to_string()));
-        }
+        // The endpoint defaults to a recursive listing, so the flag has to be sent even when
+        // it is false: omitting it returns every nested file flat, with no directory entries.
+        let query = vec![("recursive".to_string(), recursive.to_string())];
 
         Ok(self.hf_client.paginate(url, query, None))
     }
@@ -1256,7 +1255,69 @@ impl crate::blocking::HFBucketSync {
 
 #[cfg(test)]
 mod tests {
-    use super::{BucketCopyFile, BucketCopySourceType, HFBucket};
+    use futures::TryStreamExt;
+
+    use super::{BucketCopyFile, BucketCopySourceType, BucketTreeEntry, HFBucket};
+
+    /// Serves one empty JSON page and hands back the request target it was asked for.
+    async fn capture_tree_request(recursive: bool) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let served = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 2048];
+            let read = tokio::io::AsyncReadExt::read(&mut sock, &mut buf).await.unwrap();
+            let request = String::from_utf8_lossy(&buf[..read]).to_string();
+            let response =
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n[]";
+            let _ = tokio::io::AsyncWriteExt::write_all(&mut sock, response.as_bytes()).await;
+            request.lines().next().unwrap_or_default().to_string()
+        });
+
+        let client = crate::HFClient::builder().endpoint(format!("http://{addr}")).build().unwrap();
+        let bucket = HFBucket::new(client, "my-org", "my-bucket");
+        let entries: Vec<BucketTreeEntry> = bucket
+            .list_tree()
+            .prefix("data")
+            .recursive(recursive)
+            .send()
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        assert!(entries.is_empty());
+
+        served.await.unwrap()
+    }
+
+    /// The Hub's bucket tree endpoint lists recursively unless it is told not to, so a
+    /// non-recursive listing has to send `recursive=false` rather than omit the parameter.
+    /// Omitting it collapses the tree: every nested file comes back flat and the caller
+    /// never sees a directory entry to descend into.
+    #[tokio::test]
+    async fn non_recursive_list_tree_sends_the_flag_explicitly() {
+        let request = capture_tree_request(false).await;
+        assert!(
+            request.contains("recursive=false"),
+            "expected recursive=false in the request target, got: {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recursive_list_tree_sends_the_flag() {
+        let request = capture_tree_request(true).await;
+        assert!(request.contains("recursive=true"), "expected recursive=true in the request target, got: {request}");
+    }
+
+    #[tokio::test]
+    async fn list_tree_puts_the_prefix_in_the_path() {
+        let request = capture_tree_request(false).await;
+        assert!(
+            request.contains("/api/buckets/my-org/my-bucket/tree/data"),
+            "expected the prefix as a path segment, got: {request}"
+        );
+    }
 
     #[test]
     fn test_bucket_accessors() {

--- a/integration-tests/tests/bucket_xet_transfer_test.rs
+++ b/integration-tests/tests/bucket_xet_transfer_test.rs
@@ -137,6 +137,60 @@ async fn test_bucket_upload_small_text_file() {
     delete_test_bucket(&client, &namespace, &name).await;
 }
 
+/// A non-recursive listing must collapse nested files into a directory entry the caller
+/// can descend into. Every other bucket test here lists with `recursive(true)`, which
+/// masked a bug where `recursive(false)` was never sent and the endpoint's recursive
+/// default won: the tree came back flat, with nested paths and no directory entries.
+#[tokio::test]
+async fn test_bucket_list_tree_non_recursive_returns_directories() {
+    let Some(client) = api() else { return };
+    if !write_enabled() {
+        return;
+    }
+
+    let (namespace, name) = create_test_bucket(&client, &unique_suffix()).await;
+    let bucket = client.bucket(&namespace, &name);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let nested = tmp.path().join("nested.txt");
+    std::fs::write(&nested, b"nested content").unwrap();
+    let top = tmp.path().join("top.txt");
+    std::fs::write(&top, b"top content").unwrap();
+
+    bucket
+        .upload_files()
+        .files(vec![
+            BucketUpload::new(nested, "sub/nested.txt"),
+            BucketUpload::new(top, "top.txt"),
+        ])
+        .send()
+        .await
+        .expect("bucket upload_files should succeed");
+
+    wait_for_bucket_file(&bucket, "sub/nested.txt").await;
+
+    let entries: Vec<BucketTreeEntry> =
+        bucket.list_tree().recursive(false).send().unwrap().try_collect().await.unwrap();
+
+    let paths: Vec<&str> = entries
+        .iter()
+        .map(|e| match e {
+            BucketTreeEntry::File { path, .. } | BucketTreeEntry::Directory { path, .. } => path.as_str(),
+        })
+        .collect();
+
+    assert!(
+        entries
+            .iter()
+            .any(|e| matches!(e, BucketTreeEntry::Directory { path, .. } if path == "sub")),
+        "expected a directory entry for `sub`, got {paths:?}"
+    );
+    assert!(!paths.contains(&"sub/nested.txt"), "non-recursive listing leaked a nested path, got {paths:?}");
+    assert!(paths.contains(&"top.txt"), "expected the top-level file, got {paths:?}");
+
+    delete_test_bucket(&client, &namespace, &name).await;
+}
+
 #[tokio::test]
 async fn test_bucket_upload_multiple_files() {
     let Some(client) = api() else { return };


### PR DESCRIPTION
`HFBucket::list_tree` only sent the `recursive` query parameter when it was `true`. The bucket tree endpoint lists recursively unless told otherwise, so `recursive(false)` — the builder default — sent nothing and got a recursive listing back: every nested file arrived flat with its full path and no directory entries, so a caller browsing a bucket had nothing to descend into. Repo tree listing is unaffected; that endpoint defaults to non-recursive, which is why the same `if recursive` shape in `repository/listing.rs` is harmless.

- Send the flag unconditionally as `recursive={true,false}`
- Unit test asserting the outgoing request target for both values, plus the prefix path segment
- Live bucket test (`HF_TEST_WRITE=1`) listing non-recursively and asserting a directory entry appears and nested paths do not

Every existing bucket test listed with `recursive(true)`, which is how this went unnoticed. Verified against the real Hub: without the fix the new live test reports `["sub/nested.txt", "top.txt"]`; with it, `sub` comes back as a directory.